### PR TITLE
Disable fail-fast feature in test container

### DIFF
--- a/src/main/kotlin/io/askimo/core/project/PgVectorIndexer.kt
+++ b/src/main/kotlin/io/askimo/core/project/PgVectorIndexer.kt
@@ -29,13 +29,6 @@ import kotlin.streams.asSequence
 /**
  * Indexes project files into a pgvector-backed store and exposes basic embedding and
  * similarity search utilities.
- *
- * Reliability improvements vs. the base version:
- *  - Chunking large files (configurable) with small overlap to avoid huge requests
- *  - Retry with exponential backoff on transient HTTP/IO errors (EOF, 5xx, resets)
- *  - Light request throttling to avoid overwhelming local model endpoints
- *  - Soft file-size cap (skippable or adjustable)
- *  - Richer metadata (chunk_index / chunk_total) for traceability
  */
 class PgVectorIndexer(
     private val projectId: String,


### PR DESCRIPTION
- Disable Testcontainers' `FAIL_FAST_ALWAYS` to avoid premature test container failures.
- Add a Docker connectivity check during initialization to ensure Docker is running.
- Clean up imports and improve readability of `PostgresContainerManager.kt`.

No API changes were made; this commit simply improves reliability of container startup and documentation.