### PR TITLE
fix(session): prevent missing chat parallel event

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -152,6 +152,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Generate Graal metadata (arm64)
+        env:
+          DISABLE_DOCKER_TESTS: 'true'
         run: ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx2g" clean :cli:test
 
       - name: Build native image (arm64)

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -91,6 +91,7 @@ import org.koin.core.context.GlobalContext.get
 import org.koin.core.context.startKoin
 import org.koin.core.parameter.parametersOf
 import java.awt.Cursor
+import java.util.UUID
 import kotlin.system.exitProcess
 
 /**
@@ -250,8 +251,8 @@ fun app(frameWindowScope: FrameWindowScope? = null) {
         if (currentSession != null) {
             sessionManager.switchToSession(currentSession.id)
         } else {
-            val newSessionId = java.util.UUID.randomUUID().toString()
-            sessionManager.switchToSession(newSessionId)
+            val newSessionId = UUID.randomUUID().toString()
+            sessionManager.createNewSession(newSessionId)
         }
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -103,22 +103,6 @@ class ChatSessionService(
     fun getSessionById(sessionId: String): ChatSession? = sessionRepository.getSession(sessionId)
 
     /**
-     * Get a session by ID, creating it if it doesn't exist.
-     * This ensures a session always exists in the database before operations.
-     *
-     * @param sessionId The ID of the session
-     * @return The existing or newly created session
-     */
-    fun getOrCreateSession(sessionId: String): ChatSession = getSessionById(sessionId) ?: createSession(
-        ChatSession(
-            id = sessionId,
-            title = LocalizationManager.getString("chat.new_chat"),
-            createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now(),
-        ),
-    )
-
-    /**
      * Create a new session.
      *
      * @param session The session to create


### PR DESCRIPTION
- Disable Docker tests in CLI release workflow
- Update main to use UUID import and createNewSession
- Refactor SessionManager to use createSession with ChatSession constructor
- Remove deprecated getOrCreateSession from ChatSessionService
- Update ChatViewModel imports and session creation flow