### PR TITLE
test(chat-memory): strengthen summarization and pagination coverage

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -680,8 +680,7 @@
     "name": "com.github.dockerjava.api.model.PeerNode",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true,
-    "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    "queryAllDeclaredConstructors": true
   },
   {
     "name": "com.github.dockerjava.api.model.Ports",
@@ -2385,6 +2384,62 @@
     "queryAllDeclaredConstructors": true,
     "methods": [
       { "name": "<init>", "parameterTypes": [] },
+      {
+        "name": "resumeSession should handle session with attachments",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSession should include outdated messages",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSession should preserve message order",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSession should return all messages for a session",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSession should return empty list for session with no messages",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should handle large limit",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should handle limit of 1",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should handle non-existent session gracefully",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should handle session with fewer messages than limit",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should handle session with no messages",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should maintain consistency with multiple calls",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should return limited messages",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should return most recent messages first",
+        "parameterTypes": []
+      },
+      {
+        "name": "resumeSessionPaginated should return session directive if present",
+        "parameterTypes": []
+      },
       { "name": "setUpClass", "parameterTypes": ["java.nio.file.Path"] },
       {
         "name": "should add message and update session timestamp through service",
@@ -2641,16 +2696,7 @@
           "io.askimo.core.context.ExecutionMode"
         ]
       },
-      {
-        "name": "enableRagWith",
-        "parameterTypes": ["io.askimo.core.project.PgVectorIndexer"]
-      },
-      { "name": "getActiveProvider", "parameterTypes": [] },
-      { "name": "getParams", "parameterTypes": [] },
-      {
-        "name": "setScope",
-        "parameterTypes": ["io.askimo.core.project.ProjectMeta"]
-      }
+      { "name": "getParams", "parameterTypes": [] }
     ]
   },
   {
@@ -4547,7 +4593,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$DClpUKLv",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$bDmnOqaA",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/shared/src/main/kotlin/io/askimo/core/memory/MemoryConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/MemoryConfig.kt
@@ -109,27 +109,4 @@ data class MemoryConfig(
 
         return builder.build()
     }
-
-    companion object {
-        /**
-         * Basic configuration without AI summarization (free, fast, reliable)
-         */
-        fun basic(maxTokens: Int = 4000) = MemoryConfig(
-            maxTokens = maxTokens,
-            summarizerModel = null,
-        )
-
-        /**
-         * Configuration with AI summarization
-         */
-        fun withAI(
-            maxTokens: Int = 8000,
-            summarizerModel: ChatModel,
-            tokenEstimator: ((ChatMessage) -> Int)? = null,
-        ) = MemoryConfig(
-            maxTokens = maxTokens,
-            summarizerModel = summarizerModel,
-            tokenEstimator = tokenEstimator,
-        )
-    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -438,7 +438,6 @@ class TokenAwareSummarizingMemory private constructor(
                     }
                 }
             } else {
-                // Synchronous executor for testing
                 Executors.newSingleThreadExecutor()
             }
 

--- a/shared/src/test/kotlin/io/askimo/core/memory/DefaultConversationSummarizerTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/memory/DefaultConversationSummarizerTest.kt
@@ -1,0 +1,361 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.memory
+
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.response.ChatResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+
+class DefaultConversationSummarizerTest {
+
+    @Test
+    fun `should parse valid JSON response`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {
+                "name": "John",
+                "age": "30"
+              },
+              "mainTopics": ["introduction", "greetings"],
+              "recentContext": "User introduced themselves"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(2, summary.keyFacts.size)
+        assertEquals("John", summary.keyFacts["name"])
+        assertEquals("30", summary.keyFacts["age"])
+        assertEquals(2, summary.mainTopics.size)
+        assertEquals("User introduced themselves", summary.recentContext)
+    }
+
+    @Test
+    fun `should handle JSON wrapped in markdown code blocks`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            ```json
+            {
+              "keyFacts": {
+                "topic": "testing"
+              },
+              "mainTopics": ["testing"],
+              "recentContext": "Test context"
+            }
+            ```
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(1, summary.keyFacts.size)
+        assertEquals("testing", summary.keyFacts["topic"])
+    }
+
+    @Test
+    fun `should sanitize arrays in keyFacts to comma-separated strings`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {
+                "programming_language": "Java",
+                "frameworks": ["OpenAI Java SDK", "LangChain4J 1.9", "Spring Boot"],
+                "api": "DALL-E"
+              },
+              "mainTopics": ["programming"],
+              "recentContext": "Discussion about frameworks"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(3, summary.keyFacts.size)
+        assertEquals("Java", summary.keyFacts["programming_language"])
+        assertEquals("OpenAI Java SDK, LangChain4J 1.9, Spring Boot", summary.keyFacts["frameworks"])
+        assertEquals("DALL-E", summary.keyFacts["api"])
+    }
+
+    @Test
+    fun `should handle multiple arrays in keyFacts`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {
+                "languages": ["Java", "Kotlin"],
+                "tools": ["Gradle", "Maven"],
+                "version": "1.0"
+              },
+              "mainTopics": ["development"],
+              "recentContext": "Tech stack discussion"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(3, summary.keyFacts.size)
+        assertEquals("Java, Kotlin", summary.keyFacts["languages"])
+        assertEquals("Gradle, Maven", summary.keyFacts["tools"])
+        assertEquals("1.0", summary.keyFacts["version"])
+    }
+
+    @Test
+    fun `should return empty summary on parsing failure`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from("This is not valid JSON at all!")
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(0, summary.keyFacts.size)
+        assertEquals(0, summary.mainTopics.size)
+        assertEquals("", summary.recentContext)
+    }
+
+    @Test
+    fun `should handle JSON with extra text before and after`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            Here is the summary:
+            {
+              "keyFacts": {
+                "result": "success"
+              },
+              "mainTopics": ["summary"],
+              "recentContext": "Test"
+            }
+            That's all!
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(1, summary.keyFacts.size)
+        assertEquals("success", summary.keyFacts["result"])
+    }
+
+    @Test
+    fun `should handle empty keyFacts`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {},
+              "mainTopics": ["general"],
+              "recentContext": "No specific facts"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(0, summary.keyFacts.size)
+        assertEquals(1, summary.mainTopics.size)
+        assertEquals("No specific facts", summary.recentContext)
+    }
+
+    @Test
+    fun `should handle empty mainTopics`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {
+                "fact": "value"
+              },
+              "mainTopics": [],
+              "recentContext": "Context"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(1, summary.keyFacts.size)
+        assertEquals(0, summary.mainTopics.size)
+    }
+
+    @Test
+    fun `should handle chatModel throwing exception`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        whenever(chatModel.chat(any<UserMessage>())).thenThrow(RuntimeException("API Error"))
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then - Should return empty summary without throwing
+        assertEquals(0, summary.keyFacts.size)
+        assertEquals(0, summary.mainTopics.size)
+        assertEquals("", summary.recentContext)
+    }
+
+    @Test
+    fun `should handle arrays with single values`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {
+                "tool": ["Gradle"]
+              },
+              "mainTopics": ["build"],
+              "recentContext": "Build tool"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(1, summary.keyFacts.size)
+        assertEquals("Gradle", summary.keyFacts["tool"])
+    }
+
+    @Test
+    fun `should handle nested quotes in array values`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {
+                "quote": ["He said hello", "She replied hi"]
+              },
+              "mainTopics": ["conversation"],
+              "recentContext": "Dialogue"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals(1, summary.keyFacts.size)
+        assertEquals("He said hello, She replied hi", summary.keyFacts["quote"])
+    }
+
+    @Test
+    fun `should preserve special characters in values`() {
+        // Given
+        val chatModel = mock<ChatModel>()
+        val aiMessage = AiMessage.from(
+            """
+            {
+              "keyFacts": {
+                "email": "user@example.com",
+                "path": "/home/user/project"
+              },
+              "mainTopics": ["contact"],
+              "recentContext": "User info"
+            }
+            """.trimIndent(),
+        )
+
+        val response = ChatResponse.builder().aiMessage(aiMessage).build()
+        whenever(chatModel.chat(any<UserMessage>())).thenReturn(response)
+
+        val summarizer = DefaultConversationSummarizer(chatModel)
+
+        // When
+        val summary = summarizer.summarize("Test conversation")
+
+        // Then
+        assertEquals("user@example.com", summary.keyFacts["email"])
+        assertEquals("/home/user/project", summary.keyFacts["path"])
+    }
+}

--- a/shared/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
@@ -1,0 +1,585 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.memory
+
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.ChatMessage
+import dev.langchain4j.data.message.SystemMessage
+import dev.langchain4j.data.message.UserMessage
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertContains
+
+class TokenAwareSummarizingMemoryTest {
+
+    private var memory: TokenAwareSummarizingMemory? = null
+
+    @AfterEach
+    fun tearDown() {
+        memory?.close()
+    }
+
+    @Test
+    fun `should create memory with default builder settings`() {
+        memory = TokenAwareSummarizingMemory.builder().build()
+
+        assertNotNull(memory)
+        assertEquals(0, memory!!.messages().size)
+    }
+
+    @Test
+    fun `should create memory with custom max tokens`() {
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(2000)
+            .build()
+
+        assertNotNull(memory)
+    }
+
+    @Test
+    fun `should add single message to memory`() {
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        val message = UserMessage.from("Hello, world!")
+
+        memory!!.add(message)
+
+        val messages = memory!!.messages()
+        assertEquals(1, messages.size)
+        assertTrue(messages[0] is UserMessage)
+        assertEquals("Hello, world!", (messages[0] as UserMessage).singleText())
+    }
+
+    @Test
+    fun `should add multiple messages to memory`() {
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        memory!!.add(UserMessage.from("First message"))
+        memory!!.add(AiMessage.from("Second message"))
+        memory!!.add(UserMessage.from("Third message"))
+
+        val messages = memory!!.messages()
+        assertEquals(3, messages.size)
+    }
+
+    @Test
+    fun `should clear all messages from memory`() {
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        memory!!.add(UserMessage.from("Message 1"))
+        memory!!.add(UserMessage.from("Message 2"))
+        assertEquals(2, memory!!.messages().size)
+
+        memory!!.clear()
+
+        assertEquals(0, memory!!.messages().size)
+    }
+
+    @Test
+    fun `should use custom token estimator`() {
+        var estimatorCallCount = 0
+        val customEstimator: (ChatMessage) -> Int = { message ->
+            estimatorCallCount++
+            100 // Fixed token count for testing
+        }
+
+        memory = TokenAwareSummarizingMemory.builder()
+            .tokenEstimator(customEstimator)
+            .asyncSummarization(false)
+            .build()
+
+        memory!!.add(UserMessage.from("Test"))
+
+        assertTrue(estimatorCallCount > 0, "Custom estimator should have been called")
+    }
+
+    @Test
+    fun `should trigger summarization when threshold exceeded`() {
+        val latch = CountDownLatch(1)
+        var summarizerCalled = false
+
+        val summarizer: (String) -> ConversationSummary = { text ->
+            summarizerCalled = true
+            latch.countDown()
+            ConversationSummary(
+                keyFacts = mapOf("topic" to "test"),
+                mainTopics = listOf("testing"),
+                recentContext = "Test conversation",
+            )
+        }
+
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(50)
+            .summarizationThreshold(0.5)
+            .tokenEstimator { 20 } // Each message = 20 tokens
+            .summarizer(summarizer)
+            .build()
+
+        // When - Add enough messages to exceed threshold (50 * 0.5 = 25 tokens)
+        memory!!.add(UserMessage.from("Message 1")) // 20 tokens
+        memory!!.add(UserMessage.from("Message 2")) // 40 tokens total
+        memory!!.add(UserMessage.from("Message 3")) // 60 tokens - exceeds threshold!
+
+        // Wait for async summarization
+        latch.await(5, TimeUnit.SECONDS)
+
+        assertTrue(summarizerCalled, "Summarizer should have been called")
+    }
+
+    @Test
+    fun `should generate basic summary when no summarizer provided`() {
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(50)
+            .summarizationThreshold(0.5)
+            .tokenEstimator { 20 }
+            .asyncSummarization(false)
+            .build()
+
+        // When - Add enough messages to trigger summarization
+        repeat(5) { i ->
+            memory!!.add(UserMessage.from("Message $i with some content to make it longer"))
+        }
+
+        // Give time for synchronous summarization
+        Thread.sleep(500)
+
+        // Then - Should have pruned some messages or added summary
+        val messages = memory!!.messages()
+        // Either messages were pruned OR a summary was added
+        val userMessages = messages.filterIsInstance<UserMessage>()
+        val systemMessages = messages.filterIsInstance<SystemMessage>()
+
+        // Should have either pruned messages or added a system summary message
+        assertTrue(
+            userMessages.size < 5 || systemMessages.isNotEmpty(),
+            "Messages should have been pruned or summary added",
+        )
+    }
+
+    @Test
+    fun `should include structured summary in messages when available`() {
+        // Given
+        val summarizer: (String) -> ConversationSummary = { _ ->
+            ConversationSummary(
+                keyFacts = mapOf("name" to "John", "age" to "30"),
+                mainTopics = listOf("introduction", "greetings"),
+                recentContext = "User introduced themselves",
+            )
+        }
+
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(50)
+            .summarizationThreshold(0.5)
+            .tokenEstimator { 20 }
+            .summarizer(summarizer)
+            .build()
+
+        repeat(5) { i ->
+            memory!!.add(UserMessage.from("Message $i with some content to reach token limit"))
+        }
+
+        // Wait for async summarization
+        Thread.sleep(1000)
+
+        val messages = memory!!.messages()
+
+        // Then - First message should be a SystemMessage with summary
+        assertTrue(messages.isNotEmpty())
+        val firstMessage = messages.firstOrNull()
+        if (firstMessage is SystemMessage) {
+            val summaryText = firstMessage.text()
+            assertContains(summaryText, "CONVERSATION CONTEXT")
+        }
+    }
+
+    @Test
+    fun `should export and import memory state`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        val msg1 = UserMessage.from("First message")
+        val msg2 = AiMessage.from("Second message")
+        memory!!.add(msg1)
+        memory!!.add(msg2)
+
+        // When - Export state
+        val state = memory!!.exportState()
+
+        // Then
+        assertEquals(2, state.messages.size)
+
+        // When - Create new memory and import state
+        val newMemory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+        newMemory.importState(state)
+
+        // Then
+        val importedMessages = newMemory.messages()
+        assertEquals(2, importedMessages.size)
+        assertTrue(importedMessages[0] is UserMessage)
+        assertTrue(importedMessages[1] is AiMessage)
+
+        newMemory.close()
+    }
+
+    @Test
+    fun `should export state with summary`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        val summary = ConversationSummary(
+            keyFacts = mapOf("key" to "value"),
+            mainTopics = listOf("topic1"),
+            recentContext = "context",
+        )
+
+        val state = TokenAwareSummarizingMemory.MemoryState(
+            messages = listOf(UserMessage.from("Test")),
+            summary = summary,
+        )
+
+        memory!!.importState(state)
+
+        // When
+        val exportedState = memory!!.exportState()
+
+        // Then
+        assertNotNull(exportedState.summary)
+        assertEquals(summary.keyFacts, exportedState.summary!!.keyFacts)
+        assertEquals(summary.mainTopics, exportedState.summary!!.mainTopics)
+        assertEquals(summary.recentContext, exportedState.summary!!.recentContext)
+    }
+
+    @Test
+    fun `should clear summary when clearing memory`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        val state = TokenAwareSummarizingMemory.MemoryState(
+            messages = listOf(UserMessage.from("Test")),
+            summary = ConversationSummary(
+                keyFacts = mapOf("key" to "value"),
+                mainTopics = listOf("topic"),
+                recentContext = "context",
+            ),
+        )
+        memory!!.importState(state)
+
+        // When
+        memory!!.clear()
+
+        // Then
+        val exportedState = memory!!.exportState()
+        assertEquals(0, exportedState.messages.size)
+        assertNull(exportedState.summary)
+    }
+
+    @Test
+    fun `should handle different message types`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        val userMsg = UserMessage.from("User message")
+        val aiMsg = AiMessage.from("AI message")
+        val systemMsg = SystemMessage.from("System message")
+
+        // When
+        memory!!.add(userMsg)
+        memory!!.add(aiMsg)
+        memory!!.add(systemMsg)
+
+        // Then
+        val messages = memory!!.messages()
+        assertEquals(3, messages.size)
+        assertTrue(messages[0] is UserMessage)
+        assertTrue(messages[1] is AiMessage)
+        assertTrue(messages[2] is SystemMessage)
+    }
+
+    @Test
+    fun `should be thread-safe when adding messages concurrently`() = runBlocking {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        // When - Add messages from multiple threads
+        val threads = List(10) { threadIndex ->
+            Thread {
+                repeat(10) { msgIndex ->
+                    memory!!.add(UserMessage.from("Thread $threadIndex, Message $msgIndex"))
+                }
+            }
+        }
+
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        // Then - Should have all 100 messages
+        assertEquals(100, memory!!.messages().size)
+    }
+
+    @Test
+    fun `should merge summaries when summarizing multiple times`() {
+        // Given
+        var summaryCount = 0
+        val summarizer: (String) -> ConversationSummary = { _ ->
+            summaryCount++
+            ConversationSummary(
+                keyFacts = mapOf("fact$summaryCount" to "value$summaryCount"),
+                mainTopics = listOf("topic$summaryCount"),
+                recentContext = "Context $summaryCount",
+            )
+        }
+
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(50)
+            .summarizationThreshold(0.5)
+            .tokenEstimator { 15 }
+            .summarizer(summarizer)
+            .asyncSummarization(false)
+            .build()
+
+        // When - Trigger multiple summarizations
+        repeat(10) { i ->
+            memory!!.add(UserMessage.from("Message $i with content"))
+        }
+
+        Thread.sleep(500)
+
+        // Then - Should have merged multiple summaries
+        val state = memory!!.exportState()
+        if (state.summary != null) {
+            assertTrue(state.summary!!.keyFacts.size > 0)
+        }
+    }
+
+    @Test
+    fun `should properly close and cleanup resources`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder().build()
+
+        memory!!.add(UserMessage.from("Test"))
+
+        // When
+        assertDoesNotThrow {
+            memory!!.close()
+        }
+
+        // Then - Should not throw on second close
+        assertDoesNotThrow {
+            memory!!.close()
+        }
+    }
+
+    @Test
+    fun `should handle summarization timeout gracefully`() {
+        // Given
+        val summarizer: (String) -> ConversationSummary = { _ ->
+            // Simulate slow summarization
+            Thread.sleep(5000)
+            ConversationSummary()
+        }
+
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(50)
+            .summarizationThreshold(0.5)
+            .tokenEstimator { 20 }
+            .summarizer(summarizer)
+            .summarizationTimeout(1) // 1 second timeout
+            .build()
+
+        // When - Trigger summarization
+        repeat(5) { i ->
+            memory!!.add(UserMessage.from("Message $i"))
+        }
+
+        // Wait for timeout
+        Thread.sleep(2000)
+
+        // Then - Should still function normally after timeout
+        assertDoesNotThrow {
+            memory!!.add(UserMessage.from("Another message"))
+            memory!!.messages()
+        }
+    }
+
+    @Test
+    fun `should preserve message order after summarization`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(50)
+            .summarizationThreshold(0.5)
+            .tokenEstimator { 20 }
+            .asyncSummarization(false)
+            .build()
+
+        // When - Add messages
+        repeat(5) { i ->
+            memory!!.add(UserMessage.from("Message $i"))
+        }
+
+        Thread.sleep(100)
+
+        // Then - Remaining messages should maintain order
+        val messages = memory!!.messages()
+        val userMessages = messages.filterIsInstance<UserMessage>()
+
+        if (userMessages.size >= 2) {
+            val firstContent = userMessages[0].singleText()!!
+            val secondContent = userMessages[1].singleText()!!
+
+            val firstNum = firstContent.filter { it.isDigit() }.toIntOrNull()
+            val secondNum = secondContent.filter { it.isDigit() }.toIntOrNull()
+
+            if (firstNum != null && secondNum != null) {
+                assertTrue(firstNum < secondNum, "Messages should maintain chronological order")
+            }
+        }
+    }
+
+    @Test
+    fun `should use default token estimator when none provided`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        // When
+        memory!!.add(UserMessage.from("This is a test message with several words"))
+
+        // Then - Should not throw, default estimator should work
+        val messages = memory!!.messages()
+        assertEquals(1, messages.size)
+    }
+
+    @Test
+    fun `should handle builder with all options set`() {
+        // Given/When
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(3000)
+            .tokenEstimator { 50 }
+            .summarizationThreshold(0.8)
+            .summarizer { ConversationSummary() }
+            .asyncSummarization(true)
+            .summarizationTimeout(60)
+            .build()
+
+        // Then
+        assertNotNull(memory)
+        memory!!.add(UserMessage.from("Test"))
+        assertEquals(1, memory!!.messages().size)
+    }
+
+    @Test
+    fun `should return unique id for memory instance`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder().build()
+        val memory2 = TokenAwareSummarizingMemory.builder().build()
+
+        // When
+        val id1 = memory!!.id()
+        val id2 = memory2.id()
+
+        // Then
+        assertNotEquals(id1, id2)
+
+        memory2.close()
+    }
+
+    @Test
+    fun `should handle summarization with no messages`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        // When/Then - Should not throw
+        assertDoesNotThrow {
+            memory!!.clear()
+            memory!!.messages()
+        }
+    }
+
+    @Test
+    fun `should prune oldest messages during summarization`() {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .maxTokens(50)
+            .summarizationThreshold(0.5)
+            .tokenEstimator { 15 }
+            .asyncSummarization(false)
+            .build()
+
+        // When - Add messages
+        memory!!.add(UserMessage.from("Old message 1"))
+        memory!!.add(UserMessage.from("Old message 2"))
+        memory!!.add(UserMessage.from("Old message 3"))
+        memory!!.add(UserMessage.from("Recent message 4"))
+        memory!!.add(UserMessage.from("Recent message 5"))
+
+        Thread.sleep(200)
+
+        // Then - Should have pruned oldest messages
+        val messages = memory!!.messages()
+        val userMessages = messages.filterIsInstance<UserMessage>()
+        assertTrue(userMessages.size < 5, "Should have pruned some messages")
+    }
+
+    @Test
+    fun `should handle concurrent export and import operations`() = runBlocking {
+        // Given
+        memory = TokenAwareSummarizingMemory.builder()
+            .asyncSummarization(false)
+            .build()
+
+        repeat(5) { i ->
+            memory!!.add(UserMessage.from("Message $i"))
+        }
+
+        // When - Export and import concurrently
+        val threads = List(5) { threadIndex ->
+            Thread {
+                val state = memory!!.exportState()
+                val newMemory = TokenAwareSummarizingMemory.builder()
+                    .asyncSummarization(false)
+                    .build()
+                newMemory.importState(state)
+                assertEquals(5, newMemory.messages().size)
+                newMemory.close()
+            }
+        }
+
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        // Then - Original memory should still be intact
+        assertEquals(5, memory!!.messages().size)
+    }
+}

--- a/shared/src/test/kotlin/io/askimo/core/providers/ChatClientImplTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/providers/ChatClientImplTest.kt
@@ -1,0 +1,475 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.providers
+
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.SystemMessage
+import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.service.TokenStream
+import io.askimo.core.chat.domain.SessionMemory
+import io.askimo.core.chat.repository.SessionMemoryRepository
+import io.askimo.core.memory.ConversationSummary
+import io.askimo.core.memory.TokenAwareSummarizingMemory
+import io.askimo.core.memory.TokenAwareSummarizingMemory.MemoryState
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ChatClientImplTest {
+    private lateinit var delegate: ChatClient
+    private lateinit var chatMemory: TokenAwareSummarizingMemory
+    private lateinit var sessionMemoryRepository: SessionMemoryRepository
+    private lateinit var chatClient: ChatClientImpl
+
+    @BeforeEach
+    fun setup() {
+        delegate = mock()
+        chatMemory = mock()
+        sessionMemoryRepository = mock()
+        chatClient = ChatClientImpl(delegate, chatMemory, sessionMemoryRepository)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        reset(delegate, chatMemory, sessionMemoryRepository)
+    }
+
+    @Test
+    fun `sendMessageStreaming delegates to underlying client`() {
+        // Given
+        val prompt = "Hello, world!"
+        val tokenStream: TokenStream = mock()
+        whenever(delegate.sendMessageStreaming(prompt)) doReturn tokenStream
+
+        // When
+        val result = chatClient.sendMessageStreaming(prompt)
+
+        // Then
+        assertEquals(tokenStream, result)
+        verify(delegate).sendMessageStreaming(prompt)
+    }
+
+    @Test
+    fun `sendMessage delegates to underlying client`() {
+        // Given
+        val prompt = "What is 2+2?"
+        val response = "The answer is 4."
+        whenever(delegate.sendMessage(prompt)) doReturn response
+
+        // When
+        val result = chatClient.sendMessage(prompt)
+
+        // Then
+        assertEquals(response, result)
+        verify(delegate).sendMessage(prompt)
+    }
+
+    @Test
+    fun `getCurrentSessionId returns null initially`() {
+        // When
+        val sessionId = chatClient.getCurrentSessionId()
+
+        // Then
+        assertNull(sessionId)
+    }
+
+    @Test
+    fun `switchSession with no current session loads new session`() = runBlocking {
+        // Given
+        val sessionId = "session-123"
+        val savedMessages = """[{"type":"user","content":"Hello"},{"type":"ai","content":"Hi!"}]"""
+        val savedMemory = SessionMemory(
+            sessionId = sessionId,
+            memorySummary = null,
+            memoryMessages = savedMessages,
+        )
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn savedMemory
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        assertEquals(sessionId, chatClient.getCurrentSessionId())
+        verify(chatMemory).importState(any())
+        verify(sessionMemoryRepository).loadMemory(sessionId)
+    }
+
+    @Test
+    fun `switchSession saves old session before loading new one`() = runBlocking {
+        // Given
+        val oldSessionId = "session-old"
+        val newSessionId = "session-new"
+        val messages = listOf(
+            UserMessage.from("Hello"),
+            AiMessage.from("Hi there!"),
+        )
+        val state = MemoryState(messages, null)
+
+        whenever(chatMemory.exportState()) doReturn state
+        whenever(sessionMemoryRepository.loadMemory(any())) doReturn null
+
+        // Switch to old session first
+        chatClient.switchSession(oldSessionId)
+
+        // When - switch to new session
+        chatClient.switchSession(newSessionId)
+
+        // Then
+        assertEquals(newSessionId, chatClient.getCurrentSessionId())
+        verify(sessionMemoryRepository).saveMemory(argThat { memory -> memory.sessionId == oldSessionId })
+        verify(sessionMemoryRepository).loadMemory(newSessionId)
+    }
+
+    @Test
+    fun `switchSession clears memory when no saved memory exists`() = runBlocking {
+        // Given
+        val sessionId = "new-session"
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn null
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        assertEquals(sessionId, chatClient.getCurrentSessionId())
+        verify(chatMemory).clear()
+    }
+
+    @Test
+    fun `switchSession handles load error gracefully by clearing memory`() = runBlocking {
+        // Given
+        val sessionId = "problematic-session"
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doThrow RuntimeException("DB error")
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        assertEquals(sessionId, chatClient.getCurrentSessionId())
+        verify(chatMemory).clear()
+    }
+
+    @Test
+    fun `switchSession handles save error gracefully and continues`() = runBlocking {
+        // Given
+        val oldSessionId = "session-1"
+        val newSessionId = "session-2"
+
+        whenever(chatMemory.exportState()) doThrow RuntimeException("Export failed")
+        whenever(sessionMemoryRepository.loadMemory(any())) doReturn null
+
+        // Switch to old session first
+        chatClient.switchSession(oldSessionId)
+
+        // When - switch should still work despite save error
+        chatClient.switchSession(newSessionId)
+
+        // Then
+        assertEquals(newSessionId, chatClient.getCurrentSessionId())
+        verify(sessionMemoryRepository).loadMemory(newSessionId)
+    }
+
+    @Test
+    fun `saveCurrentSession persists memory state`() = runBlocking {
+        // Given
+        val sessionId = "session-to-save"
+        val messages = listOf(
+            UserMessage.from("User message"),
+            AiMessage.from("AI response"),
+        )
+        val state = MemoryState(messages, null)
+
+        whenever(chatMemory.exportState()) doReturn state
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn null
+
+        chatClient.switchSession(sessionId)
+
+        // When
+        chatClient.saveCurrentSession()
+
+        // Then
+        verify(sessionMemoryRepository).saveMemory(
+            argThat { memory ->
+                memory.sessionId == sessionId &&
+                    memory.memoryMessages.contains("\"type\":\"user\"") &&
+                    memory.memoryMessages.contains("\"type\":\"ai\"")
+            },
+        )
+    }
+
+    @Test
+    fun `saveCurrentSession with summary persists both messages and summary`() = runBlocking {
+        // Given
+        val sessionId = "session-with-summary"
+        val summary = ConversationSummary(
+            keyFacts = mapOf("weather" to "sunny"),
+            mainTopics = listOf("weather", "forecast"),
+            recentContext = "Conversation about weather",
+        )
+        val messages = listOf(UserMessage.from("How's the weather?"))
+        val state = MemoryState(messages, summary)
+
+        whenever(chatMemory.exportState()) doReturn state
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn null
+
+        chatClient.switchSession(sessionId)
+
+        // When
+        chatClient.saveCurrentSession()
+
+        // Then
+        verify(sessionMemoryRepository).saveMemory(
+            argThat { memory ->
+                memory.sessionId == sessionId &&
+                    memory.memorySummary != null &&
+                    memory.memorySummary!!.contains("recentContext")
+            },
+        )
+    }
+
+    @Test
+    fun `saveCurrentSession does nothing when no current session`() = runBlocking {
+        // When
+        chatClient.saveCurrentSession()
+
+        // Then
+        verify(sessionMemoryRepository, never()).saveMemory(any())
+    }
+
+    @Test
+    fun `clearMemory clears the chat memory`() {
+        // When
+        chatClient.clearMemory()
+
+        // Then
+        verify(chatMemory).clear()
+    }
+
+    @Test
+    fun `message serialization handles all message types`() = runBlocking {
+        // Given
+        val sessionId = "multi-type-session"
+        val messages = listOf(
+            UserMessage.from("User says hello"),
+            AiMessage.from("AI responds"),
+            SystemMessage.from("System message"),
+        )
+        val state = MemoryState(messages, null)
+
+        whenever(chatMemory.exportState()) doReturn state
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn null
+
+        chatClient.switchSession(sessionId)
+
+        // When
+        chatClient.saveCurrentSession()
+
+        // Then
+        verify(sessionMemoryRepository).saveMemory(
+            argThat { memory ->
+                memory.memoryMessages.contains("\"type\":\"user\"") &&
+                    memory.memoryMessages.contains("\"type\":\"ai\"") &&
+                    memory.memoryMessages.contains("\"type\":\"system\"") &&
+                    memory.memoryMessages.contains("User says hello") &&
+                    memory.memoryMessages.contains("AI responds") &&
+                    memory.memoryMessages.contains("System message")
+            },
+        )
+    }
+
+    @Test
+    fun `restoreMemoryState correctly deserializes user messages`() = runBlocking {
+        // Given
+        val sessionId = "restore-test"
+        val savedMessages = """[{"type":"user","content":"Test message"}]"""
+        val savedMemory = SessionMemory(
+            sessionId = sessionId,
+            memorySummary = null,
+            memoryMessages = savedMessages,
+        )
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn savedMemory
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        verify(chatMemory).importState(
+            argThat { state ->
+                state.messages.size == 1 &&
+                    state.messages[0] is UserMessage &&
+                    (state.messages[0] as UserMessage).singleText() == "Test message"
+            },
+        )
+    }
+
+    @Test
+    fun `restoreMemoryState correctly deserializes ai messages`() = runBlocking {
+        // Given
+        val sessionId = "restore-ai-test"
+        val savedMessages = """[{"type":"ai","content":"AI response"}]"""
+        val savedMemory = SessionMemory(
+            sessionId = sessionId,
+            memorySummary = null,
+            memoryMessages = savedMessages,
+        )
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn savedMemory
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        verify(chatMemory).importState(
+            argThat { state ->
+                state.messages.size == 1 &&
+                    state.messages[0] is AiMessage &&
+                    (state.messages[0] as AiMessage).text() == "AI response"
+            },
+        )
+    }
+
+    @Test
+    fun `restoreMemoryState correctly deserializes system messages`() = runBlocking {
+        // Given
+        val sessionId = "restore-system-test"
+        val savedMessages = """[{"type":"system","content":"System instruction"}]"""
+        val savedMemory = SessionMemory(
+            sessionId = sessionId,
+            memorySummary = null,
+            memoryMessages = savedMessages,
+        )
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn savedMemory
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        verify(chatMemory).importState(
+            argThat { state ->
+                state.messages.size == 1 &&
+                    state.messages[0] is SystemMessage &&
+                    (state.messages[0] as SystemMessage).text() == "System instruction"
+            },
+        )
+    }
+
+    @Test
+    fun `restoreMemoryState handles malformed JSON gracefully`() = runBlocking {
+        // Given
+        val sessionId = "malformed-json"
+        val savedMemory = SessionMemory(
+            sessionId = sessionId,
+            memorySummary = null,
+            memoryMessages = "this is not valid JSON",
+        )
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn savedMemory
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then - deserializeMessages catches the exception and returns empty list
+        verify(chatMemory).importState(
+            argThat { state ->
+                state.messages.isEmpty() && state.summary == null
+            },
+        )
+    }
+
+    @Test
+    fun `restoreMemoryState ignores unknown message types`() = runBlocking {
+        // Given
+        val sessionId = "unknown-type-test"
+        val savedMessages = """[
+            {"type":"user","content":"Valid message"},
+            {"type":"unknown","content":"Should be ignored"},
+            {"type":"ai","content":"Another valid"}
+        ]"""
+        val savedMemory = SessionMemory(
+            sessionId = sessionId,
+            memorySummary = null,
+            memoryMessages = savedMessages,
+        )
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn savedMemory
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        verify(chatMemory).importState(
+            argThat { state ->
+                state.messages.size == 2 &&
+                    state.messages[0] is UserMessage &&
+                    state.messages[1] is AiMessage
+            },
+        )
+    }
+
+    @Test
+    fun `restoreMemoryState restores summary when present`() = runBlocking {
+        // Given
+        val sessionId = "summary-test"
+        val summaryJson = """{"keyFacts":{"topic":"test"},"mainTopics":["Point 1","Point 2"],"recentContext":"Brief summary"}"""
+        val savedMessages = """[{"type":"user","content":"Test"}]"""
+        val savedMemory = SessionMemory(
+            sessionId = sessionId,
+            memorySummary = summaryJson,
+            memoryMessages = savedMessages,
+        )
+        whenever(sessionMemoryRepository.loadMemory(sessionId)) doReturn savedMemory
+
+        // When
+        chatClient.switchSession(sessionId)
+
+        // Then
+        verify(chatMemory).importState(
+            argThat { state ->
+                state.summary != null &&
+                    state.summary!!.recentContext == "Brief summary" &&
+                    state.summary!!.mainTopics.size == 2
+            },
+        )
+    }
+
+    @Test
+    fun `multiple session switches maintain correct state`() = runBlocking {
+        // Given
+        val session1 = "session-1"
+        val session2 = "session-2"
+        val session3 = "session-3"
+
+        val state1 = MemoryState(listOf(UserMessage.from("Message 1")), null)
+        val state2 = MemoryState(listOf(UserMessage.from("Message 2")), null)
+
+        whenever(chatMemory.exportState())
+            .doReturn(state1)
+            .doReturn(state2)
+        whenever(sessionMemoryRepository.loadMemory(any())) doReturn null
+
+        // When
+        chatClient.switchSession(session1)
+        assertEquals(session1, chatClient.getCurrentSessionId())
+
+        chatClient.switchSession(session2)
+        assertEquals(session2, chatClient.getCurrentSessionId())
+
+        chatClient.switchSession(session3)
+        assertEquals(session3, chatClient.getCurrentSessionId())
+
+        // Then
+        verify(sessionMemoryRepository).saveMemory(argThat { memory -> memory.sessionId == session1 })
+        verify(sessionMemoryRepository).saveMemory(argThat { memory -> memory.sessionId == session2 })
+        verify(sessionMemoryRepository, never()).saveMemory(argThat { memory -> memory.sessionId == session3 })
+    }
+}


### PR DESCRIPTION
- Add integration tests for chat session pagination and resume behavior
- Extend memory tests for summarizer and token-aware memory edge cases
- Sanitize keyFacts output to enforce simple string values in summaries
- Remove unused MemoryConfig factory helpers to simplify configuration
- Update native-image reflection config for new test and memory classes