### PR TITLE
feat(cli): add history command and refactor config handler

### DIFF
--- a/src/main/kotlin/io/askimo/cli/commands/ConfigCommandHandler.kt
+++ b/src/main/kotlin/io/askimo/cli/commands/ConfigCommandHandler.kt
@@ -14,7 +14,7 @@ import org.jline.reader.ParsedLine
  * provider, model, and all configured settings. It helps users understand the current state
  * of their chat environment.
  */
-class ConfigCommand(
+class ConfigCommandHandler(
     private val session: Session,
 ) : CommandHandler {
     override val keyword: String = ":config"

--- a/src/main/kotlin/io/askimo/cli/commands/HistoryCommandHandler.kt
+++ b/src/main/kotlin/io/askimo/cli/commands/HistoryCommandHandler.kt
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.commands
+
+import org.jline.reader.LineReader
+import org.jline.reader.ParsedLine
+import org.jline.terminal.Terminal
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+class HistoryCommandHandler(
+    private val reader: LineReader,
+    private val terminal: Terminal,
+    private val historyFile: Path? = null,
+) : CommandHandler {
+    override val keyword: String = ":history"
+    override val description: String = "Show recent prompts (use :history [N], or :history clear)."
+
+    private val timeFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+
+    override fun handle(line: ParsedLine) {
+        val arg = line.words().getOrNull(1)?.trim()
+        val history = reader.history
+
+        when {
+            arg.equals("clear", ignoreCase = true) -> {
+                history.purge()
+                if (historyFile != null) {
+                    runCatching { Files.deleteIfExists(historyFile!!) }
+                }
+                terminal.writer().println("🧹 History cleared.")
+            }
+
+            else -> {
+                val n = arg?.toIntOrNull() ?: 20
+                val total = history.size()
+                if (total == 0) {
+                    terminal.writer().println("(history empty)")
+                    terminal.flush()
+                    return
+                }
+                val start = (total - n).coerceAtLeast(0)
+                val entries = history as Iterable<org.jline.reader.History.Entry>
+                for (entry in entries.drop(start)) {
+                    val ts =
+                        entry
+                            .time()
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDateTime()
+                    val oneLine = entry.line().replace("\n", "\\n")
+                    terminal.writer().printf("%5d  %s  %s%n", entry.index(), timeFmt.format(ts), oneLine)
+                }
+            }
+        }
+        terminal.flush()
+    }
+}


### PR DESCRIPTION
- Implemented `HistoryCommandHandler` to list recent prompts, clear history, and support a configurable number of entries.
- Persisted command history to `~/.askimo/history` with a default size of 100.
- Registered the new history handler in `ChatCli.kt` and updated the command list.
- Renamed `ConfigCommand` → `ConfigCommandHandler` for consistency and updated all imports.
- Enhanced user tips, adding a second tip for history navigation.
- Removed the old `ConfigCommand.kt` file and its references.

**BREAKING CHANGE**
`ConfigCommand` has been renamed to `ConfigCommandHandler`. Existing imports or usages must be updated accordingly.