### PR TITLE
feat(directive): add support for chat directives

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/directive/ChatDirectiveRepositoryIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/directive/ChatDirectiveRepositoryIT.kt
@@ -1,0 +1,277 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.directive
+
+import io.askimo.core.util.AskimoHome
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.time.LocalDateTime
+
+class ChatDirectiveRepositoryIT {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var repository: ChatDirectiveRepository
+    private lateinit var testBaseScope: AskimoHome.TestBaseScope
+
+    @BeforeEach
+    fun setUp() {
+        testBaseScope = AskimoHome.withTestBase(tempDir)
+        repository = ChatDirectiveRepository()
+
+        // Initialize repository by calling list()
+        repository.list()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        repository.close()
+        testBaseScope.close()
+    }
+
+    @Test
+    fun `should save and retrieve a chat directive`() {
+        val directive = ChatDirective(
+            name = "concise-code",
+            content = "Provide concise code examples without verbose explanations.",
+            createdAt = LocalDateTime.now(),
+        )
+
+        val saved = repository.save(directive)
+
+        assertEquals(directive.id, saved.id)
+        assertEquals("concise-code", saved.name)
+        assertEquals("Provide concise code examples without verbose explanations.", saved.content)
+        assertNotNull(saved.createdAt)
+
+        val retrieved = repository.get(saved.id)
+        assertNotNull(retrieved)
+        assertEquals(directive.id, retrieved.id)
+        assertEquals(directive.name, retrieved.name)
+        assertEquals(directive.content, retrieved.content)
+    }
+
+    @Test
+    fun `should return null for non-existent directive`() {
+        val result = repository.get("non-existent")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should update existing directive on save with same id`() {
+        val original = ChatDirective(
+            name = "test-directive",
+            content = "Original content",
+        )
+        val saved = repository.save(original)
+
+        val updated = saved.copy(
+            name = "updated-name",
+            content = "Updated content",
+        )
+        repository.save(updated)
+
+        val retrieved = repository.get(saved.id)
+        assertNotNull(retrieved)
+        assertEquals("updated-name", retrieved.name)
+        assertEquals("Updated content", retrieved.content)
+    }
+
+    @Test
+    fun `should list all directives ordered by name`() {
+        repository.save(ChatDirective(name = "zebra", content = "Last alphabetically"))
+        repository.save(ChatDirective(name = "alpha", content = "First alphabetically"))
+        repository.save(ChatDirective(name = "middle", content = "Middle alphabetically"))
+
+        val directives = repository.list()
+
+        assertEquals(3, directives.size)
+        assertEquals("alpha", directives[0].name)
+        assertEquals("middle", directives[1].name)
+        assertEquals("zebra", directives[2].name)
+    }
+
+    @Test
+    fun `should update existing directive`() {
+        val directive = ChatDirective(name = "test", content = "Original content")
+        val saved = repository.save(directive)
+
+        val updated = saved.copy(name = "updated-test", content = "Updated content")
+        val result = repository.update(updated)
+
+        assertTrue(result)
+
+        val retrieved = repository.get(saved.id)
+        assertNotNull(retrieved)
+        assertEquals("updated-test", retrieved.name)
+        assertEquals("Updated content", retrieved.content)
+    }
+
+    @Test
+    fun `should return false when updating non-existent directive`() {
+        val directive = ChatDirective(name = "non-existent", content = "Some content")
+        val result = repository.update(directive)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should delete existing directive`() {
+        val saved = repository.save(ChatDirective(name = "to-delete", content = "Content"))
+
+        assertTrue(repository.exists(saved.id))
+
+        val deleted = repository.delete(saved.id)
+
+        assertTrue(deleted)
+        assertFalse(repository.exists(saved.id))
+        assertNull(repository.get(saved.id))
+    }
+
+    @Test
+    fun `should return false when deleting non-existent directive`() {
+        val deleted = repository.delete("non-existent-id")
+
+        assertFalse(deleted)
+    }
+
+    @Test
+    fun `should check if directive exists`() {
+        val directive = ChatDirective(name = "test-exists", content = "Content")
+
+        assertFalse(repository.exists(directive.id))
+
+        val saved = repository.save(directive)
+
+        assertTrue(repository.exists(saved.id))
+    }
+
+    @Test
+    fun `should get multiple directives by ids`() {
+        val saved1 = repository.save(ChatDirective(name = "directive1", content = "Content 1"))
+        val saved2 = repository.save(ChatDirective(name = "directive2", content = "Content 2"))
+        val saved3 = repository.save(ChatDirective(name = "directive3", content = "Content 3"))
+
+        val directives = repository.getByIds(listOf(saved1.id, saved3.id, "non-existent"))
+
+        assertEquals(2, directives.size)
+        assertEquals("directive1", directives[0].name)
+        assertEquals("directive3", directives[1].name)
+    }
+
+    @Test
+    fun `should return empty list when getting directives with empty ids list`() {
+        repository.save(ChatDirective(name = "directive1", content = "Content 1"))
+
+        val directives = repository.getByIds(emptyList())
+
+        assertTrue(directives.isEmpty())
+    }
+
+    @Test
+    fun `should get multiple directives by names`() {
+        repository.save(ChatDirective(name = "directive1", content = "Content 1"))
+        repository.save(ChatDirective(name = "directive2", content = "Content 2"))
+        repository.save(ChatDirective(name = "directive3", content = "Content 3"))
+
+        val directives = repository.getByNames(listOf("directive1", "directive3", "non-existent"))
+
+        assertEquals(2, directives.size)
+        assertEquals("directive1", directives[0].name)
+        assertEquals("directive3", directives[1].name)
+    }
+
+    @Test
+    fun `should return empty list when getting directives with empty names list`() {
+        repository.save(ChatDirective(name = "directive1", content = "Content 1"))
+
+        val directives = repository.getByNames(emptyList())
+
+        assertTrue(directives.isEmpty())
+    }
+
+    @Test
+    fun `should handle special characters in directive content`() {
+        val specialContent = """
+            Special characters: !@#$%^&*()
+            Unicode: émoji 🎉
+            Lists:
+                - Item 1
+                - Item 2
+            Code: `inline` and ```block```
+        """.trimIndent()
+
+        val directive = ChatDirective(name = "special-chars", content = specialContent)
+        val saved = repository.save(directive)
+
+        val retrieved = repository.get(saved.id)
+        assertNotNull(retrieved)
+        assertEquals(specialContent, retrieved.content)
+    }
+
+    @Test
+    fun `should enforce maximum name length`() {
+        val longName = "a".repeat(DIRECTIVE_NAME_MAX_LENGTH + 1)
+        val directive = ChatDirective(name = longName, content = "Content")
+
+        val exception = assertThrows<IllegalArgumentException> {
+            repository.save(directive)
+        }
+
+        assertTrue(exception.message!!.contains("cannot exceed $DIRECTIVE_NAME_MAX_LENGTH characters"))
+    }
+
+    @Test
+    fun `should enforce maximum content length`() {
+        val longContent = "a".repeat(DIRECTIVE_CONTENT_MAX_LENGTH + 1)
+        val directive = ChatDirective(name = "test", content = longContent)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            repository.save(directive)
+        }
+
+        assertTrue(exception.message!!.contains("cannot exceed $DIRECTIVE_CONTENT_MAX_LENGTH characters"))
+    }
+
+    @Test
+    fun `should allow maximum length name`() {
+        val maxName = "a".repeat(DIRECTIVE_NAME_MAX_LENGTH)
+        val directive = ChatDirective(name = maxName, content = "Content")
+
+        assertDoesNotThrow {
+            val saved = repository.save(directive)
+
+            val retrieved = repository.get(saved.id)
+            assertNotNull(retrieved)
+            assertEquals(maxName, retrieved.name)
+        }
+    }
+
+    @Test
+    fun `should allow maximum length content`() {
+        val maxContent = "a".repeat(DIRECTIVE_CONTENT_MAX_LENGTH)
+        val directive = ChatDirective(name = "test", content = maxContent)
+
+        assertDoesNotThrow {
+            val saved = repository.save(directive)
+
+            val retrieved = repository.get(saved.id)
+            assertNotNull(retrieved)
+            assertEquals(maxContent, retrieved.content)
+        }
+    }
+}

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import java.time.Instant
 import java.time.Year
 import java.time.ZoneOffset
@@ -75,9 +76,9 @@ compose.desktop {
 
         nativeDistributions {
             targetFormats(
-                org.jetbrains.compose.desktop.application.dsl.TargetFormat.Dmg,
-                org.jetbrains.compose.desktop.application.dsl.TargetFormat.Msi,
-                org.jetbrains.compose.desktop.application.dsl.TargetFormat.Deb,
+                TargetFormat.Dmg,
+                TargetFormat.Msi,
+                TargetFormat.Deb,
             )
             packageName = "Askimo"
             // Convert 0.x.y to 1.x.y for packaging (DMG requires MAJOR > 0)

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.KeyboardDoubleArrowLeft
 import androidx.compose.material.icons.filled.KeyboardDoubleArrowRight
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -601,6 +602,8 @@ fun mainContent(
                     onJumpToMessage = { messageId, timestamp ->
                         chatViewModel.jumpToMessage(messageId, timestamp)
                     },
+                    selectedDirective = chatViewModel.selectedDirective,
+                    onDirectiveSelected = { directiveId -> chatViewModel.setDirective(directiveId) },
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -677,7 +680,6 @@ private fun sessionItemWithMenu(
             colors = ComponentColors.navigationDrawerItemColors(),
         )
 
-        // Three-dot menu button with dropdown
         Box {
             IconButton(
                 onClick = { showMenu = true },
@@ -693,11 +695,11 @@ private fun sessionItemWithMenu(
                 )
             }
 
-            androidx.compose.material3.DropdownMenu(
+            ComponentColors.themedDropdownMenu(
                 expanded = showMenu,
                 onDismissRequest = { showMenu = false },
             ) {
-                androidx.compose.material3.DropdownMenuItem(
+                DropdownMenuItem(
                     text = { Text("Delete") },
                     onClick = {
                         showMenu = false
@@ -711,7 +713,6 @@ private fun sessionItemWithMenu(
                         )
                     },
                 )
-                // Future menu items can be added here
             }
         }
     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/components/ManageDirectivesDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/components/ManageDirectivesDialog.kt
@@ -1,0 +1,329 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.askimo.core.directive.ChatDirective
+import io.askimo.desktop.ui.theme.ComponentColors
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun manageDirectivesDialog(
+    directives: List<ChatDirective>,
+    onDismiss: () -> Unit,
+    onUpdate: (id: String, newName: String, newContent: String) -> Unit,
+    onDelete: (id: String) -> Unit,
+) {
+    var editingDirective by remember { mutableStateOf<String?>(null) }
+    var editName by remember { mutableStateOf("") }
+    var editContent by remember { mutableStateOf("") }
+    var editError by remember { mutableStateOf<String?>(null) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier
+                .width(700.dp)
+                .height(600.dp)
+                .padding(16.dp),
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 8.dp,
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // Title
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Manage Directives",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) {
+                        Icon(
+                            Icons.Default.Close,
+                            contentDescription = "Close",
+                        )
+                    }
+                }
+
+                HorizontalDivider()
+
+                // Directives list
+                if (directives.isEmpty()) {
+                    Text(
+                        text = "No directives available. Create one to get started!",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(directives, key = { it.id }) { directive ->
+                            Card(
+                                modifier = Modifier.fillMaxWidth(),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = ComponentColors.sidebarSurfaceColor(),
+                                ),
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp),
+                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    // Directive name and action buttons
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(
+                                            text = directive.name,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            color = MaterialTheme.colorScheme.primary,
+                                        )
+
+                                        if (editingDirective != directive.id) {
+                                            Row(
+                                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                            ) {
+                                                IconButton(
+                                                    onClick = {
+                                                        editingDirective = directive.id
+                                                        editName = directive.name
+                                                        editContent = directive.content
+                                                        editError = null
+                                                    },
+                                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                                ) {
+                                                    Icon(
+                                                        Icons.Default.Edit,
+                                                        contentDescription = "Edit",
+                                                        tint = MaterialTheme.colorScheme.primary,
+                                                    )
+                                                }
+                                                IconButton(
+                                                    onClick = { onDelete(directive.id) },
+                                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                                ) {
+                                                    Icon(
+                                                        Icons.Default.Delete,
+                                                        contentDescription = "Delete",
+                                                        tint = MaterialTheme.colorScheme.error,
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // Directive content or edit mode
+                                    if (editingDirective == directive.id) {
+                                        // Inline edit mode
+                                        Column(
+                                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                                        ) {
+                                            OutlinedTextField(
+                                                value = editName,
+                                                onValueChange = {
+                                                    editName = it
+                                                    editError = null
+                                                },
+                                                modifier = Modifier.fillMaxWidth(),
+                                                label = { Text("Name") },
+                                                placeholder = { Text("Enter directive name...") },
+                                                singleLine = true,
+                                                isError = editError != null && editName.isBlank(),
+                                                colors = ComponentColors.outlinedTextFieldColors(),
+                                            )
+                                            OutlinedTextField(
+                                                value = editContent,
+                                                onValueChange = {
+                                                    editContent = it
+                                                    editError = null
+                                                },
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .height(200.dp),
+                                                label = { Text("Content") },
+                                                placeholder = { Text("Enter directive instructions...") },
+                                                maxLines = 10,
+                                                isError = editError != null,
+                                                supportingText = editError?.let { { Text(it) } },
+                                                colors = ComponentColors.outlinedTextFieldColors(),
+                                            )
+
+                                            // Action buttons for edit mode
+                                            Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.End,
+                                                verticalAlignment = Alignment.CenterVertically,
+                                            ) {
+                                                TextButton(
+                                                    onClick = {
+                                                        editingDirective = null
+                                                        editName = ""
+                                                        editContent = ""
+                                                        editError = null
+                                                    },
+                                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                                ) {
+                                                    Icon(
+                                                        Icons.Default.Close,
+                                                        contentDescription = null,
+                                                        modifier = Modifier.size(16.dp),
+                                                    )
+                                                    Text("Cancel")
+                                                }
+
+                                                TextButton(
+                                                    onClick = {
+                                                        if (editName.isBlank()) {
+                                                            editError = "Name is required"
+                                                        } else if (editContent.isBlank()) {
+                                                            editError = "Content is required"
+                                                        } else {
+                                                            onUpdate(directive.id, editName.trim(), editContent.trim())
+                                                            editingDirective = null
+                                                            editName = ""
+                                                            editContent = ""
+                                                            editError = null
+                                                        }
+                                                    },
+                                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                                    colors = ComponentColors.primaryTextButtonColors(),
+                                                ) {
+                                                    Icon(
+                                                        Icons.Default.Check,
+                                                        contentDescription = null,
+                                                        modifier = Modifier.size(16.dp),
+                                                    )
+                                                    Text("Save")
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        // Display mode with truncated content and tooltip
+                                        val truncatedContent = if (directive.content.length > 150) {
+                                            directive.content.take(150) + "..."
+                                        } else {
+                                            directive.content
+                                        }
+
+                                        TooltipArea(
+                                            tooltip = {
+                                                Surface(
+                                                    modifier = Modifier.width(400.dp),
+                                                    shadowElevation = 4.dp,
+                                                    shape = MaterialTheme.shapes.small,
+                                                ) {
+                                                    Column(
+                                                        modifier = Modifier.padding(12.dp),
+                                                    ) {
+                                                        Text(
+                                                            text = "Full Content:",
+                                                            style = MaterialTheme.typography.labelMedium,
+                                                            color = MaterialTheme.colorScheme.primary,
+                                                        )
+                                                        Text(
+                                                            text = directive.content,
+                                                            style = MaterialTheme.typography.bodySmall,
+                                                            modifier = Modifier.padding(top = 8.dp),
+                                                        )
+                                                    }
+                                                }
+                                            },
+                                        ) {
+                                            Text(
+                                                text = truncatedContent,
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                maxLines = 3,
+                                                overflow = TextOverflow.Ellipsis,
+                                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                            )
+                                        }
+
+                                        // Created date
+                                        Text(
+                                            text = "Created: ${directive.createdAt.toLocalDate()}",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Close button at bottom
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) {
+                        Text("Close")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/components/NewDirectiveDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/components/NewDirectiveDialog.kt
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.askimo.desktop.ui.theme.ComponentColors
+
+@Composable
+fun newDirectiveDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (name: String, content: String, applyToCurrent: Boolean) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var content by remember { mutableStateOf("") }
+    var applyToCurrent by remember { mutableStateOf(false) }
+    var nameError by remember { mutableStateOf<String?>(null) }
+    var contentError by remember { mutableStateOf<String?>(null) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier
+                .width(500.dp)
+                .padding(16.dp),
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 8.dp,
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // Title
+                Text(
+                    text = "New Directive",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                // Name field
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = {
+                        name = it
+                        nameError = null
+                    },
+                    label = { Text("Name") },
+                    placeholder = { Text("e.g., concise-code, explain-like-im-5") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    isError = nameError != null,
+                    supportingText = nameError?.let { { Text(it) } },
+                    colors = ComponentColors.outlinedTextFieldColors(),
+                )
+
+                // Content field
+                OutlinedTextField(
+                    value = content,
+                    onValueChange = {
+                        content = it
+                        contentError = null
+                    },
+                    label = { Text("Content") },
+                    placeholder = { Text("Enter the directive instructions...") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(150.dp),
+                    maxLines = 8,
+                    isError = contentError != null,
+                    supportingText = contentError?.let { { Text(it) } },
+                    colors = ComponentColors.outlinedTextFieldColors(),
+                )
+
+                // Apply to current session checkbox
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Checkbox(
+                        checked = applyToCurrent,
+                        onCheckedChange = { applyToCurrent = it },
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    )
+                    Text(
+                        text = "Apply to the current chat session",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+
+                // Action buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) {
+                        Text("Cancel")
+                    }
+
+                    TextButton(
+                        onClick = {
+                            // Validate inputs
+                            var hasError = false
+
+                            if (name.isBlank()) {
+                                nameError = "Name is required"
+                                hasError = true
+                            }
+
+                            if (content.isBlank()) {
+                                contentError = "Content is required"
+                                hasError = true
+                            }
+
+                            if (!hasError) {
+                                onConfirm(name.trim(), content.trim(), applyToCurrent)
+                            }
+                        },
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        colors = ComponentColors.primaryTextButtonColors(),
+                    ) {
+                        Text("Create")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/theme/ComponentColors.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/theme/ComponentColors.kt
@@ -4,10 +4,12 @@
  */
 package io.askimo.desktop.ui.theme
 
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -18,6 +20,7 @@ import androidx.compose.material3.NavigationRailItemDefaults
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 
@@ -225,5 +228,44 @@ object ComponentColors {
             blue = surfaceColor.blue + (primaryColor.blue - surfaceColor.blue) * tintAmount,
             alpha = surfaceColor.alpha,
         )
+    }
+
+    /**
+     * Themed DropdownMenu that uses correct theme colors.
+     *
+     * DropdownMenu in Material3 uses surfaceContainer by default, which doesn't follow
+     * custom theme colors. This wrapper overrides the color scheme to use the proper
+     * surface color from the theme.
+     *
+     * Usage:
+     * ```kotlin
+     * ComponentColors.themedDropdownMenu(
+     *     expanded = expanded,
+     *     onDismissRequest = { expanded = false }
+     * ) {
+     *     DropdownMenuItem(...)
+     *     DropdownMenuItem(...)
+     * }
+     * ```
+     */
+    @Composable
+    fun themedDropdownMenu(
+        expanded: Boolean,
+        onDismissRequest: () -> Unit,
+        modifier: Modifier = Modifier,
+        content: @Composable ColumnScope.() -> Unit,
+    ) {
+        MaterialTheme(
+            colorScheme = MaterialTheme.colorScheme.copy(
+                surfaceContainer = MaterialTheme.colorScheme.surface,
+            ),
+        ) {
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = onDismissRequest,
+                modifier = modifier,
+                content = content,
+            )
+        }
     }
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/views/SessionsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/views/SessionsView.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -240,7 +239,7 @@ private fun sessionCard(
                     )
                 }
 
-                DropdownMenu(
+                ComponentColors.themedDropdownMenu(
                     expanded = showMenu,
                     onDismissRequest = { showMenu = false },
                 ) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/views/SettingsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/views/SettingsView.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -464,7 +463,7 @@ private fun fontSettingsCard() {
                         }
                     }
 
-                    DropdownMenu(
+                    ComponentColors.themedDropdownMenu(
                         expanded = fontDropdownExpanded,
                         onDismissRequest = { fontDropdownExpanded = false },
                         modifier = Modifier.fillMaxWidth(0.5f),
@@ -555,7 +554,7 @@ private fun fontSettingsCard() {
                         }
                     }
 
-                    DropdownMenu(
+                    ComponentColors.themedDropdownMenu(
                         expanded = fontSizeDropdownExpanded,
                         onDismissRequest = { fontSizeDropdownExpanded = false },
                     ) {
@@ -914,7 +913,7 @@ private fun enumFieldSetting(
                 }
             }
 
-            DropdownMenu(
+            ComponentColors.themedDropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
             ) {
@@ -1006,7 +1005,7 @@ private fun providerSelectionDialog(
                             colors = ComponentColors.outlinedTextFieldColors(),
                         )
 
-                        DropdownMenu(
+                        ComponentColors.themedDropdownMenu(
                             expanded = providerDropdownExpanded,
                             onDismissRequest = { providerDropdownExpanded = false },
                         ) {

--- a/shared/src/main/kotlin/io/askimo/core/directive/ChatDirective.kt
+++ b/shared/src/main/kotlin/io/askimo/core/directive/ChatDirective.kt
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.directive
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Represents a custom instruction/directive that users can apply to chat sessions
+ * to influence AI behavior (tone, format, style, etc.)
+ */
+data class ChatDirective(
+    val id: String = UUID.randomUUID().toString(), // unique identifier
+    val name: String, // user-friendly name (e.g., "Concise Code", "Explain Like I'm 5")
+    val content: String, // raw directive text provided by user
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/shared/src/main/kotlin/io/askimo/core/directive/ChatDirectiveRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/directive/ChatDirectiveRepository.kt
@@ -1,0 +1,400 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.directive
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.askimo.core.util.AskimoHome
+import java.sql.Connection
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.sql.DataSource
+
+const val DIRECTIVE_NAME_MAX_LENGTH = 128
+const val DIRECTIVE_CONTENT_MAX_LENGTH = 8192
+
+/**
+ * Repository for managing chat directives stored in SQLite database.
+ */
+class ChatDirectiveRepository {
+    private val hikariDataSource: HikariDataSource by lazy {
+        val dbPath = AskimoHome.base().resolve("chat_directives.db").toString()
+
+        val config = HikariConfig().apply {
+            jdbcUrl = "jdbc:sqlite:$dbPath"
+            driverClassName = "org.sqlite.JDBC"
+            maximumPoolSize = 10
+            minimumIdle = 2
+            connectionTimeout = 30000
+            idleTimeout = 600000
+            maxLifetime = 1800000
+            // SQLite specific optimizations
+            addDataSourceProperty("cachePrepStmts", "true")
+            addDataSourceProperty("prepStmtCacheSize", "250")
+            addDataSourceProperty("prepStmtCacheSqlLimit", "2048")
+        }
+
+        HikariDataSource(config).also { ds ->
+            // Initialize database schema
+            ds.connection.use { conn ->
+                initializeDatabase(conn)
+            }
+        }
+    }
+
+    private val dataSource: DataSource get() = hikariDataSource
+
+    private fun initializeDatabase(conn: Connection) {
+        conn.createStatement().use { stmt ->
+            // Check if old table exists
+            val oldTableExists = conn.metaData.getTables(null, null, "chat_directives", null).use { rs ->
+                rs.next()
+            }
+
+            if (oldTableExists) {
+                // Check if table has id column
+                val hasIdColumn = conn.metaData.getColumns(null, null, "chat_directives", "id").use { rs ->
+                    rs.next()
+                }
+
+                if (!hasIdColumn) {
+                    // Migrate old table to new schema
+                    migrateToNewSchema(conn)
+                }
+            } else {
+                // Create new table with id as primary key
+                stmt.executeUpdate(
+                    """
+                    CREATE TABLE IF NOT EXISTS chat_directives (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL UNIQUE,
+                        content TEXT NOT NULL,
+                        created_at TEXT NOT NULL
+                    )
+                """,
+                )
+            }
+        }
+    }
+
+    private fun migrateToNewSchema(conn: Connection) {
+        conn.createStatement().use { stmt ->
+            // Create new table with id column
+            stmt.executeUpdate(
+                """
+                CREATE TABLE chat_directives_new (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    content TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+            """,
+            )
+
+            // Migrate data from old table to new table, generating UUIDs
+            stmt.executeUpdate(
+                """
+                INSERT INTO chat_directives_new (id, name, content, created_at)
+                SELECT
+                    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' ||
+                          substr(hex(randomblob(2)), 2) || '-' ||
+                          substr('89ab', abs(random()) % 4 + 1, 1) ||
+                          substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))) as id,
+                    name,
+                    content,
+                    created_at
+                FROM chat_directives
+            """,
+            )
+
+            // Drop old table
+            stmt.executeUpdate("DROP TABLE chat_directives")
+
+            // Rename new table
+            stmt.executeUpdate("ALTER TABLE chat_directives_new RENAME TO chat_directives")
+        }
+    }
+
+    /**
+     * Save a new directive or update existing one.
+     * @throws IllegalArgumentException if name or content exceed max length
+     */
+    fun save(directive: ChatDirective): ChatDirective {
+        require(directive.name.length <= DIRECTIVE_NAME_MAX_LENGTH) {
+            "Directive name cannot exceed $DIRECTIVE_NAME_MAX_LENGTH characters"
+        }
+        require(directive.content.length <= DIRECTIVE_CONTENT_MAX_LENGTH) {
+            "Directive content cannot exceed $DIRECTIVE_CONTENT_MAX_LENGTH characters"
+        }
+
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO chat_directives (id, name, content, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name = excluded.name,
+                    content = excluded.content
+            """,
+            ).use { stmt ->
+                stmt.setString(1, directive.id)
+                stmt.setString(2, directive.name)
+                stmt.setString(3, directive.content)
+                stmt.setString(4, directive.createdAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                stmt.executeUpdate()
+            }
+        }
+
+        return directive
+    }
+
+    /**
+     * Get a directive by id.
+     */
+    fun get(id: String): ChatDirective? {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                SELECT id, name, content, created_at
+                FROM chat_directives
+                WHERE id = ?
+            """,
+            ).use { stmt ->
+                stmt.setString(1, id)
+                val rs = stmt.executeQuery()
+                return if (rs.next()) {
+                    ChatDirective(
+                        id = rs.getString("id"),
+                        name = rs.getString("name"),
+                        content = rs.getString("content"),
+                        createdAt = LocalDateTime.parse(rs.getString("created_at")),
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+    }
+
+    /**
+     * Get a directive by name.
+     */
+    fun getByName(name: String): ChatDirective? {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                SELECT id, name, content, created_at
+                FROM chat_directives
+                WHERE name = ?
+            """,
+            ).use { stmt ->
+                stmt.setString(1, name)
+                val rs = stmt.executeQuery()
+                return if (rs.next()) {
+                    ChatDirective(
+                        id = rs.getString("id"),
+                        name = rs.getString("name"),
+                        content = rs.getString("content"),
+                        createdAt = LocalDateTime.parse(rs.getString("created_at")),
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+    }
+
+    /**
+     * List all directives, ordered by name.
+     */
+    fun list(): List<ChatDirective> {
+        val directives = mutableListOf<ChatDirective>()
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery(
+                    """
+                    SELECT id, name, content, created_at
+                    FROM chat_directives
+                    ORDER BY name ASC
+                """,
+                )
+                while (rs.next()) {
+                    directives.add(
+                        ChatDirective(
+                            id = rs.getString("id"),
+                            name = rs.getString("name"),
+                            content = rs.getString("content"),
+                            createdAt = LocalDateTime.parse(rs.getString("created_at")),
+                        ),
+                    )
+                }
+            }
+        }
+        return directives
+    }
+
+    /**
+     * Update an existing directive.
+     * @return true if updated, false if directive doesn't exist
+     */
+    fun update(directive: ChatDirective): Boolean {
+        require(directive.name.length <= DIRECTIVE_NAME_MAX_LENGTH) {
+            "Directive name cannot exceed $DIRECTIVE_NAME_MAX_LENGTH characters"
+        }
+        require(directive.content.length <= DIRECTIVE_CONTENT_MAX_LENGTH) {
+            "Directive content cannot exceed $DIRECTIVE_CONTENT_MAX_LENGTH characters"
+        }
+
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                UPDATE chat_directives
+                SET name = ?, content = ?
+                WHERE id = ?
+            """,
+            ).use { stmt ->
+                stmt.setString(1, directive.name)
+                stmt.setString(2, directive.content)
+                stmt.setString(3, directive.id)
+                val rowsAffected = stmt.executeUpdate()
+                return rowsAffected > 0
+            }
+        }
+    }
+
+    /**
+     * Delete a directive by id.
+     * @return true if deleted, false if directive doesn't exist
+     */
+    fun delete(id: String): Boolean {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                DELETE FROM chat_directives WHERE id = ?
+            """,
+            ).use { stmt ->
+                stmt.setString(1, id)
+                val rowsAffected = stmt.executeUpdate()
+                return rowsAffected > 0
+            }
+        }
+    }
+
+    /**
+     * Check if a directive exists by id.
+     */
+    fun exists(id: String): Boolean {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                SELECT 1 FROM chat_directives WHERE id = ? LIMIT 1
+            """,
+            ).use { stmt ->
+                stmt.setString(1, id)
+                val rs = stmt.executeQuery()
+                return rs.next()
+            }
+        }
+    }
+
+    /**
+     * Check if a directive exists by name.
+     */
+    fun existsByName(name: String): Boolean {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                """
+                SELECT 1 FROM chat_directives WHERE name = ? LIMIT 1
+            """,
+            ).use { stmt ->
+                stmt.setString(1, name)
+                val rs = stmt.executeQuery()
+                return rs.next()
+            }
+        }
+    }
+
+    /**
+     * Get multiple directives by ids.
+     */
+    fun getByIds(ids: List<String>): List<ChatDirective> {
+        if (ids.isEmpty()) return emptyList()
+
+        val directives = mutableListOf<ChatDirective>()
+        dataSource.connection.use { conn ->
+            val placeholders = ids.joinToString(",") { "?" }
+            conn.prepareStatement(
+                """
+                SELECT id, name, content, created_at
+                FROM chat_directives
+                WHERE id IN ($placeholders)
+                ORDER BY name ASC
+            """,
+            ).use { stmt ->
+                ids.forEachIndexed { index, id ->
+                    stmt.setString(index + 1, id)
+                }
+                val rs = stmt.executeQuery()
+                while (rs.next()) {
+                    directives.add(
+                        ChatDirective(
+                            id = rs.getString("id"),
+                            name = rs.getString("name"),
+                            content = rs.getString("content"),
+                            createdAt = LocalDateTime.parse(rs.getString("created_at")),
+                        ),
+                    )
+                }
+            }
+        }
+        return directives
+    }
+
+    /**
+     * Get multiple directives by names.
+     */
+    fun getByNames(names: List<String>): List<ChatDirective> {
+        if (names.isEmpty()) return emptyList()
+
+        val directives = mutableListOf<ChatDirective>()
+        dataSource.connection.use { conn ->
+            val placeholders = names.joinToString(",") { "?" }
+            conn.prepareStatement(
+                """
+                SELECT id, name, content, created_at
+                FROM chat_directives
+                WHERE name IN ($placeholders)
+                ORDER BY name ASC
+            """,
+            ).use { stmt ->
+                names.forEachIndexed { index, name ->
+                    stmt.setString(index + 1, name)
+                }
+                val rs = stmt.executeQuery()
+                while (rs.next()) {
+                    directives.add(
+                        ChatDirective(
+                            id = rs.getString("id"),
+                            name = rs.getString("name"),
+                            content = rs.getString("content"),
+                            createdAt = LocalDateTime.parse(rs.getString("created_at")),
+                        ),
+                    )
+                }
+            }
+        }
+        return directives
+    }
+
+    /**
+     * Close the data source and release resources.
+     * Should be called when shutting down the application.
+     */
+    fun close() {
+        if (!hikariDataSource.isClosed) {
+            hikariDataSource.close()
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/directive/ChatDirectiveService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/directive/ChatDirectiveService.kt
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.directive
+
+/**
+ * Service for managing chat directives and building system prompts for chat sessions.
+ */
+class ChatDirectiveService(
+    private val repository: ChatDirectiveRepository,
+) {
+    /**
+     * Build a system prompt by combining selected directives.
+     * @param directiveIds List of directive IDs to include
+     * @return Combined system prompt text
+     */
+    fun buildSystemPrompt(
+        directiveIds: List<String> = emptyList(),
+    ): String {
+        val selected = if (directiveIds.isNotEmpty()) {
+            repository.getByIds(directiveIds)
+        } else {
+            emptyList()
+        }
+
+        if (selected.isEmpty()) {
+            return "You are a helpful AI assistant."
+        }
+
+        return buildString {
+            appendLine("You are a helpful AI assistant. Follow these session directives:")
+            appendLine()
+            selected.forEach { directive ->
+                appendLine("## ${directive.name}")
+                appendLine(directive.content.trim())
+                appendLine()
+            }
+            appendLine("---")
+            appendLine("Apply the above directives consistently throughout this conversation.")
+        }.trim()
+    }
+
+    /**
+     * Create a new directive.
+     */
+    fun createDirective(
+        name: String,
+        content: String,
+    ): ChatDirective {
+        val directive = ChatDirective(
+            name = name,
+            content = content,
+        )
+        return repository.save(directive)
+    }
+
+    /**
+     * Update an existing directive.
+     * @return true if updated successfully
+     */
+    fun updateDirective(
+        id: String,
+        name: String,
+        content: String,
+    ): Boolean {
+        val existing = repository.get(id) ?: return false
+        val directive = existing.copy(
+            name = name,
+            content = content,
+        )
+        return repository.update(directive)
+    }
+
+    /**
+     * Delete a directive.
+     * @return true if deleted successfully
+     */
+    fun deleteDirective(id: String): Boolean = repository.delete(id)
+
+    /**
+     * Get a directive by id.
+     */
+    fun getDirective(id: String): ChatDirective? = repository.get(id)
+
+    /**
+     * Get a directive by name.
+     */
+    fun getDirectiveByName(name: String): ChatDirective? = repository.getByName(name)
+
+    /**
+     * List all directives.
+     */
+    fun listAllDirectives(): List<ChatDirective> = repository.list()
+
+    /**
+     * Check if a directive exists by id.
+     */
+    fun directiveExists(id: String): Boolean = repository.exists(id)
+
+    /**
+     * Check if a directive exists by name.
+     */
+    fun directiveExistsByName(name: String): Boolean = repository.existsByName(name)
+}

--- a/shared/src/main/kotlin/io/askimo/core/directive/README.md
+++ b/shared/src/main/kotlin/io/askimo/core/directive/README.md
@@ -1,0 +1,125 @@
+# Chat Directives
+
+Chat Directives allow users to define custom instructions for AI behavior in chat sessions. Users can specify tone, format, style, and other behavioral guidelines that will be consistently applied throughout a conversation.
+
+## Domain Model
+
+### ChatDirective
+```kotlin
+data class ChatDirective(
+    val name: String,              // Unique identifier (e.g., "concise-code", "explain-like-im-5")
+    val content: String,           // The actual directive text
+    val isDefault: Boolean = false, // Auto-apply to new sessions
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)
+```
+
+## Repository Operations
+
+The `ChatDirectiveRepository` provides the following operations:
+
+### Basic CRUD
+- `save(directive: ChatDirective): ChatDirective` - Create or update a directive
+- `get(name: String): ChatDirective?` - Get a directive by name
+- `update(directive: ChatDirective): Boolean` - Update existing directive
+- `delete(name: String): Boolean` - Delete a directive
+- `exists(name: String): Boolean` - Check if directive exists
+
+### Listing
+- `list(): List<ChatDirective>` - Get all directives
+- `listDefaults(): List<ChatDirective>` - Get only default directives
+- `getByNames(names: List<String>): List<ChatDirective>` - Get multiple by names
+
+## Service Layer
+
+The `ChatDirectiveService` provides higher-level operations:
+
+### Build System Prompt
+```kotlin
+val service = ChatDirectiveService(repository)
+
+// Build prompt with specific directives
+val prompt = service.buildSystemPrompt(
+    directiveNames = listOf("concise-code", "markdown-format"),
+    includeDefaults = true
+)
+```
+
+### Manage Directives
+```kotlin
+// Create
+service.createDirective(
+    name = "concise-code",
+    content = "Always provide concise code examples without verbose explanations.",
+    isDefault = false
+)
+
+// Update
+service.updateDirective(
+    name = "concise-code",
+    content = "Provide minimal, concise code with brief inline comments.",
+    isDefault = true
+)
+
+// Delete
+service.deleteDirective("concise-code")
+
+// Query
+val directive = service.getDirective("concise-code")
+val all = service.listAllDirectives()
+val defaults = service.listDefaultDirectives()
+```
+
+## Storage
+
+Directives are stored in a SQLite database at `~/.askimo/chat_directives.db` with the following schema:
+
+```sql
+CREATE TABLE chat_directives (
+    name TEXT PRIMARY KEY,
+    content TEXT NOT NULL,
+    is_default INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL
+)
+```
+
+## Usage Example
+
+```kotlin
+// Initialize
+val repository = ChatDirectiveRepository()
+val service = ChatDirectiveService(repository)
+
+// Create some directives
+service.createDirective(
+    name = "explain-like-im-5",
+    content = "Explain concepts in very simple terms, as if talking to a 5-year-old.",
+    isDefault = false
+)
+
+service.createDirective(
+    name = "markdown-format",
+    content = "Format all responses using proper Markdown syntax with headers, lists, and code blocks.",
+    isDefault = true
+)
+
+// Start a chat session with specific directives
+val systemPrompt = service.buildSystemPrompt(
+    directiveNames = listOf("explain-like-im-5", "markdown-format"),
+    includeDefaults = true
+)
+
+// Use systemPrompt as the first system message in your chat
+```
+
+## Integration with Chat Sessions
+
+When starting a new chat session, you can:
+
+1. Get default directives automatically
+2. Allow user to select additional directives
+3. Build the system prompt using selected directives
+4. Prepend the system prompt to the chat context
+
+This ensures consistent AI behavior throughout the entire conversation.
+

--- a/shared/src/main/kotlin/io/askimo/core/session/ChatSession.kt
+++ b/shared/src/main/kotlin/io/askimo/core/session/ChatSession.kt
@@ -11,6 +11,7 @@ data class ChatSession(
     val title: String,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
+    val directiveId: String? = null,
 )
 
 data class ChatMessage(

--- a/shared/src/main/kotlin/io/askimo/core/util/AskimoHome.kt
+++ b/shared/src/main/kotlin/io/askimo/core/util/AskimoHome.kt
@@ -55,8 +55,6 @@ object AskimoHome {
 
     fun projectsDir(): Path = base().resolve("projects")
 
-    fun historyFile(): Path = base().resolve("history")
-
     fun sessionFile(): Path = base().resolve("session")
 
     fun encryptionKeyFile(): Path = base().resolve(".key")


### PR DESCRIPTION
Add a new feature that lets users create, store, and apply directives to chat sessions.
Key changes:

- **Core** – introduce `ChatDirective`, `ChatDirectiveRepository`, and `ChatDirectiveService` with full CRUD support and documentation.
- **UI** – new `ManageDirectivesDialog` and `NewDirectiveDialog` components for listing, editing, and creating directives.
- **ViewModel** – add `selectedDirective` state and expose `getSelectedDirectiveName()` for UI binding.
- **Session** – extend `ChatSession` with an optional `directiveId` field and update `ChatSessionRepository` to persist it.
- **Session logic** – when starting a new session include the chosen directive content in the system prompt.
- **Theme** – add `ComponentColors.themedDropdownMenu` helper and replace hard‑coded dropdowns across the app.
- **Build** – adjust Compose Desktop imports and target formats.
- **Tests** – add integration tests for the directive repository.

No breaking changes were introduced; the new API is fully backward‑compatible.