### PR TITLE
feature(message): add edit message support

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/model/ChatMessage.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/model/ChatMessage.kt
@@ -12,6 +12,8 @@ data class ChatMessage(
     val attachments: List<FileAttachment> = emptyList(),
     val id: String? = null,
     val timestamp: LocalDateTime? = null,
+    val isOutdated: Boolean = false,
+    val editParentId: String? = null, // ID of the message that was edited to create this branch
 )
 
 data class FileAttachment(

--- a/desktop/src/main/kotlin/io/askimo/desktop/service/ChatService.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/service/ChatService.kt
@@ -7,6 +7,8 @@ package io.askimo.desktop.service
 import io.askimo.core.session.Session
 import io.askimo.core.session.SessionFactory
 import io.askimo.core.session.SessionMode
+import java.util.Locale
+import java.util.Properties
 
 /**
  * Service for managing chat interactions in the desktop application.
@@ -49,7 +51,7 @@ class ChatService {
             userMessage = userMessage,
             onChunkReceived = { _ ->
                 // Callback not used - UI subscribes directly to StreamingService
-            }
+            },
         )
     }
 
@@ -74,7 +76,7 @@ class ChatService {
      *
      * @param locale The user's selected locale (e.g., Locale.JAPANESE, Locale.ENGLISH)
      */
-    fun setLanguageDirective(locale: java.util.Locale) {
+    fun setLanguageDirective(locale: Locale) {
         val languageDirective = buildLanguageDirective(locale)
 
         // Replace any existing language directive with the new one
@@ -89,7 +91,7 @@ class ChatService {
      * @param locale The target locale
      * @return A complete language directive with fallback instructions
      */
-    private fun buildLanguageDirective(locale: java.util.Locale): String {
+    private fun buildLanguageDirective(locale: Locale): String {
         val languageCode = locale.language
 
         // Load the properties file for the target locale directly
@@ -135,8 +137,8 @@ class ChatService {
      * Load properties file for a specific locale.
      * Handles both language_country (ja_JP) and language-only (ja) formats.
      */
-    private fun loadPropertiesForLocale(locale: java.util.Locale): java.util.Properties {
-        val properties = java.util.Properties()
+    private fun loadPropertiesForLocale(locale: Locale): Properties {
+        val properties = Properties()
 
         val language = locale.language
         val country = locale.country

--- a/desktop/src/main/kotlin/io/askimo/desktop/service/StreamingService.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/service/StreamingService.kt
@@ -63,8 +63,8 @@ class StreamingService(
      * Thread closes automatically after completion or failure.
      */
     data class StreamingThread(
-        val threadId: String,        // Unique thread ID for this Q&A
-        val chatId: String,          // Which chat this belongs to
+        val threadId: String, // Unique thread ID for this Q&A
+        val chatId: String, // Which chat this belongs to
         val job: Job,
         private val _chunks: MutableStateFlow<List<String>>,
         private val _isComplete: MutableStateFlow<Boolean>,
@@ -169,7 +169,6 @@ class StreamingService(
                 // Save to database - use the specific chat ID
                 session.saveAiResponseToSession(fullResponse, chatId)
                 session.lastResponse = fullResponse
-
             } catch (e: Exception) {
                 // Mark as failed
                 thread.markFailed()
@@ -240,9 +239,7 @@ class StreamingService(
      * @param chatId The chat ID
      * @return The last completed threadId, or null if no completed thread
      */
-    fun getLastCompletedThreadId(chatId: String): String? {
-        return completedThreads[chatId]
-    }
+    fun getLastCompletedThreadId(chatId: String): String? = completedThreads[chatId]
 
     /**
      * Stop an active thread (user clicked stop button).
@@ -281,4 +278,3 @@ class StreamingService(
         chatToThreadMap.clear()
     }
 }
-

--- a/desktop/src/main/kotlin/io/askimo/desktop/ui/components/OutdatedMessageComponents.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/ui/components/OutdatedMessageComponents.kt
@@ -1,0 +1,192 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.dp
+import io.askimo.desktop.i18n.stringResource
+import io.askimo.desktop.model.ChatMessage
+
+/**
+ * Sealed class to represent different types of message groups
+ */
+sealed class MessageGroup {
+    data class ActiveMessage(val message: ChatMessage) : MessageGroup()
+    data class OutdatedBranch(val messages: List<ChatMessage>) : MessageGroup()
+}
+
+/**
+ * Group messages into active and outdated branches for display
+ */
+fun groupMessagesWithOutdatedBranches(messages: List<ChatMessage>): List<MessageGroup> {
+    val groups = mutableListOf<MessageGroup>()
+    val outdatedBuffer = mutableListOf<ChatMessage>()
+
+    messages.forEach { message ->
+        if (message.isOutdated) {
+            outdatedBuffer.add(message)
+        } else {
+            // If we have outdated messages buffered, create an outdated group
+            if (outdatedBuffer.isNotEmpty()) {
+                groups.add(MessageGroup.OutdatedBranch(outdatedBuffer.toList()))
+                outdatedBuffer.clear()
+            }
+            // Add active message
+            groups.add(MessageGroup.ActiveMessage(message))
+        }
+    }
+
+    // Handle remaining outdated messages at the end
+    if (outdatedBuffer.isNotEmpty()) {
+        groups.add(MessageGroup.OutdatedBranch(outdatedBuffer.toList()))
+    }
+
+    return groups
+}
+
+/**
+ * Component to display a collapsible branch of outdated messages
+ */
+@Composable
+fun outdatedBranchComponent(
+    messages: List<ChatMessage>,
+    modifier: Modifier = Modifier,
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp, horizontal = 16.dp),
+    ) {
+        // Collapsible header
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { isExpanded = !isExpanded }
+                .pointerHoverIcon(PointerIcon.Hand),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = if (isExpanded) Icons.Default.ExpandMore else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = if (isExpanded) {
+                        stringResource("outdated.collapse")
+                    } else {
+                        stringResource("outdated.expand")
+                    },
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource("outdated.branch.header", messages.size),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    fontStyle = FontStyle.Italic,
+                )
+            }
+        }
+
+        // Expandable content
+        if (isExpanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, top = 8.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f),
+                        RoundedCornerShape(8.dp),
+                    )
+                    .padding(8.dp),
+            ) {
+                messages.forEach { message ->
+                    outdatedMessageItem(message)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Component to display a single outdated message
+ */
+@Composable
+fun outdatedMessageItem(message: ChatMessage) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = if (message.isUser) Arrangement.End else Arrangement.Start,
+    ) {
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = if (message.isUser) {
+                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
+                } else {
+                    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
+                },
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            ),
+            modifier = Modifier
+                .padding(horizontal = 8.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(12.dp),
+            ) {
+                Text(
+                    text = message.content,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                )
+                // Show "outdated" label
+                Text(
+                    text = stringResource("outdated.label"),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                    fontStyle = FontStyle.Italic,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+    }
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/util/ErrorHandler.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/util/ErrorHandler.kt
@@ -89,4 +89,3 @@ object ErrorHandler {
      */
     fun getCancellationMessage(): String = "Operation was cancelled."
 }
-

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SettingsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SettingsViewModel.kt
@@ -16,8 +16,8 @@ import io.askimo.core.session.ProviderTestResult
 import io.askimo.core.session.Session
 import io.askimo.core.session.SessionFactory
 import io.askimo.core.session.SessionMode
-import io.askimo.desktop.util.ErrorHandler
 import io.askimo.core.session.getConfigInfo
+import io.askimo.desktop.util.ErrorHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -202,6 +202,17 @@ message.loading.previous=Loading previous messages...
 message.thinking=Thinking… ({0}s)
 message.copy=Copy message
 message.copy.description=Copy message
+message.edit=Edit message
+message.edit.description=Edit message
+message.editing.banner=Editing message
+message.editing.banner.from=Editing message from {0}
+message.cancel.edit=Cancel edit
+message.send=Send
+message.update.regenerate=Update & Regenerate
+outdated.expand=Expand outdated messages
+outdated.collapse=Collapse outdated messages
+outdated.branch.header={0} outdated messages from previous edit (click to expand)
+outdated.label=outdated
 
 # Provider Dialog
 provider.change.title=Change Provider

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -202,6 +202,17 @@ message.loading.previous=前のメッセージを読み込み中...
 message.thinking=考え中… ({0}秒)
 message.copy=メッセージをコピー
 message.copy.description=メッセージをコピー
+message.edit=メッセージを編集
+message.edit.description=メッセージを編集
+message.editing.banner=メッセージを編集中
+message.editing.banner.from={0}からのメッセージを編集中
+message.cancel.edit=編集をキャンセル
+message.send=送信
+message.update.regenerate=更新して再生成
+outdated.expand=古いメッセージを展開
+outdated.collapse=古いメッセージを折りたたむ
+outdated.branch.header=前回の編集からの古いメッセージ {0} 件（クリックして展開）
+outdated.label=古い
 
 # Provider Dialog
 provider.change.title=プロバイダーを変更

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -202,6 +202,17 @@ message.loading.previous=Đang tải tin nhắn trước...
 message.thinking=Đang suy nghĩ… ({0} giây)
 message.copy=Sao chép tin nhắn
 message.copy.description=Sao chép tin nhắn
+message.edit=Chỉnh sửa tin nhắn
+message.edit.description=Chỉnh sửa tin nhắn
+message.editing.banner=Đang chỉnh sửa tin nhắn
+message.editing.banner.from=Đang chỉnh sửa tin nhắn từ {0}
+message.cancel.edit=Hủy chỉnh sửa
+message.send=Gửi
+message.update.regenerate=Cập nhật & Tạo lại
+outdated.expand=Mở rộng tin nhắn cũ
+outdated.collapse=Thu gọn tin nhắn cũ
+outdated.branch.header={0} tin nhắn cũ từ lần chỉnh sửa trước (nhấp để mở rộng)
+outdated.label=cũ
 
 # Provider Dialog
 provider.change.title=Thay đổi nhà cung cấp

--- a/shared/src/main/kotlin/io/askimo/core/session/ChatSession.kt
+++ b/shared/src/main/kotlin/io/askimo/core/session/ChatSession.kt
@@ -34,6 +34,8 @@ data class ChatMessage(
     val role: MessageRole,
     val content: String,
     val createdAt: LocalDateTime,
+    val isOutdated: Boolean = false,
+    val editParentId: String? = null,
 )
 
 data class ConversationSummary(

--- a/shared/src/main/kotlin/io/askimo/core/util/TokenCounter.kt
+++ b/shared/src/main/kotlin/io/askimo/core/util/TokenCounter.kt
@@ -25,13 +25,11 @@ object TokenCounter {
      * @param text The text to count tokens for
      * @return The number of tokens
      */
-    fun countTokens(text: String): Int {
-        return try {
-            encoding.countTokens(text)
-        } catch (e: Exception) {
-            // Fallback to rough estimation if tokenizer fails
-            (text.length / 4).coerceAtLeast(1)
-        }
+    fun countTokens(text: String): Int = try {
+        encoding.countTokens(text)
+    } catch (e: Exception) {
+        // Fallback to rough estimation if tokenizer fails
+        (text.length / 4).coerceAtLeast(1)
     }
 
     /**
@@ -67,17 +65,15 @@ object TokenCounter {
      * @param tokens The number of tokens
      * @return Formatted string (e.g., "1.2K tokens", "500 tokens")
      */
-    fun formatTokenCount(tokens: Int): String {
-        return when {
-            tokens < 1_000 -> "$tokens tokens"
-            tokens < 1_000_000 -> {
-                val rounded = (tokens / 100.0).toInt() / 10.0
-                "${rounded}K tokens"
-            }
-            else -> {
-                val rounded = (tokens / 100_000.0).toInt() / 10.0
-                "${rounded}M tokens"
-            }
+    fun formatTokenCount(tokens: Int): String = when {
+        tokens < 1_000 -> "$tokens tokens"
+        tokens < 1_000_000 -> {
+            val rounded = (tokens / 100.0).toInt() / 10.0
+            "${rounded}K tokens"
+        }
+        else -> {
+            val rounded = (tokens / 100_000.0).toInt() / 10.0
+            "${rounded}M tokens"
         }
     }
 
@@ -90,7 +86,7 @@ object TokenCounter {
     data class TokenInfo(
         val totalTokens: Int,
         val messageCount: Int,
-        val formattedCount: String
+        val formattedCount: String,
     )
 
     fun getTokenInfo(messages: List<ChatMessage>): TokenInfo {
@@ -98,8 +94,7 @@ object TokenCounter {
         return TokenInfo(
             totalTokens = totalTokens,
             messageCount = messages.size,
-            formattedCount = formatTokenCount(totalTokens)
+            formattedCount = formatTokenCount(totalTokens),
         )
     }
 }
-


### PR DESCRIPTION
- Introduce `isOutdated` and `editParentId` fields on `ChatMessage` and update the database schema accordingly.
- Add edit button, edit mode UI, and cancel/edit actions to the chat view.
- Create `OutdatedMessageComponents` to visually distinguish and expand outdated messages.
- Filter out outdated messages when calculating token usage and when retrieving recent/active messages.
- Update language handling utilities and add new i18n strings for edit actions.
- Adjust internal services (`ChatService`, `StreamingService`, `ChatViewModel`) to support editing flow without breaking existing APIs.

This enhances the user experience by allowing message edits while preserving conversation history and token limits.