### PR TITLE
feat(providers): integrate Anthropic (Claude) support

### DIFF
--- a/apps/src/main/kotlin/io/askimo/cli/commands/SetProviderCommandHandler.kt
+++ b/apps/src/main/kotlin/io/askimo/cli/commands/SetProviderCommandHandler.kt
@@ -7,7 +7,7 @@ package io.askimo.cli.commands
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ProviderRegistry
 import io.askimo.core.providers.ProviderValidator
-import io.askimo.core.session.MemoryPolicy
+import io.askimo.core.session.MemoryPolicy.KEEP_PER_PROVIDER_MODEL
 import io.askimo.core.session.Session
 import io.askimo.core.session.SessionConfigManager
 import org.jline.reader.ParsedLine
@@ -71,7 +71,7 @@ class SetProviderCommandHandler(
         session.params.model = model
 
         SessionConfigManager.save(session.params)
-        session.rebuildActiveChatService(MemoryPolicy.KEEP_PER_PROVIDER_MODEL)
+        session.rebuildActiveChatService(KEEP_PER_PROVIDER_MODEL)
 
         println("✅ Model provider set to: ${provider.name.lowercase()}")
         println("💡 Use `:models` to list all available models for this provider.")

--- a/apps/src/main/kotlin/io/askimo/core/project/EmbeddingModelFactory.kt
+++ b/apps/src/main/kotlin/io/askimo/core/project/EmbeddingModelFactory.kt
@@ -8,28 +8,115 @@ import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.ollama.OllamaEmbeddingModel.OllamaEmbeddingModelBuilder
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
 import io.askimo.core.providers.ModelProvider
-import io.askimo.core.providers.ModelProvider.GEMINI
-import io.askimo.core.providers.ModelProvider.OLLAMA
-import io.askimo.core.providers.ModelProvider.OPEN_AI
-import io.askimo.core.providers.ModelProvider.X_AI
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.atomic.AtomicBoolean
+
+// Defaults (can be overridden by env)
+private const val DEFAULT_OLLAMA_URL = "http://localhost:11434"
+private const val DEFAULT_OLLAMA_EMBED_MODEL = "nomic-embed-text"
+private const val DEFAULT_OPENAI_EMBED_MODEL = "text-embedding-3-small"
+
+// One-time warning flag so we don't spam the console
+private val warnedOllamaOnce = AtomicBoolean(false)
 
 fun getEmbeddingModel(provider: ModelProvider): EmbeddingModel =
     when (provider) {
-        OPEN_AI -> {
-            OpenAiEmbeddingModelBuilder().modelName("text-similarity-3-large").build()
-        }
-
-        OLLAMA -> {
-            val url = System.getenv("OLLAMA_URL") ?: "http://localhost:11434"
-            OllamaEmbeddingModelBuilder()
-                .baseUrl(url)
-                .modelName("all-mpnet-base-v2")
+        ModelProvider.OPEN_AI -> {
+            val openAiKey =
+                System.getenv("OPENAI_API_KEY")
+                    ?: error("OPENAI_API_KEY missing for OpenAI embeddings")
+            val modelName = System.getenv("OPENAI_EMBED_MODEL") ?: DEFAULT_OPENAI_EMBED_MODEL
+            OpenAiEmbeddingModelBuilder()
+                .apiKey(openAiKey)
+                .modelName(modelName)
                 .build()
         }
 
-        X_AI, GEMINI -> {
-            error("${provider.name} does not support RAG embeddings yet")
+        // For providers with no native embeddings, we ALWAYS use local Ollama
+        ModelProvider.ANTHROPIC, ModelProvider.GEMINI, ModelProvider.X_AI -> {
+            noteOllamaRequired(provider)
+            buildOllamaEmbeddingModel()
         }
+
+        // If user explicitly picked OLLAMA for chat, also use Ollama for embeddings
+        ModelProvider.OLLAMA -> buildOllamaEmbeddingModel()
 
         ModelProvider.UNKNOWN -> error("Unsupported embedding provider: $provider")
     }
+
+private fun buildOllamaEmbeddingModel(): EmbeddingModel {
+    val url = System.getenv("OLLAMA_URL") ?: DEFAULT_OLLAMA_URL
+    val model = System.getenv("OLLAMA_EMBED_MODEL") ?: DEFAULT_OLLAMA_EMBED_MODEL
+
+    ensureOllamaAvailable(url, model)
+
+    return OllamaEmbeddingModelBuilder()
+        .baseUrl(url)
+        .modelName(model)
+        .build()
+}
+
+/**
+ * Notes to the user (printed once) that Anthropic/Gemini/xAI require a local Ollama
+ * installation and an embedding model pulled.
+ */
+private fun noteOllamaRequired(provider: ModelProvider) {
+    if (warnedOllamaOnce.compareAndSet(false, true)) {
+        val model = System.getenv("OLLAMA_EMBED_MODEL") ?: DEFAULT_OLLAMA_EMBED_MODEL
+        val url = System.getenv("OLLAMA_URL") ?: DEFAULT_OLLAMA_URL
+        println(
+            """
+            ℹ️  ${provider.name} does not provide embeddings. Askimo uses local Ollama for RAG embeddings.
+               • Ollama URL: $url
+               • Embedding model: $model
+               • If not installed: https://ollama.com/download
+               • Start server:    ollama serve
+               • Pull model:      ollama pull $model
+            """.trimIndent(),
+        )
+    }
+}
+
+/**
+ * Checks that Ollama is reachable and the model exists.
+ * Throws an actionable error if not.
+ */
+private fun ensureOllamaAvailable(
+    baseUrl: String,
+    model: String,
+) {
+    val tagsBody =
+        try {
+            val conn =
+                (URL("${baseUrl.removeSuffix("/")}/api/tags").openConnection() as HttpURLConnection).apply {
+                    connectTimeout = 1500
+                    readTimeout = 1500
+                    requestMethod = "GET"
+                    doInput = true
+                }
+            conn.inputStream.bufferedReader().use { it.readText() }
+        } catch (_: Exception) {
+            error(
+                """
+                ❌ Ollama not reachable at $baseUrl
+
+                To enable embeddings for ${model.ifBlank { DEFAULT_OLLAMA_EMBED_MODEL }}:
+                  • Install: https://ollama.com/download
+                  • Start:   ollama serve
+                  • Pull:    ollama pull $model
+                """.trimIndent(),
+            )
+        }
+
+    if (!tagsBody.contains("\"name\":\"$model\"")) {
+        error(
+            """
+            ❌ Ollama model '$model' not found.
+
+            Pull it first:
+              ollama pull $model
+            """.trimIndent(),
+        )
+    }
+}

--- a/apps/src/main/kotlin/io/askimo/core/providers/ModelProvider.kt
+++ b/apps/src/main/kotlin/io/askimo/core/providers/ModelProvider.kt
@@ -40,6 +40,12 @@ enum class ModelProvider {
     OLLAMA,
 
     /**
+     * Represents Anthropic's models
+     */
+    @SerialName("ANTHROPIC")
+    ANTHROPIC,
+
+    /**
      * Represents an unidentified or unsupported model provider.
      */
     @SerialName("UNKNOWN")

--- a/apps/src/main/kotlin/io/askimo/core/providers/ProviderRegistry.kt
+++ b/apps/src/main/kotlin/io/askimo/core/providers/ProviderRegistry.kt
@@ -4,10 +4,12 @@
  */
 package io.askimo.core.providers
 
+import io.askimo.core.providers.ModelProvider.ANTHROPIC
 import io.askimo.core.providers.ModelProvider.GEMINI
 import io.askimo.core.providers.ModelProvider.OLLAMA
 import io.askimo.core.providers.ModelProvider.OPEN_AI
 import io.askimo.core.providers.ModelProvider.X_AI
+import io.askimo.core.providers.anthropic.AnthropicModelFactory
 import io.askimo.core.providers.gemini.GeminiModelFactory
 import io.askimo.core.providers.ollama.OllamaModelFactory
 import io.askimo.core.providers.openai.OpenAiModelFactory
@@ -35,6 +37,7 @@ object ProviderRegistry {
             X_AI to XAiModelFactory(),
             GEMINI to GeminiModelFactory(),
             OLLAMA to OllamaModelFactory(),
+            ANTHROPIC to AnthropicModelFactory(),
         )
 
     /**

--- a/apps/src/main/kotlin/io/askimo/core/providers/ProviderValidator.kt
+++ b/apps/src/main/kotlin/io/askimo/core/providers/ProviderValidator.kt
@@ -4,9 +4,13 @@
  */
 package io.askimo.core.providers
 
+import io.askimo.core.providers.ModelProvider.ANTHROPIC
+import io.askimo.core.providers.ModelProvider.GEMINI
 import io.askimo.core.providers.ModelProvider.OLLAMA
 import io.askimo.core.providers.ModelProvider.OPEN_AI
 import io.askimo.core.providers.ModelProvider.X_AI
+import io.askimo.core.providers.anthropic.AnthropicSettings
+import io.askimo.core.providers.gemini.GeminiSettings
 import io.askimo.core.providers.ollama.OllamaSettings
 import io.askimo.core.providers.openai.OpenAiSettings
 import io.askimo.core.providers.xai.XAiSettings
@@ -32,9 +36,13 @@ object ProviderValidator {
         when (provider) {
             OPEN_AI ->
                 (settings as? OpenAiSettings)?.apiKey?.isNotBlank() == true
-
             X_AI ->
                 (settings as? XAiSettings)?.apiKey?.isNotBlank() == true
+            GEMINI ->
+                (settings as? GeminiSettings)?.apiKey?.isNotBlank() == true
+            ANTHROPIC ->
+                (settings as? AnthropicSettings)?.apiKey?.isNotBlank() == true ||
+                    (settings as? AnthropicSettings)?.apiKey.equals("default")
 
             OLLAMA ->
                 (settings as? OllamaSettings)?.let { s ->
@@ -69,6 +77,23 @@ object ProviderValidator {
                 💡💡 To use XAI, you need to provide an API key.
                 1. Get your API key from: https://console.x.ai/
                 2. Then set it in the CLI using: :setparam api_key YOUR_API_KEY_HERE
+                """.trimIndent().trimIndent()
+
+            GEMINI ->
+                """
+                💡 To use Google Gemini, you need a valid API key.
+                1) Create or retrieve your key from Google AI Studio: https://makersuite.google.com/
+                2) Set it in the CLI using: :setparam api_key YOUR_API_KEY_HERE
+
+                """.trimIndent().trimIndent()
+
+            ANTHROPIC ->
+                """
+                💡 To use Anthropic (Claude models), you need an API key.
+                1) Get your API key from: https://console.anthropic.com/account/keys
+                2) Then set it in the CLI using: :setparam api_key YOUR_API_KEY_HERE
+                3) Example model: claude-3-5-sonnet-latest
+
                 """.trimIndent().trimIndent()
 
             else -> "💡 This provider requires custom configuration. Please refer to its documentation."

--- a/apps/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/apps/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.providers.anthropic
+
+import dev.langchain4j.memory.ChatMemory
+import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
+import dev.langchain4j.rag.RetrievalAugmentor
+import dev.langchain4j.service.AiServices
+import io.askimo.core.providers.ChatModelFactory
+import io.askimo.core.providers.ChatService
+import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.providers.verbosityInstruction
+import io.askimo.core.util.SystemPrompts.systemMessage
+import io.askimo.tools.fs.LocalFsTools
+
+class AnthropicModelFactory : ChatModelFactory {
+    override fun availableModels(settings: ProviderSettings): List<String> {
+        // Anthropic doesn’t yet expose a “list models” endpoint like OpenAI,
+        // so we’ll return known public models manually.
+        return listOf(
+            "claude-opus-4-1",
+            "claude-opus-4-0",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4-0",
+            "claude-3-7-sonnet-latest",
+            "claude-3-5-haiku-latest",
+        )
+    }
+
+    override fun defaultSettings(): ProviderSettings = AnthropicSettings()
+
+    override fun create(
+        model: String,
+        settings: ProviderSettings,
+        memory: ChatMemory,
+        retrievalAugmentor: RetrievalAugmentor?,
+    ): ChatService {
+        require(settings is AnthropicSettings) {
+            "Invalid settings type for Anthropic: ${settings::class.simpleName}"
+        }
+
+        val chatModel =
+            AnthropicStreamingChatModel
+                .builder()
+                .apiKey(settings.apiKey)
+                .modelName(model)
+                .baseUrl(settings.baseUrl)
+                .build()
+
+        val builder =
+            AiServices
+                .builder(ChatService::class.java)
+                .streamingChatModel(chatModel)
+                .chatMemory(memory)
+                .tools(LocalFsTools())
+                .systemMessageProvider {
+                    systemMessage(verbosityInstruction(settings.presets.verbosity))
+                }
+
+        if (retrievalAugmentor != null) {
+            builder.retrievalAugmentor(retrievalAugmentor)
+        }
+
+        return builder.build()
+    }
+}

--- a/apps/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicSettings.kt
+++ b/apps/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicSettings.kt
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.providers.anthropic
+
+import io.askimo.core.providers.HasApiKey
+import io.askimo.core.providers.Presets
+import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.providers.Style
+import io.askimo.core.providers.Verbosity
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AnthropicSettings(
+    val baseUrl: String = "https://api.anthropic.com/v1",
+    override var apiKey: String = "default",
+    override val defaultModel: String = "claude-sonnet-4-5",
+    override var presets: Presets = Presets(Style.BALANCED, Verbosity.NORMAL),
+) : ProviderSettings,
+    HasApiKey {
+    override fun describe(): List<String> =
+        listOf(
+            "apiKey:  ${apiKey.take(5)}***",
+            "baseUrl: $baseUrl",
+            "presets: $presets",
+        )
+}

--- a/apps/src/main/kotlin/io/askimo/core/session/Session.kt
+++ b/apps/src/main/kotlin/io/askimo/core/session/Session.kt
@@ -16,6 +16,8 @@ import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.NoopProviderSettings
 import io.askimo.core.providers.ProviderRegistry
 import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.session.MemoryPolicy.KEEP_PER_PROVIDER_MODEL
+import io.askimo.core.session.MemoryPolicy.RESET_FOR_THIS_COMBO
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -203,7 +205,7 @@ class Session(
      * @return A newly created [ChatService] instance that becomes the active model for this session.
      * @throws IllegalStateException if no model factory is registered for the current provider.
      */
-    fun rebuildActiveChatService(memoryPolicy: MemoryPolicy = MemoryPolicy.KEEP_PER_PROVIDER_MODEL): ChatService {
+    fun rebuildActiveChatService(memoryPolicy: MemoryPolicy = KEEP_PER_PROVIDER_MODEL): ChatService {
         val provider = params.currentProvider
         val factory =
             getModelFactory(provider)
@@ -212,7 +214,7 @@ class Session(
         val settings = getOrCreateProviderSettings(provider)
         val modelName = params.model
 
-        if (memoryPolicy == MemoryPolicy.RESET_FOR_THIS_COMBO) {
+        if (memoryPolicy == RESET_FOR_THIS_COMBO) {
             val key = "${provider.name}/$modelName"
             memoryMap.remove(key)
         }
@@ -230,7 +232,7 @@ class Session(
      * @param memoryPolicy Controls whether the existing memory bucket for this
      * (provider, model) is reused or reset when building for the first time.
      */
-    fun getChatService(memoryPolicy: MemoryPolicy = MemoryPolicy.KEEP_PER_PROVIDER_MODEL): ChatService =
+    fun getChatService(memoryPolicy: MemoryPolicy = KEEP_PER_PROVIDER_MODEL): ChatService =
         if (hasChatService()) chatService else rebuildActiveChatService(memoryPolicy)
 
     /**

--- a/apps/src/main/kotlin/io/askimo/core/util/Serialization.kt
+++ b/apps/src/main/kotlin/io/askimo/core/util/Serialization.kt
@@ -5,6 +5,7 @@
 package io.askimo.core.util
 
 import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.providers.anthropic.AnthropicSettings
 import io.askimo.core.providers.gemini.GeminiSettings
 import io.askimo.core.providers.ollama.OllamaSettings
 import io.askimo.core.providers.openai.OpenAiSettings
@@ -20,6 +21,7 @@ val coreProvidersModule =
             subclass(OllamaSettings::class, OllamaSettings.serializer())
             subclass(XAiSettings::class, XAiSettings.serializer())
             subclass(GeminiSettings::class, GeminiSettings.serializer())
+            subclass(AnthropicSettings::class, AnthropicSettings.serializer())
         }
     }
 


### PR DESCRIPTION
- Add AnthropicModelFactory and AnthropicSettings for Claude models
- Register ANTHROPIC provider in ProviderRegistry with validation
- Update EmbeddingModelFactory to use local Ollama for providers without native embeddings (Anthropic, Gemini, xAI)
- Add Ollama availability checks with actionable error messages
- Enhance CommandExecutor with loading spinner and streaming token handling
- Refactor GraalVM native-image agent configuration for multi-module builds
- Add langchain4j-anthropic dependency (1.7.1)