### PR TITLE
feat(session-management): Add move-to-project and remove-from-project actions

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/view/components/MoveToProjectMenu.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/components/MoveToProjectMenu.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.DriveFileMove
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.FolderOff
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -44,11 +45,11 @@ import io.askimo.desktop.theme.ComponentColors
  * - Separator
  * - List of existing projects
  *
- * This component is reusable across different views (NavigationSidebar, ChatView, etc.)
+ * This component is reusable across different views (NavigationSidebar, ChatView, ProjectView, etc.)
  *
  * @param projects List of available projects
- * @param onNewProject Callback when "New Project" is selected (for future implementation)
- * @param onSelectProject Callback when a project is selected (for future implementation)
+ * @param onNewProject Callback when "New Project" is selected
+ * @param onSelectProject Callback when a project is selected
  * @param onDismiss Callback to close the parent menu
  */
 @OptIn(ExperimentalFoundationApi::class)
@@ -170,4 +171,37 @@ fun moveToProjectMenuItem(
             }
         }
     }
+}
+
+/**
+ * Reusable "Remove from Project" menu item.
+ * Displays a menu item to remove a session from its current project.
+ *
+ * @param projectName Name of the current project
+ * @param onRemoveFromProject Callback when remove is selected
+ * @param onDismiss Callback to close the parent menu
+ */
+@Composable
+fun removeFromProjectMenuItem(
+    projectName: String,
+    onRemoveFromProject: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    DropdownMenuItem(
+        text = {
+            Text(stringResource("session.remove.from.project", projectName))
+        },
+        onClick = {
+            onDismiss()
+            onRemoveFromProject()
+        },
+        leadingIcon = {
+            Icon(
+                Icons.Default.FolderOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+        },
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+    )
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/components/SessionActionMenu.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/components/SessionActionMenu.kt
@@ -189,16 +189,41 @@ object SessionActionMenu {
 
     /**
      * Menu for project view sessions (no star/unstar).
+     * Includes move to project functionality.
      */
     @Composable
     fun projectViewMenu(
+        sessionId: String,
+        currentProjectId: String,
+        currentProjectName: String,
+        availableProjects: List<Project>,
         onExport: () -> Unit,
         onRename: () -> Unit,
         onDelete: () -> Unit,
+        onMoveToNewProject: () -> Unit,
+        onMoveToExistingProject: (Project) -> Unit,
+        onRemoveFromProject: () -> Unit,
         onDismiss: () -> Unit,
     ) {
         exportMenuItem(onExport = onExport, onDismiss = onDismiss)
         renameMenuItem(onRename = onRename, onDismiss = onDismiss)
+
+        // Move to Project submenu - exclude current project
+        val projectsToShow = availableProjects.filter { it.id != currentProjectId }
+        moveToProjectMenuItem(
+            projects = projectsToShow,
+            onNewProject = onMoveToNewProject,
+            onSelectProject = onMoveToExistingProject,
+            onDismiss = onDismiss,
+        )
+
+        // Remove from Project - separate menu item at same level
+        removeFromProjectMenuItem(
+            projectName = currentProjectName,
+            onRemoveFromProject = onRemoveFromProject,
+            onDismiss = onDismiss,
+        )
+
         deleteMenuItem(onDelete = onDelete, onDismiss = onDismiss)
     }
 

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -111,6 +111,7 @@ project.no.chats=No chats yet. Start a new chat above!
 project.none=No projects yet
 session.move.to.project=Move to Project
 session.move.to.project.new=New Project
+session.remove.from.project=Remove from {0}
 
 # Settings
 settings.title=Settings

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -110,6 +110,7 @@ project.no.chats=Noch keine Chats. Starte oben einen neuen Chat!
 project.none=Noch keine Projekte
 session.move.to.project=In Projekt verschieben
 session.move.to.project.new=Neues Projekt
+session.remove.from.project=Aus {0} entfernen
 
 # Settings
 settings.title=Einstellungen

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -110,6 +110,7 @@ project.no.chats=Aún no hay chats. ¡Inicia un nuevo chat arriba!
 project.none=Aún no hay proyectos
 session.move.to.project=Mover al proyecto
 session.move.to.project.new=Nuevo proyecto
+session.remove.from.project=Eliminar de {0}
 
 # Settings
 settings.title=Configuración

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -110,6 +110,7 @@ project.no.chats=Aucune conversation pour le moment. Commencez-en une nouvelle c
 project.none=Aucun projet pour le moment
 session.move.to.project=Déplacer vers le projet
 session.move.to.project.new=Nouveau projet
+session.remove.from.project=Retirer de {0}
 
 # Settings
 settings.title=Paramètres

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -110,6 +110,7 @@ project.no.chats=まだチャットがありません。上から新しいチャ
 project.none=まだプロジェクトはありません
 session.move.to.project=プロジェクトに移動
 session.move.to.project.new=新しいプロジェクト
+session.remove.from.project={0} から削除
 
 # Settings
 settings.title=設定

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -110,6 +110,7 @@ project.no.chats=아직 채팅이 없습니다. 위에서 새 채팅을 시작�
 project.none=아직 프로젝트가 없습니다
 session.move.to.project=프로젝트로 이동
 session.move.to.project.new=새 프로젝트
+session.remove.from.project={0}에서 제거
 
 # Settings
 settings.title=설정

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -110,6 +110,7 @@ project.no.chats=Ainda não há chats. Comece um novo chat acima!
 project.none=Ainda não há projetos
 session.move.to.project=Mover para o projeto
 session.move.to.project.new=Novo projeto
+session.remove.from.project=Remover de {0}
 
 # Settings
 settings.title=Configurações

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -110,6 +110,7 @@ project.no.chats=Chưa có cuộc trò chuyện nào. Hãy bắt đầu cuộc t
 project.none=Chưa có dự án nào
 session.move.to.project=Chuyển sang dự án
 session.move.to.project.new=Dự án mới
+session.remove.from.project=Xóa khỏi {0}
 
 # Settings
 settings.title=Cài đặt

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -110,6 +110,7 @@ project.no.chats=还没有聊天。请在上方开始新的聊天！
 project.none=暂无项目
 session.move.to.project=移动到项目
 session.move.to.project.new=新建项目
+session.remove.from.project=从 {0} 中移除
 
 # Settings
 settings.title=设置

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -110,6 +110,7 @@ project.no.chats=還沒有聊天。請在上方開始新的聊天！
 project.none=尚無專案
 session.move.to.project=移動至專案
 session.move.to.project.new=新專案
+session.remove.from.project=從 {0} 中移除
 
 # Settings
 settings.title=設定


### PR DESCRIPTION
- Add menu items for moving a session to a new project or removing it from its current project.
- Show dialog for creating a new project when moving a session.
- Emit events to refresh project and session lists after changes.
- Update i18n bundles with new labels for move/remove actions.
- Adjust ProjectView to handle session movement and dialog state.