### PR TITLE
Add more tests for jline commands

### DIFF
--- a/src/test/kotlin/io/askimo/cli/commands/ClearMemoryCommandHandlerTest.kt
+++ b/src/test/kotlin/io/askimo/cli/commands/ClearMemoryCommandHandlerTest.kt
@@ -1,0 +1,136 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import io.askimo.core.providers.ModelProvider
+import io.askimo.core.session.Session
+import io.askimo.core.session.SessionParams
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClearMemoryCommandHandlerTest : CommandHandlerTestBase() {
+    private lateinit var session: Session
+    private lateinit var handler: ClearMemoryCommandHandler
+
+    @BeforeEach
+    fun setUp() {
+        session = mock<Session>()
+        handler = ClearMemoryCommandHandler(session)
+    }
+
+    @Test
+    fun `handle clears memory for active provider and model`() {
+        val provider = ModelProvider.OPEN_AI
+        val modelName = "gpt-4"
+        val params = mock<SessionParams>()
+
+        whenever(session.getActiveProvider()) doReturn provider
+        whenever(session.params) doReturn params
+        whenever(params.getModel(provider)) doReturn modelName
+
+        val parsedLine = mockParsedLine(":clear")
+
+        handler.handle(parsedLine)
+
+        // Verify that removeMemory was called with correct parameters
+        verify(session).removeMemory(provider, modelName)
+
+        // Verify console output
+        val output = getOutput()
+        assertTrue(output.contains("🧹 Chat memory cleared"))
+        assertTrue(output.contains("OPEN_AI"))
+        assertTrue(output.contains("gpt-4"))
+    }
+
+    @Test
+    fun `handle clears memory for Ollama provider`() {
+        val provider = ModelProvider.OLLAMA
+        val modelName = "llama3.2"
+        val params = mock<SessionParams>()
+
+        whenever(session.getActiveProvider()) doReturn provider
+        whenever(session.params) doReturn params
+        whenever(params.getModel(provider)) doReturn modelName
+
+        val parsedLine = mockParsedLine(":clear")
+
+        handler.handle(parsedLine)
+
+        verify(session).removeMemory(provider, modelName)
+
+        val output = getOutput()
+        assertTrue(output.contains("🧹 Chat memory cleared"))
+        assertTrue(output.contains("OLLAMA"))
+        assertTrue(output.contains("llama3.2"))
+    }
+
+    @Test
+    fun `handle clears memory for Anthropic provider`() {
+        val provider = ModelProvider.ANTHROPIC
+        val modelName = "claude-3-5-sonnet-20241022"
+        val params = mock<SessionParams>()
+
+        whenever(session.getActiveProvider()) doReturn provider
+        whenever(session.params) doReturn params
+        whenever(params.getModel(provider)) doReturn modelName
+
+        val parsedLine = mockParsedLine(":clear")
+
+        handler.handle(parsedLine)
+
+        verify(session).removeMemory(provider, modelName)
+
+        val output = getOutput()
+        assertTrue(output.contains("🧹 Chat memory cleared"))
+        assertTrue(output.contains("ANTHROPIC"))
+        assertTrue(output.contains("claude-3-5-sonnet-20241022"))
+    }
+
+    @Test
+    fun `handle clears memory for Gemini provider`() {
+        val provider = ModelProvider.GEMINI
+        val modelName = "gemini-2.0-flash-exp"
+        val params = mock<SessionParams>()
+
+        whenever(session.getActiveProvider()) doReturn provider
+        whenever(session.params) doReturn params
+        whenever(params.getModel(provider)) doReturn modelName
+
+        val parsedLine = mockParsedLine(":clear")
+
+        handler.handle(parsedLine)
+
+        verify(session).removeMemory(provider, modelName)
+
+        val output = getOutput()
+        assertTrue(output.contains("🧹 Chat memory cleared"))
+        assertTrue(output.contains("GEMINI"))
+        assertTrue(output.contains("gemini-2.0-flash-exp"))
+    }
+
+    @Test
+    fun `keyword returns correct value`() {
+        assertEquals(":clear", handler.keyword)
+    }
+
+    @Test
+    fun `description is not empty and mentions clearing memory`() {
+        assertTrue(handler.description.isNotBlank())
+        assertTrue(handler.description.contains("clear", ignoreCase = true))
+        assertTrue(handler.description.contains("memory", ignoreCase = true))
+    }
+
+    @Test
+    fun `description mentions provider and model`() {
+        assertTrue(handler.description.contains("provider", ignoreCase = true))
+        assertTrue(handler.description.contains("model", ignoreCase = true))
+    }
+}

--- a/src/test/kotlin/io/askimo/cli/commands/CommandHandlerTestBase.kt
+++ b/src/test/kotlin/io/askimo/cli/commands/CommandHandlerTestBase.kt
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import org.jline.reader.ParsedLine
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+/**
+ * Base class for command handler tests that provides common test infrastructure.
+ *
+ * This class handles:
+ * - Console output capture for verifying printed messages
+ * - Mock creation for ParsedLine
+ * - Setup and teardown of test resources
+ */
+abstract class CommandHandlerTestBase {
+    protected lateinit var originalOut: PrintStream
+    protected lateinit var testOut: ByteArrayOutputStream
+
+    @BeforeEach
+    fun setUpBase() {
+        // Capture console output
+        originalOut = System.out
+        testOut = ByteArrayOutputStream()
+        System.setOut(PrintStream(testOut))
+    }
+
+    @AfterEach
+    fun tearDownBase() {
+        System.setOut(originalOut)
+    }
+
+    /**
+     * Helper function to create mock ParsedLine with specified words.
+     */
+    protected fun mockParsedLine(vararg words: String): ParsedLine {
+        val parsedLine = mock<ParsedLine>()
+        whenever(parsedLine.words()) doReturn words.toList()
+        return parsedLine
+    }
+
+    /**
+     * Helper function to get the captured console output.
+     */
+    protected fun getOutput(): String = testOut.toString()
+}

--- a/src/test/kotlin/io/askimo/cli/commands/CopyCommandHandlerTest.kt
+++ b/src/test/kotlin/io/askimo/cli/commands/CopyCommandHandlerTest.kt
@@ -1,0 +1,243 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import io.askimo.core.session.Session
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CopyCommandHandlerTest : CommandHandlerTestBase() {
+    private lateinit var session: Session
+    private lateinit var handler: CopyCommandHandler
+
+    @BeforeEach
+    fun setUp() {
+        session = mock<Session>()
+        handler = CopyCommandHandler(session)
+    }
+
+    @Test
+    fun `keyword returns correct value`() {
+        assertEquals(":copy", handler.keyword)
+    }
+
+    @Test
+    fun `description is not empty and mentions copying`() {
+        assertTrue(handler.description.isNotBlank())
+        assertTrue(handler.description.contains("copy", ignoreCase = true))
+        assertTrue(handler.description.contains("clipboard", ignoreCase = true))
+    }
+
+    @Test
+    fun `handle with no response shows warning`() {
+        whenever(session.lastResponse).thenReturn(null)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("⚠️ No response to copy"))
+        assertTrue(output.contains("Ask something first"))
+    }
+
+    @Test
+    fun `handle with blank response shows warning`() {
+        whenever(session.lastResponse).thenReturn("   ")
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("⚠️ No response to copy"))
+    }
+
+    @Test
+    fun `handle with empty response shows warning`() {
+        whenever(session.lastResponse).thenReturn("")
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("⚠️ No response to copy"))
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    fun `handle with valid response on macOS attempts copy`() {
+        val testResponse = "This is a test response from the AI"
+        whenever(session.lastResponse).thenReturn(testResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        // Note: This test will actually attempt to copy to clipboard on macOS
+        // The assertion is that it doesn't throw an exception
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should either succeed or fail gracefully
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("❌ Failed to copy to clipboard"),
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `handle with valid response on Windows attempts copy`() {
+        val testResponse = "This is a test response from the AI"
+        whenever(session.lastResponse).thenReturn(testResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        // Note: This test will actually attempt to copy to clipboard on Windows
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should either succeed or fail gracefully
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("❌ Failed to copy to clipboard"),
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    fun `handle with valid response on Linux attempts copy`() {
+        val testResponse = "This is a test response from the AI"
+        whenever(session.lastResponse).thenReturn(testResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        // Note: This test requires xclip or xsel to be installed on Linux
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should either succeed or show utility not found message
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("⚠️ No clipboard utility found") ||
+                output.contains("❌ Failed to copy to clipboard"),
+        )
+    }
+
+    @Test
+    fun `handle with multiline response processes correctly`() {
+        val multilineResponse =
+            """
+            This is line 1
+            This is line 2
+            This is line 3
+            """.trimIndent()
+        whenever(session.lastResponse).thenReturn(multilineResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Verify it attempts to copy (success depends on platform)
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("⚠️") ||
+                output.contains("❌"),
+        )
+    }
+
+    @Test
+    fun `handle with special characters in response processes correctly`() {
+        val specialResponse = "Response with special chars: @#\$%^&*()_+-=[]{}|;':\",./<>?"
+        whenever(session.lastResponse).thenReturn(specialResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Verify it attempts to copy
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("⚠️") ||
+                output.contains("❌"),
+        )
+    }
+
+    @Test
+    fun `handle with unicode characters in response processes correctly`() {
+        val unicodeResponse = "Response with unicode: 你好 こんにちは 안녕하세요 🚀 ✨"
+        whenever(session.lastResponse).thenReturn(unicodeResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Verify it attempts to copy
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("⚠️") ||
+                output.contains("❌"),
+        )
+    }
+
+    @Test
+    fun `handle with markdown formatted response processes correctly`() {
+        val markdownResponse =
+            """
+            # Heading
+
+            This is **bold** and this is *italic*.
+
+            ```kotlin
+            fun main() {
+                println("Hello, World!")
+            }
+            ```
+
+            - List item 1
+            - List item 2
+            """.trimIndent()
+        whenever(session.lastResponse).thenReturn(markdownResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Verify it attempts to copy
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("⚠️") ||
+                output.contains("❌"),
+        )
+    }
+
+    @Test
+    fun `handle with very long response processes correctly`() {
+        val longResponse = "A".repeat(10000) // 10KB of text
+        whenever(session.lastResponse).thenReturn(longResponse)
+
+        val parsedLine = mockParsedLine(":copy")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Verify it attempts to copy
+        assertTrue(
+            output.contains("✅ Copied last response to clipboard") ||
+                output.contains("⚠️") ||
+                output.contains("❌"),
+        )
+    }
+}

--- a/src/test/kotlin/io/askimo/cli/commands/CreateRecipeCommandHandlerTest.kt
+++ b/src/test/kotlin/io/askimo/cli/commands/CreateRecipeCommandHandlerTest.kt
@@ -4,25 +4,16 @@
  */
 package io.askimo.cli.commands
 
-import org.jline.reader.ParsedLine
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class CreateRecipeCommandHandlerTest {
+class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
     private lateinit var handler: CreateRecipeCommandHandler
-    private lateinit var originalOut: PrintStream
-    private lateinit var testOut: ByteArrayOutputStream
 
     @TempDir
     lateinit var tempDir: Path
@@ -34,18 +25,8 @@ class CreateRecipeCommandHandlerTest {
     fun setUp() {
         handler = CreateRecipeCommandHandler()
 
-        // Capture console output
-        originalOut = System.out
-        testOut = ByteArrayOutputStream()
-        System.setOut(PrintStream(testOut))
-
         // Set temporary home directory for testing
         System.setProperty("user.home", tempHome.toString())
-    }
-
-    @AfterEach
-    fun tearDown() {
-        System.setOut(originalOut)
     }
 
     @Test
@@ -68,7 +49,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         assertTrue(output.contains("✅ Registered recipe 'my-recipe'"))
 
         // Verify recipe file was created
@@ -83,7 +64,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         assertTrue(output.contains("Usage: :create-recipe"))
     }
 
@@ -93,7 +74,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         assertTrue(output.contains("❌ Template not found"))
     }
 
@@ -106,7 +87,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         assertTrue(output.contains("❌ Invalid YAML"))
     }
 
@@ -128,7 +109,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         // Missing required 'name' field causes YAML parsing to fail
         assertTrue(output.contains("❌ Invalid YAML"))
     }
@@ -152,7 +133,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         // Empty name (valid YAML but blank string) triggers the name missing check
         assertTrue(output.contains("❌ Recipe name missing"))
     }
@@ -180,7 +161,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         assertTrue(output.contains("⚠️ Recipe 'existing-recipe' already exists"))
     }
 
@@ -202,7 +183,7 @@ class CreateRecipeCommandHandlerTest {
 
         handler.handle(parsedLine)
 
-        val output = testOut.toString()
+        val output = getOutput()
         assertTrue(output.contains("✅ Registered recipe"))
     }
 
@@ -215,12 +196,5 @@ class CreateRecipeCommandHandlerTest {
     fun `description is not empty`() {
         assertTrue(handler.description.isNotBlank())
         assertTrue(handler.description.contains("Usage:"))
-    }
-
-    // Helper function to create mock ParsedLine
-    private fun mockParsedLine(vararg words: String): ParsedLine {
-        val parsedLine = mock<ParsedLine>()
-        whenever(parsedLine.words()) doReturn words.toList()
-        return parsedLine
     }
 }

--- a/src/test/kotlin/io/askimo/cli/commands/ListRecipesCommandHandlerTest.kt
+++ b/src/test/kotlin/io/askimo/cli/commands/ListRecipesCommandHandlerTest.kt
@@ -1,0 +1,326 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ListRecipesCommandHandlerTest : CommandHandlerTestBase() {
+    private lateinit var handler: ListRecipesCommandHandler
+
+    @TempDir
+    lateinit var tempHome: Path
+
+    private lateinit var originalHome: String
+    private lateinit var recipesDir: Path
+
+    @BeforeEach
+    fun setUp() {
+        handler = ListRecipesCommandHandler()
+
+        // Save original home and set temp home for testing
+        originalHome = System.getProperty("user.home")
+        System.setProperty("user.home", tempHome.toString())
+
+        // Create recipes directory
+        recipesDir = tempHome.resolve(".askimo/recipes")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // Restore original home directory
+        System.setProperty("user.home", originalHome)
+    }
+
+    @Test
+    fun `keyword returns correct value`() {
+        assertEquals(":recipes", handler.keyword)
+    }
+
+    @Test
+    fun `description is not empty and mentions recipes`() {
+        assertTrue(handler.description.isNotBlank())
+        assertTrue(handler.description.contains("recipe", ignoreCase = true))
+        assertTrue(handler.description.contains("list", ignoreCase = true))
+    }
+
+    @Test
+    fun `handle with no recipes directory shows info message`() {
+        // Don't create the recipes directory
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("ℹ️  No recipes registered yet."))
+    }
+
+    @Test
+    fun `handle with empty recipes directory shows info message`() {
+        // Create directory but don't add any recipes
+        Files.createDirectories(recipesDir)
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("ℹ️  No recipes registered."))
+    }
+
+    @Test
+    fun `handle with single recipe lists it`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("test-recipe.yml"), "name: test-recipe")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("📦 Registered recipes (1)"))
+        assertTrue(output.contains("test-recipe"))
+        assertTrue(!output.contains(".yml"))
+    }
+
+    @Test
+    fun `handle with multiple recipes lists them all`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("recipe1.yml"), "name: recipe1")
+        Files.writeString(recipesDir.resolve("recipe2.yml"), "name: recipe2")
+        Files.writeString(recipesDir.resolve("recipe3.yml"), "name: recipe3")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("📦 Registered recipes (3)"))
+        assertTrue(output.contains("recipe1"))
+        assertTrue(output.contains("recipe2"))
+        assertTrue(output.contains("recipe3"))
+    }
+
+    @Test
+    fun `handle lists recipes in sorted order`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("zebra.yml"), "name: zebra")
+        Files.writeString(recipesDir.resolve("alpha.yml"), "name: alpha")
+        Files.writeString(recipesDir.resolve("middle.yml"), "name: middle")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        val lines = output.lines()
+
+        // Find the index of each recipe name in the output
+        val alphaIndex = lines.indexOfFirst { it.contains("alpha") }
+        val middleIndex = lines.indexOfFirst { it.contains("middle") }
+        val zebraIndex = lines.indexOfFirst { it.contains("zebra") }
+
+        // Verify sorted order
+        assertTrue(alphaIndex >= 0)
+        assertTrue(middleIndex > alphaIndex)
+        assertTrue(zebraIndex > middleIndex)
+    }
+
+    @Test
+    fun `handle ignores non-yml files`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("recipe.yml"), "name: recipe")
+        Files.writeString(recipesDir.resolve("readme.txt"), "This is a readme")
+        Files.writeString(recipesDir.resolve("config.json"), "{}")
+        Files.writeString(recipesDir.resolve("backup.yaml"), "name: backup")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should only show .yml files
+        assertTrue(output.contains("📦 Registered recipes (1)"))
+        assertTrue(output.contains("recipe"))
+        assertTrue(!output.contains("readme"))
+        assertTrue(!output.contains("config"))
+        assertTrue(!output.contains("backup"))
+    }
+
+    @Test
+    fun `handle shows separator line`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("test.yml"), "name: test")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("────────────────────────────"))
+    }
+
+    @Test
+    fun `handle with recipe names containing special characters`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("my-special_recipe.yml"), "name: test")
+        Files.writeString(recipesDir.resolve("recipe.v2.yml"), "name: test")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("📦 Registered recipes (2)"))
+        assertTrue(output.contains("my-special_recipe"))
+        assertTrue(output.contains("recipe.v2"))
+    }
+
+    @Test
+    fun `handle with recipe names containing spaces`() {
+        Files.createDirectories(recipesDir)
+        // Note: File names with spaces are valid on most file systems
+        Files.writeString(recipesDir.resolve("my recipe.yml"), "name: test")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("📦 Registered recipes (1)"))
+        assertTrue(output.contains("my recipe"))
+    }
+
+    @Test
+    fun `handle with subdirectories in recipes folder`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("recipe1.yml"), "name: recipe1")
+
+        // Create a subdirectory with a recipe
+        val subDir = recipesDir.resolve("subdir")
+        Files.createDirectories(subDir)
+        Files.writeString(subDir.resolve("recipe2.yml"), "name: recipe2")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should only show top-level .yml files
+        assertTrue(output.contains("📦 Registered recipes (1)"))
+        assertTrue(output.contains("recipe1"))
+        assertTrue(!output.contains("recipe2"))
+    }
+
+    @Test
+    fun `handle with empty yml files`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("empty.yml"), "")
+        Files.writeString(recipesDir.resolve("valid.yml"), "name: valid")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should list both files regardless of content
+        assertTrue(output.contains("📦 Registered recipes (2)"))
+        assertTrue(output.contains("empty"))
+        assertTrue(output.contains("valid"))
+    }
+
+    @Test
+    fun `handle with large number of recipes`() {
+        Files.createDirectories(recipesDir)
+
+        // Create 50 recipes
+        for (i in 1..50) {
+            Files.writeString(recipesDir.resolve("recipe-$i.yml"), "name: recipe-$i")
+        }
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("📦 Registered recipes (50)"))
+    }
+
+    @Test
+    fun `handle with yml extension in different cases`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("lowercase.yml"), "name: test")
+        Files.writeString(recipesDir.resolve("uppercase.YML"), "name: test")
+        Files.writeString(recipesDir.resolve("mixedcase.Yml"), "name: test")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Only .yml (lowercase) should be recognized
+        assertTrue(output.contains("lowercase"))
+        // Behavior may vary based on file system case sensitivity
+        // On case-insensitive systems, all might be listed
+        // On case-sensitive systems, only lowercase.yml should be listed
+    }
+
+    @Test
+    fun `handle strips yml extension from displayed names`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("my-recipe.yml"), "name: test")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        val lines = output.lines()
+        val recipeLine = lines.find { it.contains("my-recipe") }
+
+        assertTrue(recipeLine != null)
+        assertTrue(recipeLine!!.contains("my-recipe"))
+        assertTrue(!recipeLine.endsWith(".yml"))
+    }
+
+    @Test
+    fun `handle with numeric recipe names`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("123.yml"), "name: test")
+        Files.writeString(recipesDir.resolve("456.yml"), "name: test")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("📦 Registered recipes (2)"))
+        assertTrue(output.contains("123"))
+        assertTrue(output.contains("456"))
+    }
+
+    @Test
+    fun `handle count matches actual number of yml files`() {
+        Files.createDirectories(recipesDir)
+        Files.writeString(recipesDir.resolve("recipe1.yml"), "name: test")
+        Files.writeString(recipesDir.resolve("recipe2.yml"), "name: test")
+        Files.writeString(recipesDir.resolve("recipe3.yml"), "name: test")
+        Files.writeString(recipesDir.resolve("not-a-recipe.txt"), "test")
+
+        val parsedLine = mockParsedLine(":recipes")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Count should be 3, not 4
+        assertTrue(output.contains("📦 Registered recipes (3)"))
+    }
+}

--- a/src/test/kotlin/io/askimo/cli/commands/ModelsCommandHandlerTest.kt
+++ b/src/test/kotlin/io/askimo/cli/commands/ModelsCommandHandlerTest.kt
@@ -1,0 +1,352 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import io.askimo.core.providers.ModelProvider
+import io.askimo.core.session.Session
+import io.askimo.core.session.SessionParams
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ModelsCommandHandlerTest : CommandHandlerTestBase() {
+    private lateinit var session: Session
+    private lateinit var handler: ModelsCommandHandler
+    private lateinit var params: SessionParams
+
+    @BeforeEach
+    fun setUp() {
+        session = mock<Session>()
+        params = mock<SessionParams>()
+        handler = ModelsCommandHandler(session)
+
+        whenever(session.params) doReturn params
+    }
+
+    @Test
+    fun `keyword returns correct value`() {
+        assertEquals(":models", handler.keyword)
+    }
+
+    @Test
+    fun `description is not empty and mentions models`() {
+        assertTrue(handler.description.isNotBlank())
+        assertTrue(handler.description.contains("model", ignoreCase = true))
+        assertTrue(
+            handler.description.contains("list", ignoreCase = true) ||
+                handler.description.contains("available", ignoreCase = true),
+        )
+    }
+
+    @Test
+    fun `handle with OpenAI provider shows models or helpful message`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OPEN_AI
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Without a valid API key, OpenAI might return no models
+        assertTrue(
+            output.contains("Available models for provider 'open_ai'") ||
+                output.contains("⚠️ No models available for provider: open_ai"),
+        )
+        // Should always show the usage hint
+        assertTrue(output.contains("💡 Use `:set-param model <modelName>` to choose"))
+    }
+
+    @Test
+    fun `handle with OpenAI and no API key shows helpful guidance`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OPEN_AI
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // If no models available, should show OpenAI-specific guidance
+        if (output.contains("⚠️ No models available")) {
+            assertTrue(output.contains("OpenAI API key") || output.contains("platform.openai.com"))
+            assertTrue(output.contains(":set-param api_key"))
+        }
+    }
+
+    @Test
+    fun `handle with Ollama provider shows models or helpful message`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OLLAMA
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Ollama might have no models if not installed, or might list available ones
+        assertTrue(
+            output.contains("Available models for provider 'ollama'") ||
+                output.contains("⚠️ No models available for provider: ollama"),
+        )
+        assertTrue(output.contains("💡 Use `:set-param model <modelName>` to choose"))
+    }
+
+    @Test
+    fun `handle with Ollama and no models shows helpful message`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OLLAMA
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // If no models are available, should show helpful Ollama-specific guidance
+        if (output.contains("⚠️ No models available")) {
+            assertTrue(output.contains("ollama pull"))
+            assertTrue(output.contains("https://ollama.com/library"))
+        }
+    }
+
+    @Test
+    fun `handle with Anthropic provider shows models or helpful message`() {
+        whenever(params.currentProvider) doReturn ModelProvider.ANTHROPIC
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(
+            output.contains("Available models for provider 'anthropic'") ||
+                output.contains("⚠️ No models available for provider: anthropic"),
+        )
+        assertTrue(output.contains("💡 Use `:set-param model <modelName>` to choose"))
+    }
+
+    @Test
+    fun `handle with Gemini provider shows models or helpful message`() {
+        whenever(params.currentProvider) doReturn ModelProvider.GEMINI
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(
+            output.contains("Available models for provider 'gemini'") ||
+                output.contains("⚠️ No models available for provider: gemini"),
+        )
+        assertTrue(output.contains("💡 Use `:set-param model <modelName>` to choose"))
+    }
+
+    @Test
+    fun `handle with xAI provider shows models or helpful message`() {
+        whenever(params.currentProvider) doReturn ModelProvider.X_AI
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(
+            output.contains("Available models for provider 'x_ai'") ||
+                output.contains("⚠️ No models available for provider: x_ai"),
+        )
+        assertTrue(output.contains("💡 Use `:set-param model <modelName>` to choose"))
+    }
+
+    @Test
+    fun `handle with unknown provider shows error`() {
+        whenever(params.currentProvider) doReturn ModelProvider.UNKNOWN
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.contains("❌ No model factory registered for provider: unknown"))
+    }
+
+    @Test
+    fun `handle always shows usage hint`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OPEN_AI
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should always show how to set a model (unless there's an error with no factory)
+        assertTrue(
+            output.contains(":set-param model") ||
+                output.contains("❌ No model factory registered"),
+        )
+    }
+
+    @Test
+    fun `handle shows provider name in lowercase`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OPEN_AI
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Provider name should be lowercase in output
+        assertTrue(output.contains("open_ai"))
+    }
+
+    @Test
+    fun `handle formats model list with dashes when models available`() {
+        whenever(params.currentProvider) doReturn ModelProvider.ANTHROPIC
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // If models are listed, they should be prefixed with "- "
+        if (output.contains("Available models")) {
+            // Check if there's at least one model line (would contain "- ")
+            val hasModelLine = output.lines().any { it.trim().startsWith("- ") }
+            assertTrue(hasModelLine)
+        }
+    }
+
+    @Test
+    fun `handle with different providers shows correct provider names`() {
+        val testCases =
+            listOf(
+                ModelProvider.OPEN_AI to "open_ai",
+                ModelProvider.OLLAMA to "ollama",
+                ModelProvider.ANTHROPIC to "anthropic",
+                ModelProvider.GEMINI to "gemini",
+                ModelProvider.X_AI to "x_ai",
+            )
+
+        testCases.forEach { (provider, expectedName) ->
+            testOut.reset() // Reset output between iterations
+
+            whenever(params.currentProvider) doReturn provider
+            whenever(params.providerSettings) doReturn mutableMapOf()
+
+            val parsedLine = mockParsedLine(":models")
+            handler.handle(parsedLine)
+
+            val output = getOutput()
+            assertTrue(
+                output.contains(expectedName),
+                "Output should contain provider name '$expectedName'",
+            )
+        }
+    }
+
+    @Test
+    fun `handle with custom provider settings uses them`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OLLAMA
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should successfully process without errors
+        assertTrue(
+            output.contains("Available models") ||
+                output.contains("⚠️ No models available") ||
+                output.contains("❌"),
+        )
+    }
+
+    @Test
+    fun `handle shows emoji in output`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OPEN_AI
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should contain at least one emoji
+        assertTrue(
+            output.contains("💡") ||
+                output.contains("⚠️") ||
+                output.contains("❌"),
+        )
+    }
+
+    @Test
+    fun `handle with empty provider settings map uses defaults`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OLLAMA
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        // Should not crash, should show models or no models message
+        assertTrue(
+            output.contains("ollama") ||
+                output.contains("Available models") ||
+                output.contains("⚠️ No models available"),
+        )
+    }
+
+    @Test
+    fun `handle shows appropriate guidance based on provider`() {
+        // Test Ollama guidance
+        whenever(params.currentProvider) doReturn ModelProvider.OLLAMA
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        var parsedLine = mockParsedLine(":models")
+        handler.handle(parsedLine)
+        var output = getOutput()
+
+        if (output.contains("⚠️ No models available")) {
+            assertTrue(output.contains("ollama") && output.contains("pull"))
+        }
+
+        // Reset and test OpenAI guidance
+        testOut.reset()
+        whenever(params.currentProvider) doReturn ModelProvider.OPEN_AI
+
+        parsedLine = mockParsedLine(":models")
+        handler.handle(parsedLine)
+        output = getOutput()
+
+        if (output.contains("⚠️ No models available")) {
+            assertTrue(output.contains("API key") || output.contains("platform.openai.com"))
+        }
+    }
+
+    @Test
+    fun `handle with null provider settings does not crash`() {
+        whenever(params.currentProvider) doReturn ModelProvider.OLLAMA
+        whenever(params.providerSettings) doReturn mutableMapOf()
+
+        val parsedLine = mockParsedLine(":models")
+
+        // Should not throw exception
+        handler.handle(parsedLine)
+
+        val output = getOutput()
+        assertTrue(output.isNotEmpty())
+    }
+}


### PR DESCRIPTION
Add a few more tests. Commands such as `CreateProjectCommandHandler` and `DeleteProjectCommandHandler` are harder to cover because they depend on TestContainers, so I’ll defer them to future pull requests.