### PR TITLE
Rename Chat API methods and add more integration tests

### DIFF
--- a/src/main/kotlin/io/askimo/cli/ChatCli.kt
+++ b/src/main/kotlin/io/askimo/cli/ChatCli.kt
@@ -29,8 +29,8 @@ import io.askimo.cli.commands.SetProviderCommandHandler
 import io.askimo.cli.commands.UseProjectCommandHandler
 import io.askimo.cli.util.NonInteractiveCommandParser
 import io.askimo.core.VersionInfo
-import io.askimo.core.providers.chat
-import io.askimo.core.providers.chatWithCallback
+import io.askimo.core.providers.sendMessage
+import io.askimo.core.providers.sendMessageStreaming
 import io.askimo.core.recipes.RecipeExecutor
 import io.askimo.core.recipes.RecipeRegistry
 import io.askimo.core.recipes.ToolRegistry
@@ -252,7 +252,7 @@ fun main(args: Array<String>) {
                     val promptWithContext = session.prepareContextAndGetPrompt(prompt)
 
                     // Stream the response directly for real-time display
-                    val output = session.getChatService().chat(promptWithContext) { token ->
+                    val output = session.getChatService().sendMessage(promptWithContext) { token ->
                         if (firstTokenSeen.compareAndSet(false, true)) {
                             indicator.stopWithElapsed()
                             reader.terminal.flush()
@@ -286,7 +286,7 @@ fun main(args: Array<String>) {
             val prompt = buildPrompt(userPrompt, stdinText)
             val out = System.out.writer()
             val output =
-                session.getChatService().chatWithCallback(prompt) { token ->
+                session.getChatService().sendMessageStreaming(prompt) { token ->
                     out.write(token)
                     out.flush()
                 }
@@ -426,7 +426,7 @@ private fun runYamlCommand(
     val executor =
         RecipeExecutor(
             session = session,
-            registry = registry, // will re-load; negligible overhead
+            registry = registry,
             tools = toolRegistry,
         )
 

--- a/src/main/kotlin/io/askimo/core/project/DiffGenerator.kt
+++ b/src/main/kotlin/io/askimo/core/project/DiffGenerator.kt
@@ -20,7 +20,7 @@ class DiffGenerator(
         val prompt = built.asSingleMessage()
 
         val sb = StringBuilder()
-        val stream: TokenStream = chat.stream(prompt)
+        val stream: TokenStream = chat.sendMessageStreaming(prompt)
         stream.onPartialResponse { sb.append(it) }
         stream.onError { error -> throw error }
         stream.start()

--- a/src/main/kotlin/io/askimo/core/providers/ChatServiceExtensions.kt
+++ b/src/main/kotlin/io/askimo/core/providers/ChatServiceExtensions.kt
@@ -16,14 +16,14 @@ import java.util.concurrent.CountDownLatch
  * @param onToken Optional callback function that is invoked for each token received from the model
  * @return The complete response from the language model as a string
  */
-fun ChatService.chat(
+fun ChatService.sendMessage(
     prompt: String,
     onToken: (String) -> Unit = {},
 ): String {
     val sb = StringBuilder()
     val done = CountDownLatch(1)
 
-    stream(prompt)
+    sendMessageStreaming(prompt)
         .onPartialResponse { chunk ->
             sb.append(chunk)
             onToken(chunk)

--- a/src/main/kotlin/io/askimo/core/providers/NoopChatService.kt
+++ b/src/main/kotlin/io/askimo/core/providers/NoopChatService.kt
@@ -17,7 +17,7 @@ import java.util.function.Consumer
  * that they need to configure a chat model using the ':set-provider' command.
  */
 object NoopChatService : ChatService {
-    override fun stream(prompt: String): TokenStream {
+    override fun sendMessageStreaming(prompt: String): TokenStream {
         return object : TokenStream {
             private var errorConsumer: Consumer<Throwable>? = null
 
@@ -44,5 +44,5 @@ object NoopChatService : ChatService {
         }
     }
 
-    override fun chat(prompt: String): String = throw RuntimeException("No chat model configured. Please configure a chat model using the 'set provider' command.")
+    override fun sendMessage(prompt: String): String = throw RuntimeException("No chat model configured. Please configure a chat model using the 'set provider' command.")
 }

--- a/src/main/kotlin/io/askimo/core/recipes/RecipeExecutor.kt
+++ b/src/main/kotlin/io/askimo/core/recipes/RecipeExecutor.kt
@@ -5,7 +5,7 @@
 package io.askimo.core.recipes
 
 import io.askimo.cli.LoadingIndicator
-import io.askimo.core.providers.chat
+import io.askimo.core.providers.sendMessage
 import io.askimo.core.session.Session
 import io.askimo.core.util.Logger.info
 import org.jline.terminal.Terminal
@@ -83,7 +83,7 @@ class RecipeExecutor(
         val output =
             session
                 .getChatService()
-                .chat(prompt) { _ ->
+                .sendMessage(prompt) { _ ->
                     if (firstTokenSeen.compareAndSet(false, true)) {
                         indicator?.stopWithElapsed()
                         opts.terminal?.flush()
@@ -115,14 +115,13 @@ class RecipeExecutor(
     private fun resolveArgs(
         args: Any?,
         vars: Map<String, String>,
-    ): Any? =
-        when (args) {
-            null -> null
-            is String -> MiniTpl.render(args, vars)
-            is List<*> -> args.map { if (it is String) MiniTpl.render(it, vars) else it }
-            is Map<*, *> -> args.mapValues { (_, v) -> if (v is String) MiniTpl.render(v, vars) else v }
-            else -> args
-        }
+    ): Any? = when (args) {
+        null -> null
+        is String -> MiniTpl.render(args, vars)
+        is List<*> -> args.map { if (it is String) MiniTpl.render(it, vars) else it }
+        is Map<*, *> -> args.mapValues { (_, v) -> if (v is String) MiniTpl.render(v, vars) else v }
+        else -> args
+    }
 
     private fun evalBool(expr: String): Boolean {
         val t = expr.trim()

--- a/src/main/kotlin/io/askimo/core/session/ChatSessionRepository.kt
+++ b/src/main/kotlin/io/askimo/core/session/ChatSessionRepository.kt
@@ -16,7 +16,7 @@ import javax.sql.DataSource
 
 class ChatSessionRepository {
     private val hikariDataSource: HikariDataSource by lazy {
-        val dbPath = AskimoHome.userHome().resolve("chat_sessions.db").toString()
+        val dbPath = AskimoHome.base().resolve("chat_sessions.db").toString()
 
         val config = HikariConfig().apply {
             jdbcUrl = "jdbc:sqlite:$dbPath"

--- a/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
+++ b/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
@@ -47,7 +47,7 @@ class OllamaModelFactoryTest {
         val prompt = "Reply with a single short word."
 
         val result = StringBuilder()
-        val stream = chatService.stream(prompt)
+        val stream = chatService.sendMessageStreaming(prompt)
         stream.onPartialResponse { token -> result.append(token) }
         stream.onError { error -> throw error }
         stream.start()

--- a/src/test/kotlin/io/askimo/core/session/ChatSessionRepositoryIT.kt
+++ b/src/test/kotlin/io/askimo/core/session/ChatSessionRepositoryIT.kt
@@ -1,0 +1,373 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.session
+
+import io.askimo.core.util.AskimoHome
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.LocalDateTime
+
+class ChatSessionRepositoryIT {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var repository: ChatSessionRepository
+    private lateinit var testBaseScope: AskimoHome.TestBaseScope
+
+    @BeforeEach
+    fun setUp() {
+        testBaseScope = AskimoHome.withTestBase(tempDir)
+        repository = ChatSessionRepository()
+
+        repository.getAllSessions()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        repository.close()
+        testBaseScope.close()
+    }
+
+    @Test
+    fun `should create and retrieve a chat session`() {
+        val session = repository.createSession("Test Session")
+
+        assertNotNull(session.id)
+        assertEquals("Test Session", session.title)
+        assertNotNull(session.createdAt)
+        assertNotNull(session.updatedAt)
+
+        val retrieved = repository.getSession(session.id)
+        assertNotNull(retrieved)
+        assertEquals(session.id, retrieved!!.id)
+        assertEquals(session.title, retrieved.title)
+        assertEquals(session.createdAt, retrieved.createdAt)
+        assertEquals(session.updatedAt, retrieved.updatedAt)
+    }
+
+    @Test
+    fun `should return null for non-existent session`() {
+        val result = repository.getSession("non-existent-id")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should retrieve all sessions ordered by updated_at desc`() {
+        val session1 = repository.createSession("First Session")
+        Thread.sleep(10) // Ensure different timestamps
+        val session2 = repository.createSession("Second Session")
+        Thread.sleep(10)
+        val session3 = repository.createSession("Third Session")
+
+        val sessions = repository.getAllSessions()
+
+        assertEquals(3, sessions.size)
+        assertEquals(session3.id, sessions[0].id) // Most recent first
+        assertEquals(session2.id, sessions[1].id)
+        assertEquals(session1.id, sessions[2].id)
+    }
+
+    @Test
+    fun `should add and retrieve messages for a session`() {
+        val session = repository.createSession("Test Session")
+
+        val userMessage = repository.addMessage(session.id, MessageRole.USER, "Hello, AI!")
+        val assistantMessage = repository.addMessage(session.id, MessageRole.ASSISTANT, "Hello! How can I help you?")
+
+        assertNotNull(userMessage.id)
+        assertEquals(session.id, userMessage.sessionId)
+        assertEquals(MessageRole.USER, userMessage.role)
+        assertEquals("Hello, AI!", userMessage.content)
+        assertNotNull(userMessage.createdAt)
+
+        assertNotNull(assistantMessage.id)
+        assertEquals(session.id, assistantMessage.sessionId)
+        assertEquals(MessageRole.ASSISTANT, assistantMessage.role)
+        assertEquals("Hello! How can I help you?", assistantMessage.content)
+        assertNotNull(assistantMessage.createdAt)
+
+        val messages = repository.getMessages(session.id)
+        assertEquals(2, messages.size)
+        assertEquals(userMessage.id, messages[0].id)
+        assertEquals(assistantMessage.id, messages[1].id)
+    }
+
+    @Test
+    fun `should update session updated_at when adding message`() {
+        val session = repository.createSession("Test Session")
+        val originalUpdatedAt = session.updatedAt
+
+        Thread.sleep(10)
+
+        repository.addMessage(session.id, MessageRole.USER, "Test message")
+
+        val updatedSession = repository.getSession(session.id)
+        assertNotNull(updatedSession)
+        assertTrue(updatedSession!!.updatedAt.isAfter(originalUpdatedAt))
+    }
+
+    @Test
+    fun `should retrieve recent messages in chronological order`() {
+        val session = repository.createSession("Test Session")
+        repository.addMessage(session.id, MessageRole.USER, "Message 1")
+        repository.addMessage(session.id, MessageRole.ASSISTANT, "Response 1")
+        repository.addMessage(session.id, MessageRole.USER, "Message 2")
+        repository.addMessage(session.id, MessageRole.ASSISTANT, "Response 2")
+
+        val recentMessages = repository.getRecentMessages(session.id, 3)
+
+        assertEquals(3, recentMessages.size)
+        assertEquals("Response 1", recentMessages[0].content) // Oldest of the 3
+        assertEquals("Message 2", recentMessages[1].content)
+        assertEquals("Response 2", recentMessages[2].content) // Most recent
+    }
+
+    @Test
+    fun `should count messages correctly`() {
+        val session = repository.createSession("Test Session")
+
+        assertEquals(0, repository.getMessageCount(session.id))
+
+        repository.addMessage(session.id, MessageRole.USER, "Message 1")
+        assertEquals(1, repository.getMessageCount(session.id))
+
+        repository.addMessage(session.id, MessageRole.ASSISTANT, "Response 1")
+        assertEquals(2, repository.getMessageCount(session.id))
+    }
+
+    @Test
+    fun `should retrieve messages after specific message`() {
+        val session = repository.createSession("Test Session")
+        val message1 = repository.addMessage(session.id, MessageRole.USER, "Message 1")
+        val message2 = repository.addMessage(session.id, MessageRole.ASSISTANT, "Response 1")
+        val message3 = repository.addMessage(session.id, MessageRole.USER, "Message 2")
+        val message4 = repository.addMessage(session.id, MessageRole.ASSISTANT, "Response 2")
+
+        val messagesAfter = repository.getMessagesAfter(session.id, message1.id, 10)
+
+        assertEquals(3, messagesAfter.size)
+        assertEquals(message2.id, messagesAfter[0].id)
+        assertEquals(message3.id, messagesAfter[1].id)
+        assertEquals(message4.id, messagesAfter[2].id)
+    }
+
+    @Test
+    fun `should save and retrieve conversation summary`() {
+        val session = repository.createSession("Test Session")
+        val message = repository.addMessage(session.id, MessageRole.USER, "Test message")
+
+        val summary = ConversationSummary(
+            sessionId = session.id,
+            keyFacts = mapOf("topic" to "testing", "language" to "kotlin"),
+            mainTopics = listOf("unit testing", "database"),
+            recentContext = "User is asking about testing",
+            lastSummarizedMessageId = message.id,
+            createdAt = LocalDateTime.now(),
+        )
+
+        repository.saveSummary(summary)
+
+        val retrievedSummary = repository.getConversationSummary(session.id)
+        assertNotNull(retrievedSummary)
+        assertEquals(summary.sessionId, retrievedSummary!!.sessionId)
+        assertEquals(summary.keyFacts, retrievedSummary.keyFacts)
+        assertEquals(summary.mainTopics, retrievedSummary.mainTopics)
+        assertEquals(summary.recentContext, retrievedSummary.recentContext)
+        assertEquals(summary.lastSummarizedMessageId, retrievedSummary.lastSummarizedMessageId)
+    }
+
+    @Test
+    fun `should update conversation summary when saving again`() {
+        val session = repository.createSession("Test Session")
+        val message1 = repository.addMessage(session.id, MessageRole.USER, "Test message 1")
+        val message2 = repository.addMessage(session.id, MessageRole.USER, "Test message 2")
+
+        val originalSummary = ConversationSummary(
+            sessionId = session.id,
+            keyFacts = mapOf("topic" to "testing"),
+            mainTopics = listOf("unit testing"),
+            recentContext = "Initial context",
+            lastSummarizedMessageId = message1.id,
+            createdAt = LocalDateTime.now(),
+        )
+
+        val updatedSummary = ConversationSummary(
+            sessionId = session.id,
+            keyFacts = mapOf("topic" to "testing", "language" to "kotlin"),
+            mainTopics = listOf("unit testing", "database"),
+            recentContext = "Updated context",
+            lastSummarizedMessageId = message2.id,
+            createdAt = LocalDateTime.now(),
+        )
+
+        // When
+        repository.saveSummary(originalSummary)
+        repository.saveSummary(updatedSummary)
+
+        // Then
+        val retrievedSummary = repository.getConversationSummary(session.id)
+        assertNotNull(retrievedSummary)
+        assertEquals(updatedSummary.keyFacts, retrievedSummary!!.keyFacts)
+        assertEquals(updatedSummary.mainTopics, retrievedSummary.mainTopics)
+        assertEquals(updatedSummary.recentContext, retrievedSummary.recentContext)
+        assertEquals(updatedSummary.lastSummarizedMessageId, retrievedSummary.lastSummarizedMessageId)
+    }
+
+    @Test
+    fun `should return null for non-existent conversation summary`() {
+        val result = repository.getConversationSummary("non-existent-session-id")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should generate and update session title`() {
+        val session = repository.createSession("Temporary Title")
+        val firstMessage = "What is the best way to test a Kotlin application?"
+
+        repository.generateAndUpdateTitle(session.id, firstMessage)
+
+        val updatedSession = repository.getSession(session.id)
+        assertNotNull(updatedSession)
+        assertNotEquals("Temporary Title", updatedSession!!.title)
+        assertTrue(updatedSession.title.contains("What is the best way to test"))
+    }
+
+    @Test
+    fun `should generate title with ellipsis for long messages`() {
+        val session = repository.createSession("Temporary Title")
+        val longMessage = "This is a very long message that exceeds the fifty character limit and should be truncated with ellipsis"
+
+        repository.generateAndUpdateTitle(session.id, longMessage)
+
+        val updatedSession = repository.getSession(session.id)
+        assertNotNull(updatedSession)
+        assertTrue(updatedSession!!.title.endsWith("..."))
+        assertTrue(updatedSession.title.length <= 50)
+    }
+
+    @Test
+    fun `should generate title ending with period for sentences`() {
+        val session = repository.createSession("Temporary Title")
+        val sentenceMessage = "This is a complete sentence. And this is another one."
+
+        repository.generateAndUpdateTitle(session.id, sentenceMessage)
+
+        val updatedSession = repository.getSession(session.id)
+        assertNotNull(updatedSession)
+        assertEquals("This is a complete sentence.", updatedSession!!.title)
+    }
+
+    @Test
+    fun `should handle database transactions correctly on failure`() {
+        val session = repository.createSession("Test Session")
+
+        // This test verifies that if something goes wrong during message addition,
+        // the transaction is rolled back. We can't easily simulate a database failure,
+        // but we can verify the basic transaction structure works.
+        assertDoesNotThrow {
+            repository.addMessage(session.id, MessageRole.USER, "Test message")
+        }
+
+        assertEquals(1, repository.getMessageCount(session.id))
+    }
+
+    @Test
+    fun `should create database file in correct location`() {
+        val dbFile = tempDir.resolve("chat_sessions.db")
+        assertTrue(Files.exists(dbFile))
+        assertTrue(Files.isRegularFile(dbFile))
+    }
+
+    @Test
+    fun `should handle different message roles correctly`() {
+        val session = repository.createSession("Test Session")
+
+        repository.addMessage(session.id, MessageRole.USER, "User message")
+        repository.addMessage(session.id, MessageRole.ASSISTANT, "Assistant message")
+        repository.addMessage(session.id, MessageRole.SYSTEM, "System message")
+
+        val messages = repository.getMessages(session.id)
+        assertEquals(3, messages.size)
+        assertEquals(MessageRole.USER, messages[0].role)
+        assertEquals(MessageRole.ASSISTANT, messages[1].role)
+        assertEquals(MessageRole.SYSTEM, messages[2].role)
+    }
+
+    @Test
+    fun `should handle empty sessions list`() {
+        val sessions = repository.getAllSessions()
+
+        assertTrue(sessions.isEmpty())
+    }
+
+    @Test
+    fun `should handle empty messages list`() {
+        val session = repository.createSession("Empty Session")
+
+        val messages = repository.getMessages(session.id)
+
+        assertTrue(messages.isEmpty())
+    }
+
+    @Test
+    fun `should limit recent messages correctly`() {
+        val session = repository.createSession("Test Session")
+        repeat(10) { i ->
+            repository.addMessage(session.id, MessageRole.USER, "Message $i")
+        }
+
+        val recentMessages = repository.getRecentMessages(session.id, 5)
+
+        assertEquals(5, recentMessages.size)
+        assertEquals("Message 5", recentMessages[0].content) // 5th message (0-indexed)
+        assertEquals("Message 9", recentMessages[4].content) // Most recent
+    }
+
+    @Test
+    fun `should handle conversation summary with complex data`() {
+        val session = repository.createSession("Test Session")
+        val message = repository.addMessage(session.id, MessageRole.USER, "Test message")
+
+        val complexSummary = ConversationSummary(
+            sessionId = session.id,
+            keyFacts = mapOf(
+                "user_name" to "John Doe",
+                "project_type" to "web application",
+                "tech_stack" to "Kotlin, Spring Boot, PostgreSQL",
+                "special_chars" to "!@#$%^&*(){}[]|\\:;\"'<>,.?/~`",
+            ),
+            mainTopics = listOf(
+                "software development",
+                "database design",
+                "unit testing",
+                "performance optimization",
+            ),
+            recentContext = "User is working on a complex web application with multiple microservices. They need help with database optimization and testing strategies.",
+            lastSummarizedMessageId = message.id,
+            createdAt = LocalDateTime.now(),
+        )
+
+        repository.saveSummary(complexSummary)
+
+        val retrievedSummary = repository.getConversationSummary(session.id)
+        assertNotNull(retrievedSummary)
+        assertEquals(complexSummary.keyFacts, retrievedSummary!!.keyFacts)
+        assertEquals(complexSummary.mainTopics, retrievedSummary.mainTopics)
+        assertEquals(complexSummary.recentContext, retrievedSummary.recentContext)
+    }
+}


### PR DESCRIPTION
```
refactor(chat): rename chat API to sendMessage and add chat config

- Rename `ChatService` methods `stream` / `chat` to `sendMessageStreaming` / `sendMessage`
- Update all imports, usages, and test references accordingly
- Add new `ChatConfig` with limits and environment variables
- Adjust `Session` to use new config values (base scope, updated paths)
- Add comprehensive integration tests for `ChatSessionRepository`
- Include new SPDX‑licensed test file `ChatSessionRepositoryIT.kt`

BREAKING CHANGE: The public `ChatService` API has been renamed; callers must replace
`stream`/`chat` calls with the new `sendMessageStreaming`/`sendMessage` methods.