### PR TITLE
refactor: add exception handling for failed chat messages

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -2696,7 +2696,16 @@
           "io.askimo.core.context.ExecutionMode"
         ]
       },
-      { "name": "getParams", "parameterTypes": [] }
+      {
+        "name": "enableRagWith",
+        "parameterTypes": ["io.askimo.core.project.PgVectorIndexer"]
+      },
+      { "name": "getActiveProvider", "parameterTypes": [] },
+      { "name": "getParams", "parameterTypes": [] },
+      {
+        "name": "setScope",
+        "parameterTypes": ["io.askimo.core.project.ProjectMeta"]
+      }
     ]
   },
   {
@@ -4593,7 +4602,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$bDmnOqaA",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$f2y6vehu",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -830,8 +830,9 @@ fun mainContent(
                     onDeleteSession = { sessionId ->
                         sessionsViewModel.deleteSessionWithCleanup(sessionId)
                     },
-                    showRetryButton = chatViewModel.showRetryButton,
-                    onRetry = { chatViewModel.retryLastMessage() },
+                    onRetryMessage = { failedMessageId ->
+                        chatViewModel.retryMessage(failedMessageId)
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/chat/ChatView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/chat/ChatView.kt
@@ -176,8 +176,7 @@ fun chatView(
     sessionId: String? = null,
     onExportSession: (String) -> Unit = {},
     onDeleteSession: (String) -> Unit = {},
-    showRetryButton: Boolean = false,
-    onRetry: () -> Unit = {},
+    onRetryMessage: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     // Internal state management for ChatView
@@ -742,7 +741,7 @@ fun chatView(
                         messages = searchResults,
                         isThinking = false,
                         thinkingElapsedSeconds = 0,
-                        spinnerFrame = spinnerFrame,
+                        spinnerFrame = spinnerFrame.toString(),
                         hasMoreMessages = false,
                         isLoadingPrevious = false,
                         onLoadPrevious = {},
@@ -766,8 +765,7 @@ fun chatView(
                         onDownloadAttachment = downloadAttachment,
                         userAvatarPath = userAvatarPath,
                         aiAvatarPath = aiAvatarPath,
-                        showRetryButton = showRetryButton,
-                        onRetry = onRetry,
+                        onRetryMessage = onRetryMessage,
                     )
                 }
                 messages.isEmpty() -> {
@@ -783,7 +781,7 @@ fun chatView(
                         messages = messages,
                         isThinking = isThinking,
                         thinkingElapsedSeconds = thinkingElapsedSeconds,
-                        spinnerFrame = spinnerFrame,
+                        spinnerFrame = spinnerFrame.toString(),
                         hasMoreMessages = hasMoreMessages,
                         isLoadingPrevious = isLoadingPrevious,
                         onLoadPrevious = onLoadPrevious,
@@ -804,8 +802,7 @@ fun chatView(
                         onDownloadAttachment = downloadAttachment,
                         userAvatarPath = userAvatarPath,
                         aiAvatarPath = aiAvatarPath,
-                        showRetryButton = showRetryButton,
-                        onRetry = onRetry,
+                        onRetryMessage = onRetryMessage,
                     )
                 }
             }

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -373,3 +373,5 @@ system.cpu=CPU
 system.resources.tooltip=Memory: {0} MB | CPU: {1}%
 system.share.feedback=Share feedback
 
+# Error Messages
+error.network=⚠️ Cannot connect to AI service{endpoint}\n\nPlease check:\n• Your internet connection\n• AI service URL (check settings)\n• Firewall settings\n• Service availability

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -373,3 +373,6 @@ system.memory=Speicher
 system.cpu=CPU
 system.resources.tooltip=Speicher: {0} MB | CPU: {1}%
 system.share.feedback=Feedback teilen
+
+# Error messages
+error.network=⚠️ Verbindung zum KI-Dienst{endpoint} nicht möglich\n\nBitte überprüfen Sie:\n• Ihre Internetverbindung\n• Die URL des KI-Dienstes (Einstellungen prüfen)\n• Firewall-Einstellungen\n• Verfügbarkeit des Dienstes

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -374,3 +374,6 @@ system.memory=Memoria
 system.cpu=CPU
 system.resources.tooltip=Memoria: {0} MB | CPU: {1}%
 system.share.feedback=Compartir comentarios
+
+# Error messages
+error.network=⚠️ No se puede conectar al servicio de IA{endpoint}\n\nPor favor, compruebe:\n• Su conexión a Internet\n• La URL del servicio de IA (revise la configuración)\n• La configuración del firewall\n• La disponibilidad del servicio

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -372,3 +372,6 @@ system.memory=Mémoire
 system.cpu=CPU
 system.resources.tooltip=Mémoire : {0} MB | CPU : {1}%
 system.share.feedback=Partager vos commentaires
+
+# Error messages
+error.network=⚠️ Impossible de se connecter au service IA{endpoint}\n\nVeuillez vérifier :\n• Votre connexion Internet\n• L’URL du service IA (vérifiez les paramètres)\n• Les paramètres du pare-feu\n• La disponibilité du service

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -372,3 +372,6 @@ system.memory=メモリ
 system.cpu=CPU
 system.resources.tooltip=メモリ: {0} MB | CPU: {1}%
 system.share.feedback=フィードバックを共有
+
+# Error messages
+error.network=⚠️ AI サービス{endpoint}に接続できません\n\n以下をご確認ください：\n• インターネット接続\n• AI サービスの URL（設定を確認）\n• ファイアウォール設定\n• サービスの稼働状況

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -372,3 +372,6 @@ system.memory=메모리
 system.cpu=CPU
 system.resources.tooltip=메모리: {0} MB | CPU: {1}%
 system.share.feedback=피드백 공유
+
+# Error messages
+error.network=⚠️ AI 서비스{endpoint}에 연결할 수 없습니다\n\n다음을 확인하세요:\n• 인터넷 연결 상태\n• AI 서비스 URL (설정 확인)\n• 방화벽 설정\n• 서비스 사용 가능 여부

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -372,3 +372,6 @@ system.memory=Memória
 system.cpu=CPU
 system.resources.tooltip=Memória: {0} MB | CPU: {1}%
 system.share.feedback=Compartilhar feedback
+
+# Error messages
+error.network=⚠️ Não foi possível conectar ao serviço de IA{endpoint}\n\nVerifique:\n• Sua conexão com a internet\n• A URL do serviço de IA (verifique as configurações)\n• As configurações do firewall\n• A disponibilidade do serviço

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -371,3 +371,6 @@ system.memory=Bộ nhớ
 system.cpu=CPU
 system.resources.tooltip=Bộ nhớ: {0} MB | CPU: {1}%
 system.share.feedback=Chia sẻ phản hồi
+
+# Error messages
+error.network=⚠️ Không thể kết nối tới dịch vụ AI{endpoint}\n\nVui lòng kiểm tra:\n• Kết nối internet của bạn\n• URL dịch vụ AI (kiểm tra cài đặt)\n• Cấu hình tường lửa\n• Trạng thái hoạt động của dịch vụ

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -371,3 +371,6 @@ system.memory=内存
 system.cpu=CPU
 system.resources.tooltip=内存：{0} MB | CPU：{1}%
 system.share.feedback=分享反馈
+
+# Error messages
+error.network=⚠️ 无法连接到 AI 服务{endpoint}\n\n请检查：\n• 您的网络连接\n• AI 服务地址（检查设置）\n• 防火墙设置\n• 服务是否可用

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -372,3 +372,6 @@ system.memory=記憶體
 system.cpu=CPU
 system.resources.tooltip=記憶體：{0} MB | CPU：{1}%
 system.share.feedback=分享回饋
+
+# Error messages
+error.network=⚠️ 無法連線至 AI 服務{endpoint}\n\n請檢查：\n• 您的網路連線\n• AI 服務位址（請確認設定）\n• 防火牆設定\n• 服務是否可用

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.1.3
+projectVersion=1.1.4
 
 # About information
 author=Hai Nguyen

--- a/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatMessage.kt
@@ -17,4 +17,5 @@ data class ChatMessage(
     val editParentId: String? = null,
     val isEdited: Boolean = false,
     val attachments: List<FileAttachment> = emptyList(),
+    val isFailed: Boolean = false,
 )

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
@@ -19,4 +19,5 @@ data class ChatMessageDTO(
     val editParentId: String? = null,
     val isEdited: Boolean = false,
     val attachments: List<FileAttachmentDTO> = emptyList(),
+    val isFailed: Boolean = false,
 )

--- a/shared/src/main/kotlin/io/askimo/core/chat/mapper/ChatMessageMapper.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/mapper/ChatMessageMapper.kt
@@ -28,6 +28,7 @@ object ChatMessageMapper {
         editParentId = this.editParentId,
         isEdited = this.isEdited,
         attachments = this.attachments.map { it.toDTO() },
+        isFailed = this.isFailed,
     )
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -176,16 +176,15 @@ class ChatSessionService(
         return createdMessage
     }
 
-    fun saveAiResponse(sessionId: String, response: String) {
-        addMessage(
-            ChatMessage(
-                id = "",
-                sessionId = sessionId,
-                role = MessageRole.ASSISTANT,
-                content = response,
-            ),
-        )
-    }
+    fun saveAiResponse(sessionId: String, response: String, isFailed: Boolean = false): ChatMessage = addMessage(
+        ChatMessage(
+            id = "",
+            sessionId = sessionId,
+            role = MessageRole.ASSISTANT,
+            content = response,
+            isFailed = isFailed,
+        ),
+    )
 
     /**
      * Get all messages for a session.
@@ -194,6 +193,10 @@ class ChatSessionService(
      * @return List of messages in chronological order
      */
     fun getMessages(sessionId: String): List<ChatMessageDTO> = messageRepository.getMessages(sessionId).toDTOs()
+
+    fun deleteMessage(messageId: String) {
+        messageRepository.deleteMessage(messageId)
+    }
 
     /**
      * Get recent active (non-outdated) messages for a session.

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -167,6 +167,17 @@ class DatabaseManager private constructor(
             } catch (e: Exception) {
                 // Column already exists, ignore the error
             }
+
+            // Migration: Add is_failed column if it doesn't exist (for existing databases)
+            try {
+                stmt.executeUpdate(
+                    """
+                    ALTER TABLE chat_messages ADD COLUMN is_failed INTEGER DEFAULT 0
+                    """,
+                )
+            } catch (e: Exception) {
+                // Column already exists, ignore the error
+            }
         }
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/exception/AskimoException.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/AskimoException.kt
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.exception
+
+/**
+ * Base exception for all Askimo-specific errors.
+ * Provides message keys for localization and distinguishes between user and system errors.
+ */
+sealed class AskimoException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause) {
+    /**
+     * Get the localization message key for this exception.
+     */
+    abstract fun getMessageKey(): String
+
+    /**
+     * Get the arguments to be used with the localization message template.
+     */
+    abstract fun getMessageArgs(): Map<String, String>
+
+    /**
+     * Whether this is a user error (can be fixed by user) or system error (needs support).
+     */
+    abstract fun isUserError(): Boolean
+}

--- a/shared/src/main/kotlin/io/askimo/core/exception/ExceptionHandler.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/ExceptionHandler.kt
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.exception
+
+import io.askimo.core.i18n.LocalizationManager
+import io.askimo.core.logging.logger
+
+/**
+ * Handles exceptions by converting them to localized user-friendly messages.
+ * This centralizes exception handling logic for reusability across CLI and Desktop.
+ */
+object ExceptionHandler {
+    private val log = logger<ExceptionHandler>()
+
+    /**
+     * Handle an exception and return a localized user message.
+     * Also logs the exception appropriately based on whether it's a user or system error.
+     *
+     * @param throwable The exception to handle
+     * @param contextId Optional context ID (session ID, command name, etc.) for logging
+     * @return Localized user-friendly error message
+     */
+    fun handle(
+        throwable: Throwable,
+        contextId: String? = null,
+    ): String {
+        // 1. Classify exception
+        val askimoException = ExceptionMapper.map(throwable)
+
+        // 2. Get localized message (uses LocalizationManager.getCurrentLocale() internally)
+        val localizedMessage = LocalizationManager.getString(
+            askimoException.getMessageKey(),
+        )
+
+        // 3. Replace placeholders with actual values
+        var result = localizedMessage
+        askimoException.getMessageArgs().forEach { (key, value) ->
+            result = result.replace("{$key}", value)
+        }
+
+        // 4. Log appropriately
+        val logPrefix = contextId?.let { "[$it] " } ?: ""
+        if (askimoException.isUserError()) {
+            log.warn("${logPrefix}User error: ${askimoException.message}")
+        } else {
+            log.error("${logPrefix}System error: ${askimoException.message}", askimoException)
+        }
+
+        return result
+    }
+
+    /**
+     * Handle an exception with partial content (useful for streaming responses).
+     * Combines the partial content with the localized error message.
+     *
+     * @param throwable The exception to handle
+     * @param partialContent Partial content that was generated before the error
+     * @param contextId Optional context ID for logging
+     * @return Partial content combined with localized error message
+     */
+    fun handleWithPartialContent(
+        throwable: Throwable,
+        partialContent: String,
+        contextId: String? = null,
+    ): String {
+        val errorMessage = handle(throwable, contextId)
+
+        return if (partialContent.isNotBlank()) {
+            "$partialContent\n\n$errorMessage"
+        } else {
+            errorMessage
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/exception/ExceptionMapper.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/ExceptionMapper.kt
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.exception
+
+import io.askimo.core.logging.logger
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+/**
+ * Maps generic exceptions to Askimo-specific exceptions with user-friendly messages.
+ * This centralizes exception classification logic to distinguish between user errors
+ * and system errors.
+ *
+ * The mapper traverses the entire exception chain to find the root cause, ensuring
+ * that wrapped exceptions (like RuntimeException wrapping ConnectException) are
+ * properly classified based on their underlying cause.
+ */
+object ExceptionMapper {
+    private val log = logger<ExceptionMapper>()
+
+    /**
+     * Map a throwable to an AskimoException by traversing the entire exception chain.
+     * If already an AskimoException, returns it as-is.
+     * Otherwise, analyzes all exceptions in the chain and maps to the appropriate type.
+     *
+     * @param throwable The exception to map
+     * @return An AskimoException (either user or system error)
+     */
+    fun map(throwable: Throwable): AskimoException {
+        if (throwable is AskimoException) {
+            return throwable
+        }
+
+        // Build the complete exception chain
+        val exceptionChain = buildExceptionChain(throwable)
+        val rootCause = exceptionChain.last()
+
+        // Try to match by exception type first (checking all in chain)
+        exceptionChain.forEach { exception ->
+            matchByType(exception)?.let { return it }
+        }
+
+        // Try to match by message pattern (checking all messages in chain)
+        val allMessages = exceptionChain.mapNotNull { it.message }
+        return matchByMessage(allMessages, rootCause)
+    }
+
+    /**
+     * Build the complete exception chain from a throwable.
+     * Traverses through all causes until reaching the root cause.
+     *
+     * @param throwable The starting exception
+     * @return List of exceptions from the top-level to root cause
+     */
+    private fun buildExceptionChain(throwable: Throwable): List<Throwable> {
+        val chain = mutableListOf<Throwable>()
+        var current: Throwable? = throwable
+        val seen = mutableSetOf<Throwable>()
+
+        while (current != null && current !in seen) {
+            chain.add(current)
+            seen.add(current)
+            current = current.cause
+        }
+
+        return chain
+    }
+
+    /**
+     * Try to match an exception by its concrete type.
+     *
+     * @param exception The exception to check
+     * @return An AskimoException if matched, null otherwise
+     */
+    private fun matchByType(exception: Throwable): AskimoException? = when (exception) {
+        // Network exceptions
+        is ConnectException,
+        is UnknownHostException,
+        is NoRouteToHostException,
+        -> NetworkException(cause = exception)
+
+        // Timeout exceptions
+        is SocketTimeoutException,
+        is java.util.concurrent.TimeoutException,
+        -> TimeoutException(timeoutSeconds = 30, cause = exception)
+
+        // Add more type-based matches as needed
+        else -> null
+    }
+
+    /**
+     * Try to match by message patterns across all messages in the exception chain.
+     *
+     * @param messages All messages from the exception chain
+     * @param rootCause The root cause exception to use in the created AskimoException
+     * @return An AskimoException based on message pattern matching
+     */
+    private fun matchByMessage(messages: List<String>, rootCause: Throwable): AskimoException {
+        val combinedMessage = messages.joinToString(" | ")
+
+        return when {
+            // Network connectivity issues
+            combinedMessage.contains("Connection refused", ignoreCase = true) ||
+                combinedMessage.contains("Network is unreachable", ignoreCase = true) ||
+                combinedMessage.contains("Connection timeout", ignoreCase = true) ||
+                combinedMessage.contains("Failed to connect", ignoreCase = true) ||
+                combinedMessage.contains("ConnectException", ignoreCase = true) ->
+                NetworkException(cause = rootCause)
+
+            // Authentication issues
+            combinedMessage.contains("api key", ignoreCase = true) ||
+                combinedMessage.contains("authentication", ignoreCase = true) ||
+                combinedMessage.contains("unauthorized", ignoreCase = true) ||
+                combinedMessage.contains("invalid API key", ignoreCase = true) ||
+                combinedMessage.contains("Incorrect API key", ignoreCase = true) ||
+                combinedMessage.contains("invalid_api_key", ignoreCase = true) ||
+                combinedMessage.contains("401", ignoreCase = true) ->
+                AuthenticationException(cause = rootCause)
+
+            // Model configuration issues
+            combinedMessage.contains("model is required", ignoreCase = true) ||
+                combinedMessage.contains("No model provided", ignoreCase = true) ||
+                combinedMessage.contains("model not found", ignoreCase = true) ||
+                combinedMessage.contains("invalid model", ignoreCase = true) ||
+                combinedMessage.contains("does not exist", ignoreCase = true) ->
+                ModelConfigurationException(
+                    issue = "No model selected or invalid model specified",
+                    cause = rootCause,
+                )
+
+            // Rate limiting
+            combinedMessage.contains("rate limit", ignoreCase = true) ||
+                combinedMessage.contains("quota exceeded", ignoreCase = true) ||
+                combinedMessage.contains("too many requests", ignoreCase = true) ||
+                combinedMessage.contains("429", ignoreCase = true) ->
+                RateLimitException(cause = rootCause)
+
+            // Timeout
+            combinedMessage.contains("timeout", ignoreCase = true) ||
+                combinedMessage.contains("timed out", ignoreCase = true) ->
+                TimeoutException(timeoutSeconds = 30, cause = rootCause)
+
+            // Invalid request
+            combinedMessage.contains("400", ignoreCase = true) ||
+                combinedMessage.contains("bad request", ignoreCase = true) ||
+                combinedMessage.contains("invalid request", ignoreCase = true) ||
+                combinedMessage.contains("malformed", ignoreCase = true) ->
+                InvalidRequestException(
+                    details = combinedMessage.take(200),
+                    cause = rootCause,
+                )
+
+            // Unknown error: System error (contact support)
+            else -> {
+                log.error("Unmapped exception chain: ${rootCause::class.simpleName}", rootCause)
+                SystemException(
+                    message = "${rootCause::class.simpleName}: ${rootCause.message?.take(100) ?: "Unknown"}",
+                    cause = rootCause,
+                )
+            }
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/exception/SystemException.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/SystemException.kt
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.exception
+
+/**
+ * System/internal error that requires support contact.
+ * Used for unexpected errors that cannot be classified or fixed by the user.
+ */
+class SystemException(
+    message: String,
+    cause: Throwable? = null,
+) : AskimoException(message, cause) {
+
+    override fun isUserError() = false
+
+    override fun getMessageKey() = "error.system"
+
+    override fun getMessageArgs() = mapOf(
+        "errorCode" to (message?.take(50) ?: "Unknown error"),
+    )
+}

--- a/shared/src/main/kotlin/io/askimo/core/exception/UserException.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/UserException.kt
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.exception
+
+/**
+ * Base class for user-facing exceptions that can be fixed by the user.
+ * Examples: network issues, authentication errors, configuration problems.
+ */
+sealed class UserException(
+    message: String,
+    cause: Throwable? = null,
+) : AskimoException(message, cause) {
+    override fun isUserError() = true
+}
+
+/**
+ * Network connectivity issues (can't reach API server).
+ */
+class NetworkException(
+    val endpoint: String? = null,
+    cause: Throwable? = null,
+) : UserException("Network connection failed", cause) {
+
+    override fun getMessageKey() = "error.network"
+
+    override fun getMessageArgs() = mapOf(
+        "endpoint" to (endpoint?.let { " at $it" } ?: ""),
+    )
+}
+
+/**
+ * Authentication/API key issues.
+ */
+class AuthenticationException(
+    val provider: String? = null,
+    cause: Throwable? = null,
+) : UserException("Authentication failed", cause) {
+
+    override fun getMessageKey() = "error.authentication"
+
+    override fun getMessageArgs() = mapOf(
+        "provider" to (provider?.let { " for $it" } ?: ""),
+    )
+}
+
+/**
+ * Model configuration issues (no model selected, invalid model).
+ */
+class ModelConfigurationException(
+    val issue: String,
+    cause: Throwable? = null,
+) : UserException("Model configuration error", cause) {
+
+    override fun getMessageKey() = "error.model_configuration"
+
+    override fun getMessageArgs() = mapOf("issue" to issue)
+}
+
+/**
+ * Rate limit or quota exceeded.
+ */
+class RateLimitException(
+    val retryAfterSeconds: Long? = null,
+    cause: Throwable? = null,
+) : UserException("Rate limit exceeded", cause) {
+
+    override fun getMessageKey() = "error.rate_limit"
+
+    override fun getMessageArgs() = mapOf(
+        "retryAfter" to (retryAfterSeconds?.toString() ?: ""),
+    )
+}
+
+/**
+ * Timeout waiting for response.
+ */
+class TimeoutException(
+    val timeoutSeconds: Int,
+    cause: Throwable? = null,
+) : UserException("Request timeout", cause) {
+
+    override fun getMessageKey() = "error.timeout"
+
+    override fun getMessageArgs() = mapOf("timeout" to timeoutSeconds.toString())
+}
+
+/**
+ * Invalid request (malformed input, unsupported features).
+ */
+class InvalidRequestException(
+    val details: String,
+    cause: Throwable? = null,
+) : UserException("Invalid request", cause) {
+
+    override fun getMessageKey() = "error.invalid_request"
+
+    override fun getMessageArgs() = mapOf("details" to details.take(200))
+}


### PR DESCRIPTION
- Introduce new AskimoException hierarchy with SystemException and UserException
- Add isFailed flag to ChatMessage, DTO, mapper, and database schema
- Update ChatSessionService.saveAiResponse to accept isFailed and persist flag
- Extend UI to display retry button and handle retry logic
- Add i18n error messages for network connectivity issues
- Update DatabaseManager to migrate existing tables