### PR TITLE
feat(session): add rename chat session feature

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionsViewModel.kt
@@ -165,4 +165,25 @@ class SessionsViewModel(
             }
         }
     }
+
+    /**
+     * Rename a session's title and refresh the list.
+     */
+    fun renameSession(sessionId: String, newTitle: String) {
+        scope.launch {
+            try {
+                val updated = withContext(Dispatchers.IO) {
+                    sessionService.renameTitle(sessionId, newTitle)
+                }
+                if (updated) {
+                    // Refresh the current page
+                    refresh()
+                } else {
+                    errorMessage = "Failed to rename session"
+                }
+            } catch (e: Exception) {
+                errorMessage = "Error renaming session: ${e.message}"
+            }
+        }
+    }
 }

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -34,6 +34,8 @@ session.all=All Sessions
 session.delete.confirm=Are you sure you want to delete this session?
 session.export=Export
 session.export.tooltip=Export entire chat history
+session.rename.title=Rename Title
+session.rename.title.tooltip=Rename the session title
 session.delete.tooltip=Delete chat session (cannot be undone)
 
 # Settings

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -34,6 +34,8 @@ session.all=すべてのセッション
 session.delete.confirm=このセッションを削除してもよろしいですか？
 session.export=エクスポート
 session.export.tooltip=チャット履歴全体をエクスポート
+session.rename.title=タイトルを変更
+session.rename.title.tooltip=セッションのタイトルを変更
 session.delete.tooltip=チャットセッションを削除（元に戻せません）
 
 # Settings

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -34,6 +34,8 @@ session.all=Tất cả phiên
 session.delete.confirm=Bạn có chắc chắn muốn xóa phiên này không?
 session.export=Xuất
 session.export.tooltip=Xuất toàn bộ lịch sử trò chuyện
+session.rename.title=Đổi tên tiêu đề
+session.rename.title.tooltip=Đổi tên tiêu đề phiên
 session.delete.tooltip=Xóa phiên trò chuyện (không thể hoàn tác)
 
 # Settings

--- a/shared/src/main/kotlin/io/askimo/core/session/ChatSessionRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/session/ChatSessionRepository.kt
@@ -711,6 +711,30 @@ class ChatSessionRepository {
     }
 
     /**
+     * Update the title of a session
+     */
+    fun updateSessionTitle(sessionId: String, title: String): Boolean {
+        val trimmedTitle = title.trim().take(SESSION_TITLE_MAX_LENGTH)
+        if (trimmedTitle.isEmpty()) {
+            return false
+        }
+
+        dataSource.connection.use { conn ->
+            val rowsAffected = conn.prepareStatement(
+                """
+                UPDATE chat_sessions SET title = ?, updated_at = ? WHERE id = ?
+            """,
+            ).use { stmt ->
+                stmt.setString(1, trimmedTitle)
+                stmt.setString(2, LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                stmt.setString(3, sessionId)
+                stmt.executeUpdate()
+            }
+            return rowsAffected > 0
+        }
+    }
+
+    /**
      * Get all sessions in a folder
      */
     fun getSessionsByFolder(folderId: String?): List<ChatSession> {

--- a/shared/src/main/kotlin/io/askimo/core/session/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/session/ChatSessionService.kt
@@ -101,6 +101,15 @@ class ChatSessionService(
     fun updateSessionStarred(sessionId: String, isStarred: Boolean): Boolean = repository.updateSessionStarred(sessionId, isStarred)
 
     /**
+     * Rename the title of a chat session.
+     *
+     * @param sessionId The ID of the session to rename
+     * @param newTitle The new title for the session
+     * @return true if the session was renamed, false if it didn't exist or the title is invalid
+     */
+    fun renameTitle(sessionId: String, newTitle: String): Boolean = repository.updateSessionTitle(sessionId, newTitle)
+
+    /**
      * Resume a chat session by ID and return the result with messages.
      *
      * @param session The current Session instance to resume into


### PR DESCRIPTION
- Add `renameSession` method to `SessionsViewModel` and UI controls (edit icon, text field)
- Implement `updateSessionTitle` in `ChatSessionRepository` with title trimming and timestamp update
- Expose `renameTitle` in `ChatSessionService` as a public API
- Add `isValidTitle` helper for safe title characters
- Write integration test `should update session title` to verify persistence and timestamp change
- Update i18n resource files (messages.properties, messages_ja_JP.properties, messages_vi_VN.properties) with `session.rename.title` and tooltip keys
- Add new toolbar button and dialog for renaming sessions
- Minor refactor of imports and formatting across desktop modules