### PR TITLE
feat(cli): enhance support for non-interactive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,26 +70,65 @@ Other ways to install → [Installation Guide](docs/installation.md)
 
 ## Available Commands
 
-| Command           | Description                                                                                                 | Example Usage                                      |
-|-------------------|-------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
-| `:help`           | Show all available commands                                                                                 | `:help`                                           |
-| `:set-param`      | Set a parameter for the current provider                                                                    | `:set-param style creative`                       |
-| `:params`         | View current session parameters                                                                             | `:params`                                         |
-| `:config`         | Show the current provider, model, and settings                                                              | `:config`                                         |
-| `:providers`      | List all supported AI providers                                                                             | `:providers`                                      |
-| `:set-provider`   | Switch to a different AI provider                                                                           | `:set-provider ollama`                            |
-| `:models`         | List available models for the current provider                                                              | `:models`                                         |
-| `:copy`           | Copy the last response to the clipboard                                                                     | `:copy`                                           |
-| `:clear`          | Clear the chat history for the current session                                                              | `:clear`                                          |
-| `:create-project` | Create a project, auto-start Postgres+pgvector (Testcontainers), and index the folder                      | `:create-project -n myapp -d /path/to/folder`     |
-| `:projects`       | List all saved Askimo projects                                                                              | `:projects`                                       |
-| `:use-project`    | Activate a saved project (sets scope and enables RAG)                                                       | `:project myapp`                                  |
-| `:delete-project` | Delete a saved project: removes it from ~/.askimo/projects.json and drops its pgvector embedding table      | `:delete-project myapp`                           |
-| `:create-recipe`  | Create a provider-agnostic recipe from a YAML template                                                      | `:create-recipe myrecipe -template recipe.yml`    |
-| `:recipes`        | List all registered recipes in ~/.askimo/recipes                                                            | `:recipes`                                        |
-| `:delete-recipe`  | Delete a registered recipe from ~/.askimo/recipes                                                           | `:delete-recipe myrecipe`                         |
-| `:exit`           | Exit the Askimo REPL                                                                                        | `:exit`                                           |
+Askimo supports **two modes** for running commands:
 
+### 🔄 Interactive Mode
+Start Askimo without arguments to enter interactive mode:
+```bash
+askimo
+askimo> :help
+```
+
+### 🚀 Non-Interactive Mode  
+Run commands directly from the command line:
+```bash
+askimo --help
+askimo --list-providers
+askimo --set-provider openai
+```
+
+### 📋 Command Reference
+
+All commands work in both modes - just use `:command` for interactive or `--command` for non-interactive:
+
+| Interactive Mode    | Non-Interactive Mode     | Description                                                                                                 | Example Usage                                      |
+|-------------------|--------------------------|-------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| `:help`           | `--help`                 | Show all available commands                                                                                 | `:help` or `askimo --help`                       |
+| `:set-param`      | `--set-param`            | Set a parameter for the current provider                                                                    | `:set-param style creative`                       |
+| `:params`         | `--params`               | View current session parameters                                                                             | `:params` or `askimo --params`                   |
+| `:config`         | `--config`               | Show the current provider, model, and settings                                                              | `:config` or `askimo --config`                   |
+| `:providers`      | `--providers`            | List all supported AI providers                                                                             | `:providers` or `askimo --providers`             |
+| `:set-provider`   | `--set-provider`         | Switch to a different AI provider                                                                           | `:set-provider ollama` or `askimo --set-provider ollama` |
+| `:models`         | `--models`               | List available models for the current provider                                                              | `:models` or `askimo --models`                   |
+| `:copy`           | `--copy`                 | Copy the last response to the clipboard                                                                     | `:copy`                                           |
+| `:clear`          | `--clear`                | Clear the chat history for the current session                                                              | `:clear`                                          |
+| `:create-project` | `--create-project`       | Create a project, auto-start Postgres+pgvector (Testcontainers), and index the folder                      | `:create-project -n myapp -d /path/to/folder`     |
+| `:projects`       | `--projects`             | List all saved Askimo projects                                                                              | `:projects` or `askimo --projects`               |
+| `:use-project`    | `--use-project`          | Activate a saved project (sets scope and enables RAG)                                                       | `:use-project myapp`                             |
+| `:delete-project` | `--delete-project`       | Delete a saved project: removes it from ~/.askimo/projects.json and drops its pgvector embedding table      | `:delete-project myapp`                           |
+| `:create-recipe`  | `--create-recipe`        | Create a provider-agnostic recipe from a YAML template                                                      | `:create-recipe myrecipe --template recipe.yml` or `askimo --create-recipe myrecipe --template recipe.yml` |
+| `:recipes`        | `--recipes`              | List all registered recipes in ~/.askimo/recipes                                                            | `:recipes` or `askimo --recipes`                 |
+| `:delete-recipe`  | `--delete-recipe`        | Delete a registered recipe from ~/.askimo/recipes                                                           | `:delete-recipe myrecipe`                         |
+| `:exit`           | N/A                      | Exit the Askimo REPL (interactive mode only)                                                                | `:exit`                                           |
+
+### 💡 Quick Examples
+
+**Interactive Mode:**
+```bash
+$ askimo
+askimo> :providers
+askimo> :set-provider openai  
+askimo> :config
+askimo> What is TypeScript?
+```
+
+**Non-Interactive Mode:**
+```bash
+$ askimo --providers
+$ askimo --set-provider openai
+$ askimo --config
+$ echo "function add(a, b) { return a + b; }" | askimo "Convert this to TypeScript"
+```
 
 ➡ **[View the full command reference »](docs/commands.md)**  
 Includes detailed usage, options, and examples for each command.
@@ -113,4 +152,3 @@ Askimo is designed to be pluggable, so you can tailor it to your needs:
 * Create a feature branch
 
 * Open a PR
-

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,12 +265,12 @@ Create a provider-agnostic recipe from a YAML template file. Recipes are reusabl
 
 **Parameters:**
 - `[name]` - Optional name for the recipe (can also be specified in the YAML file)
-- `-template, --template` - Path to the YAML template file
+- `-f, --file` - Path to the YAML template file
 
 **Example:**
 
 ```bash
-:create-recipe myrecipe -template ~/templates/code-review.yml
+:create-recipe myrecipe -f ~/templates/code-review.yml
 ```
 
 **Notes:**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ testcontainers = "1.21.3"
 mockitoKotlin = "6.1.0"
 kotlin = "2.2.20"
 jackson = "2.19.2"
-spotless = "7.2.1"
+spotless = "8.0.0"
 shadow = "9.0.1"
 graalvmSvm = "25.0.0"
 

--- a/src/main/kotlin/io/askimo/cli/commands/ApiKeySecurityCommandHandler.kt
+++ b/src/main/kotlin/io/askimo/cli/commands/ApiKeySecurityCommandHandler.kt
@@ -19,8 +19,8 @@ class ApiKeySecurityCommandHandler(
     override val keyword: String = ":security"
     override val description: String = "Manage API key security settings"
 
-    override fun handle(parsedLine: org.jline.reader.ParsedLine) {
-        val args = parsedLine.words().drop(1)
+    override fun handle(line: org.jline.reader.ParsedLine) {
+        val args = line.words().drop(1)
 
         if (args.isEmpty()) {
             showSecurityStatus()

--- a/src/main/kotlin/io/askimo/cli/commands/CreateRecipeCommandHandler.kt
+++ b/src/main/kotlin/io/askimo/cli/commands/CreateRecipeCommandHandler.kt
@@ -19,13 +19,13 @@ class CreateRecipeCommandHandler : CommandHandler {
     override val keyword: String = ":create-recipe"
     override val description: String =
         "Create a provider-agnostic recipe from a YAML template.\n" +
-            "Usage: :create-recipe <name?> -template <file.yml>"
+            "Usage: :create-recipe <name?> -f <file.yml>"
 
     override fun handle(line: ParsedLine) {
         val args = line.words().drop(1)
         val (maybeName, templatePath) =
             parseArgs(args) ?: run {
-                info("Usage: :create-recipe <name?> -template <file.yml>")
+                info("Usage: :create-recipe <name?> -f <file.yml>")
                 return
             }
 
@@ -101,7 +101,7 @@ class CreateRecipeCommandHandler : CommandHandler {
         }
         while (i < args.size) {
             when (args[i]) {
-                "-template", "--template" -> {
+                "-f", "--file" -> {
                     if (i + 1 < args.size) {
                         template = args[i + 1]
                         i += 2

--- a/src/main/kotlin/io/askimo/cli/commands/HelpCommandHandler.kt
+++ b/src/main/kotlin/io/askimo/cli/commands/HelpCommandHandler.kt
@@ -19,15 +19,68 @@ class HelpCommandHandler : CommandHandler {
     override val description = "Show available commands"
 
     private var commands: List<CommandHandler> = emptyList()
+    private var isNonInteractiveMode = false
 
     fun setCommands(commands: List<CommandHandler>) {
         this.commands = commands
     }
 
     override fun handle(line: ParsedLine) {
-        info("Available commands:\n")
-        commands.sortedBy { it.keyword }.forEach {
-            info("  ${it.keyword.padEnd(14)} - ${it.description}")
+        // Detect if this is non-interactive mode by checking if the line contains "--help"
+        isNonInteractiveMode = line.line().contains("--help")
+
+        val modeText = if (isNonInteractiveMode) "non-interactive" else "interactive"
+        val prefix = if (isNonInteractiveMode) "--" else ":"
+
+        info("Available commands ($modeText mode):\n")
+
+        commands.sortedBy { it.keyword }.forEach { handler ->
+            val commandName = if (isNonInteractiveMode) {
+                "--" + handler.keyword.removePrefix(":")
+            } else {
+                handler.keyword
+            }
+
+            formatCommand(commandName, handler.description)
+        }
+
+        if (isNonInteractiveMode) {
+            info("\nFor interactive mode, run 'askimo' without arguments and use ':command' format.")
+        } else {
+            info("\nFor non-interactive mode, use 'askimo --command' format from command line.")
+        }
+    }
+
+    private fun formatCommand(commandName: String, description: String) {
+        val lines = description.split('\n')
+        val mainDescription = lines[0]
+        val additionalLines = lines.drop(1)
+
+        // Format main command line
+        info("  ${commandName.padEnd(18)} - $mainDescription")
+
+        // Format usage and additional lines with proper indentation
+        additionalLines.forEach { line ->
+            when {
+                line.trim().startsWith("Usage:") -> {
+                    info("${" ".repeat(22)}$line")
+                }
+                line.trim().startsWith("Example:") -> {
+                    info("${" ".repeat(22)}$line")
+                }
+                line.trim().startsWith("Options:") -> {
+                    info("${" ".repeat(22)}$line")
+                }
+                line.trim().startsWith("--") -> {
+                    info("${" ".repeat(24)}$line")
+                }
+                line.trim().isNotEmpty() -> {
+                    info("${" ".repeat(22)}$line")
+                }
+                else -> {
+                    info("")
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/io/askimo/cli/util/NonInteractiveCommandParser.kt
+++ b/src/main/kotlin/io/askimo/cli/util/NonInteractiveCommandParser.kt
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.cli.util
+
+import org.jline.reader.ParsedLine
+
+/**
+ * Utility for parsing non-interactive command line arguments into ParsedLine objects
+ * that can be used with existing interactive command handlers.
+ */
+object NonInteractiveCommandParser {
+    /**
+     * Creates an empty ParsedLine for commands that don't require parameters.
+     * Used for commands like --list-providers, --list-projects, --list-recipes.
+     */
+    fun createEmptyParsedLine(): ParsedLine = EmptyParsedLine()
+
+    /**
+     * Creates a ParsedLine for commands that require parameters.
+     * Used for commands like --set-provider <provider>.
+     *
+     * @param interactiveCommand The interactive command format (e.g., ":set-provider")
+     * @param parameters The command parameters
+     * @return ParsedLine that can be used with existing command handlers
+     */
+    fun createParameterizedParsedLine(
+        interactiveCommand: String,
+        vararg parameters: String,
+    ): ParsedLine = ParameterizedParsedLine(interactiveCommand, parameters.toList())
+
+    /**
+     * Parses command line arguments for a specific flag and returns the argument value.
+     *
+     * @param args Command line arguments array
+     * @param flag The flag to look for (e.g., "--set-provider")
+     * @return The argument value following the flag, or null if not found or no value
+     */
+    fun extractFlagValue(
+        args: Array<String>,
+        flag: String,
+    ): String? {
+        val flagIndex = args.indexOfFirst { it == flag }
+        return if (flagIndex != -1 && flagIndex + 1 < args.size) {
+            args[flagIndex + 1]
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Extracts all arguments following a specific flag until the next flag or end of arguments.
+     * This is a generic method that lets command handlers do their own parsing and validation.
+     *
+     * @param args Command line arguments array
+     * @param flag The flag to look for (e.g., "--create-recipe")
+     * @return List of arguments following the flag, or null if flag not found
+     */
+    fun extractFlagArguments(
+        args: Array<String>,
+        flag: String,
+    ): List<String>? {
+        val flagIndex = args.indexOfFirst { it == flag }
+        if (flagIndex == -1) return null
+
+        val arguments = mutableListOf<String>()
+        var i = flagIndex + 1
+
+        // Collect all arguments until we hit another flag (starts with -) or end of args
+        while (i < args.size && !args[i].startsWith("-")) {
+            arguments.add(args[i])
+            i++
+        }
+
+        // Also collect flag-value pairs (like -f file.yml)
+        while (i < args.size) {
+            if (args[i].startsWith("-") && i + 1 < args.size && !args[i + 1].startsWith("-")) {
+                arguments.add(args[i]) // Add the flag
+                arguments.add(args[i + 1]) // Add the value
+                i += 2
+            } else {
+                break
+            }
+        }
+
+        return arguments
+    }
+
+    private class EmptyParsedLine : ParsedLine {
+        override fun word() = ""
+
+        override fun wordCursor() = 0
+
+        override fun wordIndex() = 0
+
+        override fun words() = emptyList<String>()
+
+        override fun line() = ""
+
+        override fun cursor() = 0
+    }
+
+    private class ParameterizedParsedLine(
+        private val command: String,
+        private val parameters: List<String>,
+    ) : ParsedLine {
+        private val allWords = listOf(command) + parameters
+        private val fullLine = allWords.joinToString(" ")
+
+        override fun word() = parameters.firstOrNull() ?: ""
+
+        override fun wordCursor() = 0
+
+        override fun wordIndex() = 1
+
+        override fun words() = allWords
+
+        override fun line() = fullLine
+
+        override fun cursor() = fullLine.length
+    }
+}

--- a/src/test/kotlin/io/askimo/cli/commands/CreateRecipeCommandHandlerTest.kt
+++ b/src/test/kotlin/io/askimo/cli/commands/CreateRecipeCommandHandlerTest.kt
@@ -45,7 +45,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
             """.trimIndent()
         Files.writeString(templateFile, yamlContent)
 
-        val parsedLine = mockParsedLine(":create-recipe", "my-recipe", "-template", templateFile.toString())
+        val parsedLine = mockParsedLine(":create-recipe", "my-recipe", "-f", templateFile.toString())
 
         handler.handle(parsedLine)
 
@@ -70,7 +70,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
 
     @Test
     fun `handle with non-existent template shows error`() {
-        val parsedLine = mockParsedLine(":create-recipe", "my-recipe", "-template", "/non/existent/file.yml")
+        val parsedLine = mockParsedLine(":create-recipe", "my-recipe", "-f", "/non/existent/file.yml")
 
         handler.handle(parsedLine)
 
@@ -83,7 +83,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
         val templateFile = tempDir.resolve("invalid.yml")
         Files.writeString(templateFile, "invalid: yaml: content:")
 
-        val parsedLine = mockParsedLine(":create-recipe", "test", "-template", templateFile.toString())
+        val parsedLine = mockParsedLine(":create-recipe", "test", "-f", templateFile.toString())
 
         handler.handle(parsedLine)
 
@@ -105,7 +105,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
             """.trimIndent()
         Files.writeString(templateFile, yamlContent)
 
-        val parsedLine = mockParsedLine(":create-recipe", "-template", templateFile.toString())
+        val parsedLine = mockParsedLine(":create-recipe", "-f", templateFile.toString())
 
         handler.handle(parsedLine)
 
@@ -129,7 +129,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
             """.trimIndent()
         Files.writeString(templateFile, yamlContent)
 
-        val parsedLine = mockParsedLine(":create-recipe", "-template", templateFile.toString())
+        val parsedLine = mockParsedLine(":create-recipe", "-f", templateFile.toString())
 
         handler.handle(parsedLine)
 
@@ -157,7 +157,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
         Files.createDirectories(recipesDir)
         Files.writeString(recipesDir.resolve("existing-recipe.yml"), yamlContent)
 
-        val parsedLine = mockParsedLine(":create-recipe", "existing-recipe", "-template", templateFile.toString())
+        val parsedLine = mockParsedLine(":create-recipe", "existing-recipe", "-f", templateFile.toString())
 
         handler.handle(parsedLine)
 
@@ -179,7 +179,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
             """.trimIndent()
         Files.writeString(templateFile, yamlContent)
 
-        val parsedLine = mockParsedLine(":create-recipe", "test", "-template", "~/template.yml")
+        val parsedLine = mockParsedLine(":create-recipe", "test", "-f", "~/template.yml")
 
         handler.handle(parsedLine)
 
@@ -213,7 +213,7 @@ class CreateRecipeCommandHandlerTest : CommandHandlerTestBase() {
             mockParsedLine(
                 ":create-recipe",
                 "gitcommit-test",
-                "-template",
+                "-f",
                 templatePath.toString(),
             )
 


### PR DESCRIPTION
- Add `NonInteractiveCommandParser` utility for parsing CLI arguments.
- Update `ChatCli.kt` to handle non-interactive command flags.
- Adjust `HelpCommandHandler` to differentiate between interactive and non-interactive modes.
- Modify `ApiKeySecurityCommandHandler` and `CreateRecipeCommandHandler` for better argument handling.
- Change `-template` argument to `-f` for `CreateRecipeCommandHandler`.

BREAKING CHANGE: The `CreateRecipeCommandHandler` now uses `-f` instead of `-template` for specifying YAML template files. This change affects both interactive and non-interactive modes.