### PR TITLE
refactor(core): improve session caching and API key handling

### DIFF
--- a/src/main/kotlin/io/askimo/core/project/EmbeddingModelFactory.kt
+++ b/src/main/kotlin/io/askimo/core/project/EmbeddingModelFactory.kt
@@ -14,6 +14,9 @@ import io.askimo.core.providers.ModelProvider.OLLAMA
 import io.askimo.core.providers.ModelProvider.OPEN_AI
 import io.askimo.core.providers.ModelProvider.UNKNOWN
 import io.askimo.core.providers.ModelProvider.X_AI
+import io.askimo.core.providers.openai.OpenAiSettings
+import io.askimo.core.session.SessionFactory
+import io.askimo.core.util.ApiKeyUtils.safeApiKey
 import java.net.HttpURLConnection
 import java.net.URI
 import java.util.concurrent.atomic.AtomicBoolean
@@ -27,12 +30,11 @@ private val warnedOllamaOnce = AtomicBoolean(false)
 fun getEmbeddingModel(provider: ModelProvider): EmbeddingModel =
     when (provider) {
         OPEN_AI -> {
-            val openAiKey =
-                System.getenv("OPENAI_API_KEY")
-                    ?: error("OPENAI_API_KEY missing for OpenAI embeddings")
+            val openAiKey = (SessionFactory.createSession().getCurrentProviderSettings() as OpenAiSettings).apiKey
             val modelName = System.getenv("OPENAI_EMBED_MODEL") ?: DEFAULT_OPENAI_EMBED_MODEL
+
             OpenAiEmbeddingModelBuilder()
-                .apiKey(openAiKey)
+                .apiKey(safeApiKey(openAiKey))
                 .modelName(modelName)
                 .build()
         }

--- a/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -12,6 +12,7 @@ import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.ChatService
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.verbosityInstruction
+import io.askimo.core.util.ApiKeyUtils.safeApiKey
 import io.askimo.core.util.SystemPrompts.systemMessage
 import io.askimo.tools.fs.LocalFsTools
 
@@ -44,7 +45,7 @@ class AnthropicModelFactory : ChatModelFactory {
         val chatModel =
             AnthropicStreamingChatModel
                 .builder()
-                .apiKey(settings.apiKey)
+                .apiKey(safeApiKey(settings.apiKey))
                 .modelName(model)
                 .baseUrl(settings.baseUrl)
                 .build()

--- a/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -15,6 +15,7 @@ import io.askimo.core.providers.ProviderModelUtils.fetchModels
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.samplingFor
 import io.askimo.core.providers.verbosityInstruction
+import io.askimo.core.util.ApiKeyUtils.safeApiKey
 import io.askimo.core.util.SystemPrompts.systemMessage
 import io.askimo.tools.fs.LocalFsTools
 
@@ -49,7 +50,7 @@ class GeminiModelFactory : ChatModelFactory {
         val chatModel =
             GoogleAiGeminiStreamingChatModel
                 .builder()
-                .apiKey(settings.apiKey)
+                .apiKey(safeApiKey(settings.apiKey))
                 .modelName(model)
                 .apply {
                     if (supportsSampling(model)) {

--- a/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -15,6 +15,7 @@ import io.askimo.core.providers.ProviderModelUtils.fetchModels
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.samplingFor
 import io.askimo.core.providers.verbosityInstruction
+import io.askimo.core.util.ApiKeyUtils.safeApiKey
 import io.askimo.core.util.SystemPrompts.systemMessage
 import io.askimo.tools.fs.LocalFsTools
 
@@ -46,7 +47,7 @@ class OpenAiModelFactory : ChatModelFactory {
         val chatModel =
             OpenAiStreamingChatModel
                 .builder()
-                .apiKey(settings.apiKey)
+                .apiKey(safeApiKey(settings.apiKey))
                 .modelName(model)
                 .apply {
                     if (supportsSampling(model)) {

--- a/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
+++ b/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
@@ -15,6 +15,7 @@ import io.askimo.core.providers.ProviderModelUtils.fetchModels
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.samplingFor
 import io.askimo.core.providers.verbosityInstruction
+import io.askimo.core.util.ApiKeyUtils.safeApiKey
 import io.askimo.core.util.SystemPrompts.systemMessage
 import io.askimo.tools.fs.LocalFsTools
 
@@ -49,7 +50,7 @@ class XAiModelFactory : ChatModelFactory {
         val chatModel =
             OpenAiStreamingChatModel
                 .builder()
-                .apiKey(settings.apiKey)
+                .apiKey(safeApiKey(settings.apiKey))
                 .baseUrl(settings.baseUrl)
                 .modelName(model)
                 .apply {

--- a/src/main/kotlin/io/askimo/core/session/SessionFactory.kt
+++ b/src/main/kotlin/io/askimo/core/session/SessionFactory.kt
@@ -11,35 +11,70 @@ import io.askimo.core.providers.ProviderRegistry
 import io.askimo.core.providers.ProviderSettings
 
 object SessionFactory {
-    // TODO: create session for both cli and web application. Now, the web application is simple while it serves for one user only
-    // If in the future, we decide to let web application can serve multiple users then
-    // this function is subject to change
-    fun createSession(params: SessionParams = SessionConfigManager.load()): Session {
-        log { "Current provider: $params" }
+    @Volatile
+    private var cached: Session? = null
+
+    /** Return the cached session if any (no I/O). */
+    fun current(): Session? = cached
+
+    /** Drop the cached session (e.g., after logout or user switch). */
+    fun clear() {
+        cached = null
+    }
+
+    /**
+     * Create (or reuse) a Session.
+     * - Reuses cached if params are equal to the cached session's params and forceReload == false.
+     * - Otherwise builds a new Session and caches it.
+     */
+    fun createSession(
+        params: SessionParams = SessionConfigManager.load(),
+        forceReload: Boolean = false,
+    ): Session {
+        if (!forceReload) {
+            val existing = cached
+            if (existing != null && existing.params == params) return existing
+        }
+
+        return synchronized(this) {
+            if (!forceReload) {
+                val again = cached
+                if (again != null && again.params == params) return@synchronized again
+            }
+            val fresh = buildSession(params)
+            cached = fresh
+            fresh
+        }
+    }
+
+    /** Persist params, then (re)build and cache a fresh Session from them. */
+    fun reconfigure(params: SessionParams): Session {
+        SessionConfigManager.save(params)
+        return createSession(params, forceReload = true)
+    }
+
+    /** Reload params from disk and rebuild the cached session. */
+    fun reloadFromDisk(): Session = createSession(SessionConfigManager.load(), forceReload = true)
+
+    private fun buildSession(params: SessionParams): Session {
+        log { "Building session with params: $params" }
 
         val session = Session(params)
-
         val provider = session.params.currentProvider
         val modelName = session.params.getModel(provider)
 
+        val factory = ProviderRegistry.getFactory(provider)
+
         val settings: ProviderSettings =
             session.params.providerSettings[provider]
-                ?: ProviderRegistry.getFactory(provider)?.defaultSettings()
+                ?: factory?.defaultSettings()
                 ?: NoopProviderSettings
 
         val memory = session.getOrCreateMemory(provider, modelName, settings)
 
-        val factory = ProviderRegistry.getFactory(provider)
-        val chatService =
-            factory
-                ?.create(
-                    modelName,
-                    settings,
-                    memory,
-                )
-                ?: NoopChatService
-
+        val chatService = factory?.create(modelName, settings, memory) ?: NoopChatService
         session.setChatService(chatService)
+
         return session
     }
 }

--- a/src/main/kotlin/io/askimo/core/util/ApiKeyUtils.kt
+++ b/src/main/kotlin/io/askimo/core/util/ApiKeyUtils.kt
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.util
+
+object ApiKeyUtils {
+    /**
+     * Returns a safe API key for use in OpenAI or providers requires api key / LangChain4j builders.
+     * - Uses the provided key if non-blank.
+     * - Falls back to a harmless default ("sk-dummy") to avoid IllegalArgumentException
+     *   during native image or test runs.
+     */
+    fun safeApiKey(raw: String?): String = raw?.takeIf { it.isNotBlank() } ?: "sk-dummy"
+}

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1571,7 +1571,28 @@
   },
   {
     "name": "io.askimo.tools.fs.LocalFsTools",
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "queryAllPublicMethods": true,
     "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.askimo.tools.fs.LocalFsToolsTest",
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] },
+      { "name": "testCountEntries", "parameterTypes": ["java.nio.file.Path"] },
+      { "name": "testFilesByType", "parameterTypes": ["java.nio.file.Path"] },
+      { "name": "testReadText", "parameterTypes": ["java.nio.file.Path"] },
+      {
+        "name": "testTotalSizeByType",
+        "parameterTypes": ["java.nio.file.Path"]
+      }
+    ]
   },
   {
     "name": "io.askimo.tools.git.GitTools",
@@ -2370,7 +2391,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$kBgPJtbn",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$FUAida8k",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/src/main/resources/META-INF/services/org.graalvm.nativeimage.hosted.Feature
+++ b/src/main/resources/META-INF/services/org.graalvm.nativeimage.hosted.Feature
@@ -1,0 +1,1 @@
+io.askimo.core.graal.AskimoReflectionFeature


### PR DESCRIPTION
- Introduced in-memory caching for session parameters in `SessionConfigManager`.
- Implemented caching mechanism in `SessionFactory` to reuse sessions.
- Added `ApiKeyUtils` for safe API key management, replacing direct usage of environment variables.
- Simplified reflection registration in `AskimoFeature` for GraalVM native image support.
- Updated `reflect-config.json` to include new reflection configurations.
- Added service descriptor for GraalVM feature registration.

BREAKING CHANGE: `SessionFactory.createSession` now includes caching, which might affect session lifecycle management if external dependencies are sensitive to session reuse.