### PR TITLE
chore: prepare 1.1.1 release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -276,27 +276,3 @@ jobs:
           echo "Release files prepared:"
           ls -lh release/
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            release/*
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
-          name: Desktop ${{ github.ref_name }}
-          body: |
-            ## Askimo Application
-            
-            ### Installation
-            
-            For installation instructions, please visit:
-            - **Desktop**: https://askimo.chat/docs/desktop/installation/
-            - **CLI**: https://askimo.chat/docs/cli/installation/
-            
-            ### Checksums
-            
-            Verify your download using the SHA256SUMS.txt file.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.1.0
+projectVersion=1.1.1
 
 # About information
 author=Hai Nguyen


### PR DESCRIPTION
- Remove GitHub release step from desktop workflow
- Bump project version to 1.1.1