### PR TITLE
docs(config): add sitemap plugin to config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,6 +2,7 @@ title: Askimo CLI
 description: Cross-platform AI CLI for OpenAI, Ollama, Gemini, and more.
 remote_theme: just-the-docs/just-the-docs
 color_scheme: light
+url: https://haiphucnguyen.github.io/askimo/
 
 #logo: /assets/images/askimo-logo-64.png
 favicon_ico: /assets/images/askimo-favicon.ico
@@ -30,6 +31,7 @@ defaults:
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-sitemap
 
 # Feed config (optional)
 feed:


### PR DESCRIPTION
- Added `url` configuration for sitemap generation.
- Integrated `jekyll-sitemap` plugin.

This update enhances the site's SEO by generating a sitemap automatically.