### PR TITLE
refactor(graal): register config classes for reflection

### DIFF
--- a/src/main/kotlin/io/askimo/core/graal/AskimoFeature.kt
+++ b/src/main/kotlin/io/askimo/core/graal/AskimoFeature.kt
@@ -4,18 +4,40 @@
  */
 package io.askimo.core.graal
 
+import io.askimo.core.config.AppConfigData
+import io.askimo.core.config.ChatConfig
+import io.askimo.core.config.EmbeddingConfig
+import io.askimo.core.config.IndexingConfig
+import io.askimo.core.config.PgVectorConfig
+import io.askimo.core.config.RetryConfig
+import io.askimo.core.config.ThrottleConfig
 import io.askimo.tools.fs.LocalFsTools
 import io.askimo.tools.git.GitTools
 import org.graalvm.nativeimage.hosted.Feature
 import org.graalvm.nativeimage.hosted.RuntimeClassInitialization
 import org.graalvm.nativeimage.hosted.RuntimeReflection
 
+/**
+ * GraalVM native image feature that configures runtime reflection and class initialization
+ * for Askimo components to ensure proper functionality in compiled native executables.
+ */
 class AskimoFeature : Feature {
     override fun beforeAnalysis(access: Feature.BeforeAnalysisAccess) {
         // Register Askimo tool classes invoked via reflection by your ToolRegistry
         registerAllDeclared(LocalFsTools::class.java, GitTools::class.java)
 
-        // Handle LangChain4j internal Jackson deserializer (cannot import; use analysis access)
+        // Register configuration classes for reflection
+        registerAllDeclared(
+            AppConfigData::class.java,
+            PgVectorConfig::class.java,
+            EmbeddingConfig::class.java,
+            RetryConfig::class.java,
+            ThrottleConfig::class.java,
+            IndexingConfig::class.java,
+            ChatConfig::class.java,
+        )
+
+        // Handle LangChain4j internal Jackson deserializer (package-private, cannot import directly)
         val openAiEmbeddingDeserializer =
             access.findClassByName("dev.langchain4j.model.openai.internal.embedding.OpenAiEmbeddingDeserializer")
 

--- a/src/main/kotlin/io/askimo/core/project/ProjectStore.kt
+++ b/src/main/kotlin/io/askimo/core/project/ProjectStore.kt
@@ -135,7 +135,6 @@ object ProjectStore {
                 true
             }
 
-        // (optional) verify write succeeded
         if (!moved) error("Failed to write $path")
     }
 

--- a/src/main/kotlin/io/askimo/core/util/Git.kt
+++ b/src/main/kotlin/io/askimo/core/util/Git.kt
@@ -8,18 +8,16 @@ import java.io.File
 
 object Git {
     /** True if there are unstaged/unstashed changes. */
-    fun isDirty(root: String): Boolean =
-        runCatching {
-            val out = execOut(root, "git", "status", "--porcelain")
-            out.isNotBlank()
-        }.getOrElse { true } // if git fails, be conservative
+    fun isDirty(root: String): Boolean = runCatching {
+        val out = execOut(root, "git", "status", "--porcelain")
+        out.isNotBlank()
+    }.getOrElse { true } // if git fails, be conservative
 
     /** Short SHA of HEAD, or "nohead" on failure. */
-    fun headShort(root: String): String =
-        runCatching {
-            val out = execOut(root, "git", "rev-parse", "--short", "HEAD").trim()
-            if (out.isBlank()) "nohead" else out
-        }.getOrElse { "nohead" }
+    fun headShort(root: String): String = runCatching {
+        val out = execOut(root, "git", "rev-parse", "--short", "HEAD").trim()
+        out.ifBlank { "nohead" }
+    }.getOrElse { "nohead" }
 
     private fun execOut(
         dir: String,


### PR DESCRIPTION
- Add imports for AppConfigData, ChatConfig, EmbeddingConfig, IndexingConfig, PgVectorConfig, RetryConfig, ThrottleConfig
- Register all config classes in `AskimoFeature` for GraalVM runtime reflection
- Simplify `Git.isDirty` and `Git.headShort` with concise lambda expressions
- Minor cleanup: remove unnecessary comment in `ProjectStore`

BREAKING CHANGE: No public API changes; internal implementation updated for native image compatibility.