### PR TITLE
feat(desktop-chat): add LaTeX rendering and feedback entrypoint

### DIFF
--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.commonmark.ext.autolink)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+    implementation(libs.jlatexmath)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.koin.test)
@@ -263,4 +264,19 @@ tasks.register("detectUnusedLocalizations") {
             }
         }
     }
+}
+tasks.register<JavaExec>("runLatexTest") {
+    group = "verification"
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("io.askimo.desktop.view.components.LatexParsingTestKt")
+}
+tasks.register<JavaExec>("testMarkdownLatex") {
+    group = "verification"
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("io.askimo.desktop.view.components.MarkdownLatexTestKt")
+}
+tasks.register<JavaExec>("runLatexVisualTest") {
+    group = "verification"
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("io.askimo.desktop.view.components.LatexVisualTestKt")
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -247,7 +247,7 @@ fun app(frameWindowScope: FrameWindowScope? = null) {
             parametersOf(
                 scope,
                 sessionManager,
-                { appContext.startNewChatSession().id }, // onCreateNewSession callback
+                { appContext.startNewChatSession().id },
             )
         }
     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/components/FooterBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/components/FooterBar.kt
@@ -62,6 +62,8 @@ import io.askimo.desktop.monitoring.SystemResourceMonitor
 import io.askimo.desktop.theme.ComponentColors
 import kotlinx.coroutines.launch
 import org.koin.java.KoinJavaComponent.get
+import java.awt.Desktop
+import java.net.URI
 
 /**
  * Footer bar component showing system resources, notifications, and version info.
@@ -143,6 +145,23 @@ fun footerBar(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                TextButton(
+                    onClick = {
+                        try {
+                            Desktop.getDesktop().browse(URI("https://github.com/haiphucnguyen/askimo/issues"))
+                        } catch (e: Exception) {
+                            // Silently fail if unable to open browser
+                        }
+                    },
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Text(
+                        text = stringResource("system.share.feedback"),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+
                 notificationIcon(onShowUpdateDetails = onShowUpdateDetails)
 
                 Text(

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/components/LatexRenderer.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/components/LatexRenderer.kt
@@ -1,0 +1,135 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.view.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import org.scilab.forge.jlatexmath.TeXConstants
+import org.scilab.forge.jlatexmath.TeXFormula
+import java.awt.AlphaComposite
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import java.awt.Color as AwtColor
+
+/**
+ * Renders a LaTeX formula as an image using JLaTeXMath.
+ */
+@Composable
+fun latexFormula(
+    latex: String,
+    modifier: Modifier = Modifier,
+    fontSize: Float = 32f,
+) {
+    // Get the actual content color that matches the surrounding text
+    // This is the same color that MaterialTheme.typography.bodyMedium text uses
+    val textColor = LocalContentColor.current
+
+    val formulaImage = remember(latex, fontSize, textColor) {
+        renderLatexToImage(latex, fontSize, textColor)
+    }
+
+    if (formulaImage != null) {
+        Image(
+            bitmap = formulaImage,
+            contentDescription = "LaTeX formula: $latex",
+            modifier = modifier
+                .height(50.dp)
+                .padding(vertical = 4.dp),
+            contentScale = ContentScale.Fit,
+            alignment = Alignment.CenterStart,
+        )
+    } else {
+        // Fallback to plain text if rendering fails
+        Text(
+            text = latex,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+            modifier = modifier,
+        )
+    }
+}
+
+/**
+ * Render LaTeX formula as an image using JLaTeXMath.
+ */
+private fun renderLatexToImage(
+    latex: String,
+    fontSize: Float,
+    textColor: Color,
+): ImageBitmap? = try {
+    // Convert Compose Color to AWT Color
+    val red = (textColor.red * 255).toInt().coerceIn(0, 255)
+    val green = (textColor.green * 255).toInt().coerceIn(0, 255)
+    val blue = (textColor.blue * 255).toInt().coerceIn(0, 255)
+    val awtColor = AwtColor(red, green, blue)
+
+    // Create formula without color wrapping
+    val formula = TeXFormula(latex)
+    val icon = formula.createTeXIcon(TeXConstants.STYLE_DISPLAY, fontSize)
+
+    // Set the foreground color on the icon using reflection to access internal box
+    try {
+        val boxField = icon.javaClass.getDeclaredField("box")
+        boxField.isAccessible = true
+        val box = boxField.get(icon)
+        val foregroundField = box.javaClass.superclass.getDeclaredField("foreground")
+        foregroundField.isAccessible = true
+        foregroundField.set(box, awtColor)
+    } catch (e: Exception) {
+        // If reflection fails, continue without custom color
+        println("Warning: Could not set LaTeX foreground color: ${e.message}")
+    }
+
+    val bufferedImage = BufferedImage(icon.iconWidth, icon.iconHeight, BufferedImage.TYPE_INT_ARGB)
+    val g2 = bufferedImage.createGraphics()
+
+    // Set transparent background
+    g2.composite = AlphaComposite.getInstance(AlphaComposite.CLEAR)
+    g2.fillRect(0, 0, icon.iconWidth, icon.iconHeight)
+    g2.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER)
+
+    // Enable anti-aliasing for better quality
+    g2.setRenderingHint(
+        RenderingHints.KEY_ANTIALIASING,
+        RenderingHints.VALUE_ANTIALIAS_ON,
+    )
+    g2.setRenderingHint(
+        RenderingHints.KEY_TEXT_ANTIALIASING,
+        RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
+    )
+    g2.setRenderingHint(
+        RenderingHints.KEY_RENDERING,
+        RenderingHints.VALUE_RENDER_QUALITY,
+    )
+
+    // Paint the icon
+    icon.paintIcon(null, g2, 0, 0)
+    g2.dispose()
+
+    // Convert BufferedImage to Compose ImageBitmap via Skia
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(bufferedImage, "PNG", outputStream)
+    val bytes = outputStream.toByteArray()
+    org.jetbrains.skia.Image.makeFromEncoded(bytes).toComposeImageBitmap()
+} catch (e: Exception) {
+    println("Failed to render LaTeX: $latex - ${e.message}")
+    e.printStackTrace()
+    null
+}

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -343,4 +343,5 @@ language.name.display=English
 system.memory=Memory
 system.cpu=CPU
 system.resources.tooltip=Memory: {0} MB | CPU: {1}%
+system.share.feedback=Share feedback
 

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -345,3 +345,4 @@ language.name.display=Deutsch
 system.memory=Speicher
 system.cpu=CPU
 system.resources.tooltip=Speicher: {0} MB | CPU: {1}%
+system.share.feedback=Feedback teilen

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -346,3 +346,4 @@ language.name.display=Español
 system.memory=Memoria
 system.cpu=CPU
 system.resources.tooltip=Memoria: {0} MB | CPU: {1}%
+system.share.feedback=Compartir comentarios

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -344,3 +344,4 @@ language.name.display=Français
 system.memory=Mémoire
 system.cpu=CPU
 system.resources.tooltip=Mémoire : {0} MB | CPU : {1}%
+system.share.feedback=Partager vos commentaires

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -344,3 +344,4 @@ language.name.display=日本語
 system.memory=メモリ
 system.cpu=CPU
 system.resources.tooltip=メモリ: {0} MB | CPU: {1}%
+system.share.feedback=フィードバックを共有

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -344,3 +344,4 @@ language.name.display=한국어
 system.memory=메모리
 system.cpu=CPU
 system.resources.tooltip=메모리: {0} MB | CPU: {1}%
+system.share.feedback=피드백 공유

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -344,3 +344,4 @@ language.name.display=Português Brasileiro
 system.memory=Memória
 system.cpu=CPU
 system.resources.tooltip=Memória: {0} MB | CPU: {1}%
+system.share.feedback=Compartilhar feedback

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -343,3 +343,4 @@ language.name.display=Tiếng Việt
 system.memory=Bộ nhớ
 system.cpu=CPU
 system.resources.tooltip=Bộ nhớ: {0} MB | CPU: {1}%
+system.share.feedback=Chia sẻ phản hồi

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -343,3 +343,4 @@ language.name.display=简体中文
 system.memory=内存
 system.cpu=CPU
 system.resources.tooltip=内存：{0} MB | CPU：{1}%
+system.share.feedback=分享反馈

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -344,3 +344,4 @@ language.name.display=繁體中文
 system.memory=記憶體
 system.cpu=CPU
 system.resources.tooltip=記憶體：{0} MB | CPU：{1}%
+system.share.feedback=分享回饋

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ exposed = "0.61.0"
 compose = "1.9.3"
 coil = "3.3.0"
 koin = "4.1.1"
+jlatexmath = "1.0.7"
 
 [libraries]
 # JLine
@@ -46,6 +47,9 @@ langchain4j-localai = { group = "dev.langchain4j", name = "langchain4j-local-ai"
 commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
 commonmark-ext-gfm-tables = { group = "org.commonmark", name = "commonmark-ext-gfm-tables", version.ref = "commonmark" }
 commonmark-ext-autolink = { group = "org.commonmark", name = "commonmark-ext-autolink", version.ref = "commonmark" }
+
+# LaTeX Rendering
+jlatexmath = { group = "org.scilab.forge", name = "jlatexmath", version.ref = "jlatexmath" }
 
 # Image Loading (Coil)
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }


### PR DESCRIPTION
- Add LaTeX renderer and wire markdown support for math content
- Introduce jlatexmath dependency and Gradle tasks for LaTeX tests
- Add localized "Share feedback" action in footer bar across languages
- Fix provider settings initialization via registry default settings
- Tidy desktop app context and logging for chat summaries