### PR TITLE
feat: refine about layout and session sidebar behavior

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/model/View.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/model/View.kt
@@ -9,5 +9,4 @@ enum class View {
     NEW_CHAT,
     SESSIONS,
     SETTINGS,
-    ABOUT,
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/theme/ComponentColors.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/theme/ComponentColors.kt
@@ -81,9 +81,11 @@ object ComponentColors {
         selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
         selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
         selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedBadgeColor = MaterialTheme.colorScheme.onPrimaryContainer,
         unselectedContainerColor = Color.Transparent,
         unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
         unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        unselectedBadgeColor = MaterialTheme.colorScheme.onSurfaceVariant,
     )
 
     /**

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/views/AboutView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/views/AboutView.kt
@@ -6,106 +6,144 @@ package io.askimo.desktop.ui.views
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import io.askimo.core.VersionInfo
 import io.askimo.desktop.ui.theme.ComponentColors
 import java.time.Year
 
 @Composable
-fun aboutView(modifier: Modifier = Modifier) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text(
-            text = "About",
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onBackground,
-        )
-        HorizontalDivider()
-
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = ComponentColors.bannerCardColors(),
-        ) {
+fun aboutDialog(
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = "About ${VersionInfo.name}",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        },
+        text = {
             Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .widthIn(max = 500.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                Text(
-                    text = VersionInfo.name,
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    text = "Version ${VersionInfo.version}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    text = "Build Date: ${VersionInfo.buildDate}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
-        }
+                // Version Info
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ComponentColors.bannerCardColors(),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = VersionInfo.name,
+                            style = MaterialTheme.typography.titleLarge,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Text(
+                            text = "Version ${VersionInfo.version}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Text(
+                            text = "Build Date: ${VersionInfo.buildDate}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        TextButton(
+                            onClick = {
+                                try {
+                                    java.awt.Desktop.getDesktop().browse(java.net.URI("https://askimo.chat"))
+                                } catch (e: Exception) {
+                                    // Silently fail if browser cannot be opened
+                                }
+                            },
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Text(
+                                text = "https://askimo.chat",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = ComponentColors.bannerCardColors(),
-        ) {
-            Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = "Description",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    text = "A modern desktop application for AI-powered conversations built with Kotlin and Compose Multiplatform.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
-        }
+                // Description
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ComponentColors.bannerCardColors(),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = "Description",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Text(
+                            text = "A modern desktop application for AI-powered conversations built with Kotlin and Compose Multiplatform.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                }
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = ComponentColors.bannerCardColors(),
-        ) {
-            Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = "License",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    text = VersionInfo.license,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    text = "Copyright (c) ${Year.now().value} ${VersionInfo.author}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
+                // License
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ComponentColors.bannerCardColors(),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = "License",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Text(
+                            text = VersionInfo.license,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                        Text(
+                            text = "Copyright (c) ${Year.now().value} ${VersionInfo.author}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                }
             }
-        }
-    }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onDismiss,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) {
+                Text("Close")
+            }
+        },
+    )
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionsViewModel.kt
@@ -21,6 +21,10 @@ class SessionsViewModel(
     private val scope: CoroutineScope,
     private val sessionService: ChatSessionService = ChatSessionService(),
 ) {
+    companion object {
+        const val MAX_SIDEBAR_SESSIONS = 50
+    }
+
     var pagedSessions by mutableStateOf<PagedSessions?>(null)
         private set
 
@@ -44,13 +48,13 @@ class SessionsViewModel(
     }
 
     /**
-     * Load recent sessions for sidebar display (max 10).
+     * Load recent sessions for sidebar display (max defined by MAX_SIDEBAR_SESSIONS).
      */
     fun loadRecentSessions() {
         scope.launch {
             try {
                 val result = withContext(Dispatchers.IO) {
-                    sessionService.getAllSessionsSorted().take(10)
+                    sessionService.getAllSessionsSorted().take(MAX_SIDEBAR_SESSIONS)
                 }
                 recentSessions = result
                 totalSessionCount = withContext(Dispatchers.IO) {


### PR DESCRIPTION
- Replace in-content about view with dialog-style presentation
- Remove obsolete ABOUT route from view model enum
- Add badge color variants for selected and unselected states
- Cap sidebar sessions using MAX_SIDEBAR_SESSIONS constant
- Tweak top bar layout to right-align settings affordances