### PR TITLE
Add dynamic command handling to CLI

### DIFF
--- a/apps/build.gradle.kts
+++ b/apps/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation(libs.postgresql)
     implementation(libs.langchain4j.pgvector)
     implementation(libs.testcontainers.postgresql)
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.2")
     implementation(kotlin("stdlib"))
     runtimeOnly(libs.slf4j.nop)
     testImplementation(platform(libs.junit.bom))

--- a/apps/src/main/kotlin/io/askimo/cli/commands/DeleteCommandHandler.kt
+++ b/apps/src/main/kotlin/io/askimo/cli/commands/DeleteCommandHandler.kt
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import org.jline.reader.ParsedLine
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class DeleteCommandHandler : CommandHandler {
+    override val keyword = ":delete-command"
+    override val description = "Delete a registered command from ~/.askimo/commands\nUsage: :delete-command <name>"
+
+    override fun handle(line: ParsedLine) {
+        val args = line.words().drop(1)
+        if (args.isEmpty()) {
+            println("Usage: :delete-command <name>")
+            return
+        }
+
+        val name = args[0]
+        val path = Paths.get(System.getProperty("user.home"), ".askimo", "commands", "$name.yml")
+        if (!Files.exists(path)) {
+            println("❌ Command '$name' not found.")
+            return
+        }
+
+        print("⚠️  Delete command '$name'? [y/N]: ")
+        val confirm = readLine()?.trim()?.lowercase()
+        if (confirm != "y") {
+            println("✋ Aborted.")
+            return
+        }
+
+        try {
+            Files.delete(path)
+            println("🗑️  Deleted '$name'")
+        } catch (e: Exception) {
+            println("❌ Failed to delete: ${e.message}")
+        }
+    }
+}

--- a/apps/src/main/kotlin/io/askimo/cli/commands/ListCommandsHandler.kt
+++ b/apps/src/main/kotlin/io/askimo/cli/commands/ListCommandsHandler.kt
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import org.jline.reader.ParsedLine
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class ListCommandsHandler : CommandHandler {
+    override val keyword = ":list-commands"
+    override val description = "List all registered commands in ~/.askimo/commands"
+
+    override fun handle(line: ParsedLine) {
+        val dir = Paths.get(System.getProperty("user.home"), ".askimo", "commands")
+        if (!Files.exists(dir)) {
+            println("ℹ️  No commands registered yet.")
+            return
+        }
+
+        val files =
+            Files
+                .list(dir)
+                .filter { it.fileName.toString().endsWith(".yml") }
+                .sorted()
+                .toList()
+
+        if (files.isEmpty()) {
+            println("ℹ️  No commands registered.")
+            return
+        }
+
+        println("📦 Registered commands (${files.size})")
+        println("────────────────────────────")
+        files.forEach {
+            println(it.fileName.toString().removeSuffix(".yml"))
+        }
+    }
+}

--- a/apps/src/main/kotlin/io/askimo/cli/commands/RegisterCommandHandler.kt
+++ b/apps/src/main/kotlin/io/askimo/cli/commands/RegisterCommandHandler.kt
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import io.askimo.commands.CommandDef
+import io.askimo.core.util.Yaml.yamlMapper
+import org.jline.reader.ParsedLine
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+class RegisterCommandHandler : CommandHandler {
+    override val keyword: String = ":register-command"
+    override val description: String =
+        "Register a provider-agnostic command from a YAML template.\n" +
+            "Usage: :register-command <name?> -template <file.yml>"
+
+    override fun handle(line: ParsedLine) {
+        val args = line.words().drop(1)
+        val (maybeName, templatePath) =
+            parseArgs(args) ?: run {
+                println("Usage: :register-command <name?> -template <file.yml>")
+                return
+            }
+
+        val src = expandHome(templatePath!!)
+        if (!src.exists()) {
+            println("❌ Template not found: $src")
+            return
+        }
+
+        val defFromFile =
+            try {
+                yamlMapper.readValue(src.readText(), CommandDef::class.java)
+            } catch (e: Exception) {
+                println("❌ Invalid YAML (${e.message})")
+                return
+            }
+
+        val name =
+            when {
+                !maybeName.isNullOrBlank() -> maybeName
+                !defFromFile.name.isNullOrBlank() -> defFromFile.name
+                else -> {
+                    println("❌ Command name missing. Provide it as first arg or in YAML `name:`.")
+                    return
+                }
+            }
+
+        val targetDir = Paths.get(System.getProperty("user.home"), ".askimo", "commands")
+        try {
+            Files.createDirectories(targetDir)
+        } catch (e: Exception) {
+            println("❌ Cannot create commands dir: $targetDir (${e.message})")
+            return
+        }
+
+        val dst = targetDir.resolve("$name.yml")
+        if (Files.exists(dst)) {
+            println("⚠️ Command '$name' already exists at $dst")
+            println("   Delete it first or choose a different name.")
+            return
+        }
+
+        // Normalize the YAML with the final name (provider-agnostic schema v3)
+        val normalized = defFromFile.copy(name = name)
+        val yamlOut =
+            try {
+                // pretty writer is fine; order may differ but schema is kept
+                yamlMapper.writerWithDefaultPrettyPrinter().writeValueAsString(normalized)
+            } catch (e: Exception) {
+                println("❌ Failed to serialize YAML (${e.message})")
+                return
+            }
+
+        try {
+            Files.writeString(dst, yamlOut)
+        } catch (e: Exception) {
+            println("❌ Failed to write: $dst (${e.message})")
+            return
+        }
+
+        println("✅ Registered command '$name' at $dst")
+        println("➡  Run: askimo -c $name")
+    }
+
+    private fun parseArgs(args: List<String>): Pair<String?, String?>? {
+        var name: String? = null
+        var template: String? = null
+        var i = 0
+        if (args.isNotEmpty() && !args[0].startsWith("-")) {
+            name = args[0]
+            i = 1
+        }
+        while (i < args.size) {
+            when (args[i]) {
+                "-template", "--template" -> {
+                    if (i + 1 < args.size) {
+                        template = args[i + 1]
+                        i += 2
+                    } else {
+                        return null
+                    }
+                }
+                else -> return null
+            }
+        }
+        return if (!template.isNullOrBlank()) name to template else null
+    }
+
+    private fun expandHome(raw: String): Path {
+        val home = System.getProperty("user.home")
+        return Paths.get(raw.replaceFirst(Regex("^~(?=/|$)"), home)).toAbsolutePath().normalize()
+    }
+}

--- a/apps/src/main/kotlin/io/askimo/commands/CommandDef.kt
+++ b/apps/src/main/kotlin/io/askimo/commands/CommandDef.kt
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.commands
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+/**
+ * Defines a command that can be executed by Askimo.
+ *
+ * Instances are typically loaded from YAML (see templates), then consumed by the
+ * command registry/executor to render prompts and optionally run post actions.
+ *
+ * @property name Unique identifier for the command.
+ * @property version Schema version of the command definition (default is 3).
+ * @property description Optional human‑readable description of what the command does.
+ * @property allowedTools Whitelist of tool names that the command is allowed to use.
+ * @property vars Map of variable placeholders to tool calls used to compute their values.
+ * @property system The system prompt provided to the chat model.
+ * @property userTemplate The user prompt template rendered with resolved variables.
+ * @property postActions Actions to run after the model response is received.
+ * @property defaults Default values for variables when not otherwise provided.
+ */
+data class CommandDef(
+    val name: String,
+    val version: Int = 3,
+    val description: String? = null,
+    val allowedTools: List<String> = emptyList(),
+    val vars: Map<String, VarCall> = emptyMap(),
+    val system: String,
+    val userTemplate: String,
+    val postActions: List<PostAction> = emptyList(),
+    val defaults: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Describes a tool invocation used to compute a variable or perform an action.
+ *
+ * The arguments may be any JSON/YAML compatible structure (list, map, or string).
+ *
+ * @property tool Name of the tool to call.
+ * @property args Arguments for the tool. Can be a List, Map, String, or null.
+ */
+data class VarCall(
+    val tool: String,
+    // List<Any>/Map<String,Any>/String
+    val args: Any? = null,
+)
+
+/**
+ * Post-execution action that can be conditionally triggered after a command runs.
+ *
+ * Note: The field is named `when_` in Kotlin because `when` is a reserved keyword.
+ * In YAML it is written as `when` and mapped manually as needed.
+ *
+ * @property when_ Optional condition expression controlling whether the action runs.
+ * @property call The tool invocation to execute when the condition is met.
+ */
+data class PostAction(
+    val when_: String? = null, // named 'when' in YAML; map it manually if needed
+    val call: VarCall,
+)

--- a/apps/src/main/kotlin/io/askimo/commands/CommandExecutor.kt
+++ b/apps/src/main/kotlin/io/askimo/commands/CommandExecutor.kt
@@ -1,0 +1,153 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.commands
+
+import io.askimo.core.providers.chat
+import io.askimo.core.session.Session
+
+object MiniTpl {
+    private val re = Regex("\\{\\{([^}|]+)(?:\\|([^}]+))?}}")
+
+    fun render(
+        tpl: String,
+        vars: Map<String, String>,
+    ) = re.replace(tpl) { m ->
+        val key = m.groupValues[1].trim()
+        val fallback = m.groupValues.getOrNull(2)?.trim()
+        vars[key] ?: fallback ?: ""
+    }
+}
+
+class CommandExecutor(
+    private val session: Session,
+    private val registry: CommandRegistry,
+    private val tools: ToolRegistry,
+) {
+    data class RunOpts(
+        val overrides: Map<String, String> = emptyMap(),
+    )
+
+    fun run(
+        name: String,
+        opts: RunOpts = RunOpts(),
+    ) {
+        val def = registry.load(name)
+
+        // 1) baseline vars (defaults ⊕ overrides)
+        val vars = def.defaults.toMutableMap().apply { putAll(opts.overrides) }
+
+        // 2) pre-step: resolve declared vars via tools (generic; no git knowledge here)
+        def.vars.forEach { (varName, call) ->
+            val out = tools.invoke(call.tool, call.args)
+            vars[varName] = out?.toString().orEmpty()
+        }
+
+        // 3) prompts — since ChatService only takes a @UserMessage string,
+        // we inline the system content at the top of the user prompt.
+        val system = MiniTpl.render(def.system, vars)
+        val user = MiniTpl.render(def.userTemplate, vars)
+
+        var prompt =
+            buildString {
+                appendLine("SYSTEM:")
+                appendLine(system.trim())
+                appendLine()
+                appendLine("USER:")
+                appendLine(user.trim())
+            }.trim()
+
+        val leftover = detectTemplateVar(prompt)
+        if (leftover != null) {
+            // 4) neutralize them so LC4J won't parse as variables
+            prompt = neutralizeForLc4j(prompt)
+        }
+
+
+        // 4) stream the model output and capture it
+
+        val chat = session.getChatService()
+        val buf = StringBuilder()
+        val output = chat.chat(prompt) { token -> buf.append(token) }
+        val finalText = if (output.isNullOrBlank()) buf.toString().trim() else output.trim()
+        require(finalText.isNotBlank()) { "Model returned empty output" }
+        val formatted = formatOutput(output, vars["format"] ?: "plain")
+
+        // 5) post-actions (generic). We expose {{output}} to templates.
+        val actionVars = vars.toMutableMap().apply { put("output", formatted) }
+        def.postActions.forEach { action ->
+            if (evalBool(MiniTpl.render(action.when_ ?: "true", actionVars))) {
+                val resolvedArgs = resolveArgs(action.call.args, actionVars)
+                tools.invoke(action.call.tool, resolvedArgs)
+            }
+        }
+        println(formatted)
+    }
+
+    private fun resolveArgs(
+        args: Any?,
+        vars: Map<String, String>,
+    ): Any? =
+        when (args) {
+            null -> null
+            is String -> MiniTpl.render(args, vars)
+            is List<*> -> args.map { if (it is String) MiniTpl.render(it, vars) else it }
+            is Map<*, *> -> args.mapValues { (_, v) -> if (v is String) MiniTpl.render(v, vars) else v }
+            else -> args
+        }
+
+    private fun evalBool(expr: String): Boolean {
+        val t = expr.trim()
+        if (t.equals("true", true)) return true
+        if (t.equals("false", true)) return false
+        val parts = t.split("==").map { it.trim().trim('"') }
+        return parts.size == 2 && parts[0].equals(parts[1], true)
+    }
+
+    private fun formatOutput(
+        text: String,
+        mode: String,
+    ): String {
+        val t = text.trim()
+        return when (mode.lowercase()) {
+            "markdown", "md" -> {
+                // strip any existing fences and re-wrap cleanly
+                val clean =
+                    t
+                        .removePrefix("```markdown")
+                        .removePrefix("```md")
+                        .removePrefix("```")
+                        .removeSuffix("```")
+                        .trim()
+                "```markdown\n$clean\n```"
+            }
+            "ansi" -> {
+                // simple ANSI styling example: make header bold + cyan
+                val lines = t.lines()
+                if (lines.isEmpty()) return t
+                val header = "\u001B[1;36m${lines.first()}\u001B[0m"
+                (listOf(header) + lines.drop(1)).joinToString("\n")
+            }
+            else -> {
+                // plain text: remove any markdown fences if present
+                t
+                    .removePrefix("```markdown")
+                    .removePrefix("```md")
+                    .removePrefix("```")
+                    .removeSuffix("```")
+                    .trim()
+            }
+        }
+    }
+
+    // find the first {{...}} occurrence; returns the variable name inside, or null if none
+    private fun detectTemplateVar(s: String): String? {
+        val m = Regex("\\{\\{([^}]+)}}").find(s) ?: return null
+        return m.groupValues[1]
+    }
+
+    // neutralize *all* occurrences so LC4J will not treat them as PromptTemplate vars
+    private fun neutralizeForLc4j(s: String): String =
+        s.replace("{{", "{\u200B{").replace("}}", "}\u200B}")
+}

--- a/apps/src/main/kotlin/io/askimo/commands/CommandRegistry.kt
+++ b/apps/src/main/kotlin/io/askimo/commands/CommandRegistry.kt
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.commands
+
+import io.askimo.core.util.Yaml.yamlMapper
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class CommandRegistry(
+    private val baseDir: Path = Paths.get(System.getProperty("user.home"), ".askimo", "commands"),
+) {
+    fun load(name: String): CommandDef {
+        val file = baseDir.resolve("$name.yml")
+        require(Files.exists(file)) { "Command not found: $file" }
+        return Files
+            .newBufferedReader(file)
+            .use { yamlMapper.readValue(it, CommandDef::class.java) }
+            .fixWhenField() // tiny shim: map YAML 'when' → PostAction.when_
+    }
+}
+
+private fun CommandDef.fixWhenField(): CommandDef {
+    // If you map with Jackson annotations you can skip this. Shown compactly here.
+    return this
+}

--- a/apps/src/main/kotlin/io/askimo/commands/ToolRegistry.kt
+++ b/apps/src/main/kotlin/io/askimo/commands/ToolRegistry.kt
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.commands
+
+import dev.langchain4j.agent.tool.Tool
+import dev.langchain4j.agent.tool.ToolSpecification
+import dev.langchain4j.agent.tool.ToolSpecifications
+import java.lang.reflect.Method
+import kotlin.reflect.jvm.kotlinFunction
+
+class ToolRegistry(
+    val instances: List<Any>,
+) {
+    private val annotated: Map<String, Pair<Any, Method>> =
+        buildMap {
+            for (inst in instances) {
+                for (m in inst::class.java.methods) {
+                    if (m.isAnnotationPresent(Tool::class.java)) {
+                        put(m.name, inst to m) // key = method name
+                    }
+                }
+            }
+        }
+
+    fun specifications(allowed: List<String>): List<ToolSpecification> {
+        val all = instances.flatMap { ToolSpecifications.toolSpecificationsFrom(it) }
+        return if (allowed.isEmpty()) all else all.filter { it.name() in allowed }
+    }
+
+    /**
+     * Invoke a tool by method name, supporting:
+     *  - 0 params: call()
+     *  - 1 param:  call(args) where args can be String/List/Map (coerced)
+     *  - N params: call(arg1,...,argN) where args must be a Map<String,Any?> keyed by param names
+     */
+    fun invoke(
+        name: String,
+        args: Any?,
+    ): Any? {
+        val (target, method) =
+            annotated[name]
+                ?: error("Tool not found or not allowed: $name")
+
+        val javaParams = method.parameters
+        val paramCount = javaParams.size
+
+        if (paramCount == 0) {
+            return method.invoke(target)
+        }
+
+        if (paramCount == 1 && args !is Map<*, *>) {
+            val coerced = coerce(args, javaParams[0].type)
+            return method.invoke(target, coerced)
+        }
+
+        // Multi-arg path: expect a Map of paramName -> value
+        require(args is Map<*, *>) {
+            "Tool '$name' requires $paramCount parameters; provide args as a map of paramName -> value"
+        }
+
+        // Get parameter names reliably via Kotlin reflection (preferred),
+        // falling back to Java reflection names if kotlinFunction is null.
+        val kfun = method.kotlinFunction
+        val paramNames: List<String> =
+            kfun
+                ?.parameters
+                ?.drop(1)
+                ?.map { it.name ?: error("Missing parameter name for tool '$name'") }
+                ?: javaParams.map { it.name }
+
+        val argArray = Array<Any?>(paramCount) { null }
+        for (i in 0 until paramCount) {
+            val pName = paramNames[i]
+            val pType = javaParams[i].type
+            val raw = args[pName]
+            argArray[i] = coerce(raw, pType)
+        }
+
+        return method.invoke(target, *argArray)
+    }
+
+    private fun coerce(
+        value: Any?,
+        targetType: Class<*>,
+    ): Any? {
+        if (value == null) return null
+
+        // If already assignable (List/Map/String/etc.), let it through
+        if (targetType.isInstance(value)) return value
+
+        val s = value.toString()
+
+        return when (targetType) {
+            String::class.java -> s
+
+            Boolean::class.java, java.lang.Boolean.TYPE ->
+                s.equals("true", true) || s == "1"
+
+            Integer::class.java, java.lang.Integer.TYPE ->
+                s.toIntOrNull() ?: error("Cannot coerce '$value' to Int")
+
+            Long::class.java, java.lang.Long.TYPE ->
+                s.toLongOrNull() ?: error("Cannot coerce '$value' to Long")
+
+            Double::class.java, java.lang.Double.TYPE ->
+                s.toDoubleOrNull() ?: error("Cannot coerce '$value' to Double")
+
+            Float::class.java, java.lang.Float.TYPE ->
+                s.toFloatOrNull() ?: error("Cannot coerce '$value' to Float")
+
+            else -> {
+                // If target is a List or Map and value is compatible, return as-is
+                if (List::class.java.isAssignableFrom(targetType) && value is List<*>) return value
+                if (Map::class.java.isAssignableFrom(targetType) && value is Map<*, *>) return value
+                // Last resort: return as string
+                s
+            }
+        }
+    }
+}

--- a/apps/src/main/kotlin/io/askimo/core/util/Yaml.kt
+++ b/apps/src/main/kotlin/io/askimo/core/util/Yaml.kt
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.util
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+
+object Yaml {
+    val yamlMapper: ObjectMapper =
+        ObjectMapper(YAMLFactory())
+            .registerKotlinModule()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+}

--- a/apps/src/main/kotlin/io/askimo/tools/git/GitTools.kt
+++ b/apps/src/main/kotlin/io/askimo/tools/git/GitTools.kt
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.tools.git
+
+import dev.langchain4j.agent.tool.Tool
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+
+class GitTools {
+    @Tool("Unified diff of staged changes (git diff --cached)")
+    fun stagedDiff(args: List<String> = listOf("--no-color", "--unified=0")): String = exec(listOf("git", "diff", "--cached") + args)
+
+    @Tool("Concise git status (-sb)")
+    fun status(): String = exec(listOf("git", "status", "-sb"))
+
+    @Tool("Current branch name")
+    fun branch(): String = exec(listOf("git", "rev-parse", "--abbrev-ref", "HEAD")).trim()
+
+    @Tool("Write .git/COMMIT_EDITMSG and run git commit -F -")
+    fun commit(
+        message: String,
+        signoff: Boolean = false,
+        noVerify: Boolean = false,
+        writeEditmsg: Boolean = true,
+    ): String {
+        // Optionally save commit message to file (mimics git's default behavior)
+        if (writeEditmsg) IoTools.writeFile(".git/COMMIT_EDITMSG", message)
+
+        // Early check: no staged changes = fail fast
+        val hasStaged = exec(listOf("git", "diff", "--cached", "--name-only")).isNotBlank()
+        require(hasStaged) {
+            "No staged changes. Run `git add` first."
+        }
+
+        val cmd =
+            buildList {
+                addAll(listOf("git", "commit"))
+                if (noVerify) add("--no-verify")
+                if (signoff) add("--signoff")
+                addAll(listOf("-F", "-"))
+            }
+
+        return execWithStdinOrThrow(cmd, message)
+    }
+
+    private fun exec(cmd: List<String>): String {
+        val p =
+            ProcessBuilder(cmd)
+                .redirectErrorStream(true)
+                .start()
+        val out = ByteArrayOutputStream()
+        p.inputStream.copyTo(out)
+        val code = p.waitFor()
+        val text = out.toString(StandardCharsets.UTF_8)
+        if (code != 0) {
+            throw IllegalStateException("Command failed: ${cmd.joinToString(" ")} ($code)\n$text")
+        }
+        return text
+    }
+
+    @Suppress("ktlint:standard:max-line-length")
+    private fun execWithStdinOrThrow(
+        cmd: List<String>,
+        input: String,
+    ): String {
+        val pb = ProcessBuilder(cmd).redirectErrorStream(true)
+        val p = pb.start()
+        p.outputStream.bufferedWriter().use { it.write(input) }
+        val out = ByteArrayOutputStream()
+        p.inputStream.copyTo(out)
+        val code = p.waitFor()
+        val text = out.toString(StandardCharsets.UTF_8).trim()
+
+        if (code != 0) {
+            val hints =
+                buildString {
+                    if (text.contains("nothing to commit", ignoreCase = true)) {
+                        appendLine("Hint: Nothing to commit (no staged files?). Run `git add -A`.")
+                    }
+                    if (text.contains("pre-commit", ignoreCase = true)) {
+                        appendLine("Hint: A pre-commit hook failed. Try fixing issues or run with noVerify=true.")
+                    }
+                    if (text.contains("gpg", ignoreCase = true) || text.contains("signing", ignoreCase = true)) {
+                        appendLine("Hint: GPG signing failed. Configure GPG or disable signing with `git config commit.gpgsign false`.")
+                    }
+                    if (text.contains("merge", ignoreCase = true) && text.contains("in progress", ignoreCase = true)) {
+                        appendLine(
+                            "Hint: Merge/rebase in progress. Resolve conflicts or run `git merge --continue` / `git rebase --continue`.",
+                        )
+                    }
+                    if (text.contains("user.name", ignoreCase = true) || text.contains("user.email", ignoreCase = true)) {
+                        appendLine(
+                            "Hint: Missing user identity. Run `git config user.name 'Your Name'` and `git config user.email you@example.com`.",
+                        )
+                    }
+                }.trim()
+
+            val msg =
+                buildString {
+                    appendLine("Command failed ($code): ${cmd.joinToString(" ")}")
+                    if (text.isNotBlank()) {
+                        appendLine("Output:")
+                        appendLine(text)
+                    }
+                    if (hints.isNotBlank()) {
+                        appendLine()
+                        appendLine(hints)
+                    }
+                }.trim()
+
+            throw IllegalStateException(msg)
+        }
+
+        return text
+    }
+}

--- a/apps/src/main/kotlin/io/askimo/tools/git/IoTools.kt
+++ b/apps/src/main/kotlin/io/askimo/tools/git/IoTools.kt
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.tools.git
+
+import dev.langchain4j.agent.tool.Tool
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object IoTools {
+    @Tool("Write text file to path")
+    fun writeFile(
+        path: String,
+        content: String,
+    ): String {
+        val p = Paths.get(path)
+        Files.createDirectories(p.toAbsolutePath().parent)
+        Files.writeString(p, content)
+        return "wrote:\n${p.toAbsolutePath()}"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 graalvm-plugin = "0.11.0"
 jline = "3.30.5"
-langchain4j = "1.5.0"
+langchain4j = "1.7.1"
 commonmark = "0.25.1"
 kotlinxSerializationJson = "1.9.0"
 ktor = "3.2.3"
@@ -10,7 +10,7 @@ junitBom = "5.10.0"
 hikariCP = "7.0.2"
 mcp = "0.6.0"
 postgresql = "42.7.7"
-langchain4jPgvector = "1.6.0-beta12"
+langchain4jPgvector = "1.7.1-beta14"
 testcontainersPostgresql = "1.21.3"
 
 [libraries]

--- a/templates/gitcommit.yml
+++ b/templates/gitcommit.yml
@@ -1,0 +1,57 @@
+name: gitCommit
+version: 3
+description: "Generate a Conventional Commit message from staged changes"
+
+allowedTools:
+  - stagedDiff
+  - status
+  - branch
+  - commit
+  - writeFile
+
+vars:
+  diff:
+    tool: stagedDiff
+    args: ["--no-color", "--unified=0"]
+  status:
+    tool: status
+  branch:
+    tool: branch
+
+system: |
+  You are a senior engineer writing Conventional Commit messages.
+  Follow these rules:
+  - Header: type(scope): summary (≤ {{max_header|72}} chars, imperative mood)
+  - Use docs:, test:, refactor:, style:, chore:, ci:, build: appropriately.
+  - Include bullet points when helpful (≤ 6).
+  - Add a BREAKING CHANGE: trailer if a public API is modified.
+  - Never paste the diff back.
+
+userTemplate: |
+  Write the commit message based on these details:
+
+  Current branch: {{branch}}
+  Repo status:
+  {{status}}
+
+  Staged diff (for context only):
+  ```diff
+  {{diff}}
+  ```
+
+postActions:
+  - when_: "{{dry_run|false}} == false"
+    call:
+      tool: commit
+      args:
+        message: "{{output}}"
+        signoff: "{{signoff|false}}"
+        noVerify: "{{no_verify|false}}"
+        writeEditmsg: "true"
+
+defaults:
+  max_header: "72"
+  dry_run: "false"
+  signoff: "false"
+  no_verify: "false"
+  format: "plain"


### PR DESCRIPTION
- Implement `RegisterCommandHandler` to register commands using YAML templates.
- Implement `ListCommandsHandler` to list all registered commands.
- Implement `DeleteCommandHandler` to delete registered commands.
- Introduce `CommandDef`, `CommandExecutor`, and `CommandRegistry` for command management.
- Add support for dynamic tool registry with `ToolRegistry`.
- Integrate YAML handling via `Yaml` utility.
- Update dependencies in `build.gradle.kts` and `libs.versions.toml`.

BREAKING CHANGE: The CLI now supports dynamic command registration, listing, and deletion with a new command structure.