### PR TITLE
feat(session): persist directive selection in chat session

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -64,6 +64,26 @@ tasks.test {
         environment(key, value)
     }
 
+    // Configure SQLite temp directory for tests
+    val sqliteTmpDir =
+        layout.buildDirectory
+            .dir("sqlite-tmp")
+            .get()
+            .asFile
+    val javaTmpDir =
+        layout.buildDirectory
+            .dir("tmp")
+            .get()
+            .asFile
+
+    doFirst {
+        sqliteTmpDir.mkdirs()
+        javaTmpDir.mkdirs()
+    }
+
+    systemProperty("org.sqlite.tmpdir", sqliteTmpDir.absolutePath)
+    systemProperty("java.io.tmpdir", javaTmpDir.absolutePath)
+
     jvmArgs = listOf("-XX:+EnableDynamicAgentLoading")
 
     if (traceAgent) {
@@ -166,6 +186,26 @@ tasks.named<ProcessResources>("processResources") {
 
 tasks.named<JavaExec>("run") {
     standardInput = System.`in`
+
+    // Configure SQLite temp directory for development runs
+    val sqliteTmpDir =
+        layout.buildDirectory
+            .dir("sqlite-tmp")
+            .get()
+            .asFile
+    val javaTmpDir =
+        layout.buildDirectory
+            .dir("tmp")
+            .get()
+            .asFile
+
+    doFirst {
+        sqliteTmpDir.mkdirs()
+        javaTmpDir.mkdirs()
+    }
+
+    systemProperty("org.sqlite.tmpdir", sqliteTmpDir.absolutePath)
+    systemProperty("java.io.tmpdir", javaTmpDir.absolutePath)
 }
 
 tasks.register<Sync>("syncGraalMetadata") {

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -86,6 +86,24 @@ compose.desktop {
     application {
         mainClass = "io.askimo.desktop.MainKt"
 
+        // Configure JVM args for SQLite temp directory
+        val sqliteTmpDir =
+            layout.buildDirectory
+                .dir("sqlite-tmp")
+                .get()
+                .asFile
+        val javaTmpDir =
+            layout.buildDirectory
+                .dir("tmp")
+                .get()
+                .asFile
+
+        jvmArgs +=
+            listOf(
+                "-Dorg.sqlite.tmpdir=${sqliteTmpDir.absolutePath}",
+                "-Djava.io.tmpdir=${javaTmpDir.absolutePath}",
+            )
+
         nativeDistributions {
             targetFormats(
                 TargetFormat.Dmg,
@@ -126,6 +144,26 @@ tasks.withType<Zip> {
 
 tasks.test {
     useJUnitPlatform()
+
+    // Configure SQLite temp directory for tests
+    val sqliteTmpDir =
+        layout.buildDirectory
+            .dir("sqlite-tmp")
+            .get()
+            .asFile
+    val javaTmpDir =
+        layout.buildDirectory
+            .dir("tmp")
+            .get()
+            .asFile
+
+    doFirst {
+        sqliteTmpDir.mkdirs()
+        javaTmpDir.mkdirs()
+    }
+
+    systemProperty("org.sqlite.tmpdir", sqliteTmpDir.absolutePath)
+    systemProperty("java.io.tmpdir", javaTmpDir.absolutePath)
 }
 kotlin {
     jvmToolchain(21)

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/ChatViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/ChatViewModel.kt
@@ -902,7 +902,20 @@ class ChatViewModel(
      */
     fun setDirective(directiveId: String?) {
         selectedDirective = directiveId
-        // TODO: Persist directive selection to the session if needed
+
+        val sessionId = currentSessionId.value
+        if (sessionId != null) {
+            scope.launch {
+                try {
+                    withContext(Dispatchers.IO) {
+                        chatSessionService.updateSessionDirective(sessionId, directiveId)
+                    }
+                    log.debug("Updated directive for session $sessionId to $directiveId")
+                } catch (e: Exception) {
+                    log.error("Failed to update session directive: ${e.message}", e)
+                }
+            }
+        }
     }
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-graalvm-plugin = "0.11.1"
+graalvm-plugin = "0.11.3"
 jline = "3.30.6"
 langchain4j = "1.9.1"
 commonmark = "0.27.0"
@@ -25,6 +25,8 @@ coil = "3.3.0"
 koin = "4.1.1"
 jlatexmath = "1.0.7"
 tika = "3.2.3"
+lucene = "10.3.2"
+jvector = "1.9.1-beta17"
 
 [libraries]
 # JLine
@@ -74,6 +76,13 @@ logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.
 tika-core = { group = "org.apache.tika", name = "tika-core", version.ref = "tika" }
 tika-parser-pdf = { group = "org.apache.tika", name = "tika-parser-pdf-module", version.ref = "tika" }
 tika-parser-microsoft = { group = "org.apache.tika", name = "tika-parser-microsoft-module", version.ref = "tika" }
+
+# Apache Lucene
+lucene-core = { group = "org.apache.lucene", name = "lucene-core", version.ref = "lucene" }
+lucene-queryparser = { group = "org.apache.lucene", name = "lucene-queryparser", version.ref = "lucene" }
+
+# LangChain4j JVector
+langchain4j-jvector = { group = "dev.langchain4j", name = "langchain4j-community-jvector", version.ref = "jvector" }
 
 # Database and MCP SDK
 postgresql = { group = "org.postgresql", name = "postgresql", version.ref = "postgresql" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -23,10 +23,9 @@ dependencies {
     api(libs.postgresql)
     api(libs.langchain4j.pgvector)
     api(libs.testcontainers.postgresql)
-    // Lucene embedding store (community)
-    api("dev.langchain4j:langchain4j-community-lucene:1.9.1-beta17")
-    // JVector embedding store (community)
-    api("dev.langchain4j:langchain4j-community-jvector:1.9.1-beta17")
+    api(libs.lucene.core)
+    api(libs.lucene.queryparser)
+    api(libs.langchain4j.jvector)
     api(libs.jackson.module.kotlin)
     api(libs.jackson.dataformat.yaml)
     api(libs.sqlite.jdbc)
@@ -57,6 +56,26 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+
+    // Configure SQLite temp directory for tests
+    val sqliteTmpDir =
+        layout.buildDirectory
+            .dir("sqlite-tmp")
+            .get()
+            .asFile
+    val javaTmpDir =
+        layout.buildDirectory
+            .dir("tmp")
+            .get()
+            .asFile
+
+    doFirst {
+        sqliteTmpDir.mkdirs()
+        javaTmpDir.mkdirs()
+    }
+
+    systemProperty("org.sqlite.tmpdir", sqliteTmpDir.absolutePath)
+    systemProperty("java.io.tmpdir", javaTmpDir.absolutePath)
 }
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
- Add updateSessionDirective in ChatSessionService to set or clear directive
- Persist directive selection from ChatViewModel to session on user change
- Configure SQLite temp directory for tests and desktop builds
- Update Gradle dependencies: bump graalvm-plugin, add Lucene/JVector libraries
- Simplify shared build.gradle to use libs.lucene.core only
- Ensure proper logging and error handling when updating session directive