### PR TITLE
feat(provider-selection): add setup guide link for selected provider

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/view/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/settings/ProviderSelectionDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Help
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
@@ -318,6 +319,36 @@ fun providerSelectionDialog(
                                         )
                                     }
                                 }
+                            }
+                        }
+
+                        // Help link for provider setup instructions
+                        if (viewModel.selectedProvider != null) {
+                            TextButton(
+                                onClick = {
+                                    try {
+                                        val providerName = viewModel.selectedProvider?.name?.lowercase() ?: return@TextButton
+                                        Desktop.getDesktop().browse(
+                                            URI("https://askimo.chat/docs/desktop/providers/$providerName/"),
+                                        )
+                                    } catch (_: Exception) {
+                                        // Silently fail if browser cannot be opened
+                                    }
+                                },
+                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                contentPadding = PaddingValues(0.dp),
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.Help,
+                                    contentDescription = "Help",
+                                    modifier = Modifier.size(16.dp),
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                                Text(
+                                    text = stringResource("provider.setup.guide", viewModel.selectedProvider?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
                             }
                         }
 

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -389,6 +389,7 @@ provider.setup.required.button=Set Up Provider
 provider.select.prompt=Select a provider:
 provider.configure.prompt=Configure provider:
 provider.choose.placeholder=Choose a provider...
+provider.setup.guide=How to set up {0}
 provider.apikey.stored=API key stored securely
 provider.apikey.enter=Enter API key
 provider.apikey.already.stored=Already stored

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -390,6 +390,7 @@ provider.setup.required.button=Konfigurieren
 provider.select.prompt=Anbieter auswählen:
 provider.configure.prompt=Konfigurieren:
 provider.choose.placeholder=Anbieter auswählen...
+provider.setup.guide=So richten Sie {0} ein
 provider.apikey.stored=API-Schlüssel wurde sicher gespeichert
 provider.apikey.enter=API-Schlüssel eingeben
 provider.apikey.already.stored=Bereits gespeichert

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -390,6 +390,7 @@ provider.setup.required.button=Configurar
 provider.select.prompt=Seleccionar proveedor:
 provider.configure.prompt=Configurar:
 provider.choose.placeholder=Escoge un proveedor...
+provider.setup.guide=Cómo configurar {0}
 provider.apikey.stored=Clave API almacenada de forma segura
 provider.apikey.enter=Ingresar clave API
 provider.apikey.already.stored=Ya almacenada

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -389,6 +389,7 @@ provider.setup.required.button=Configurer
 provider.select.prompt=Sélectionner un fournisseur :
 provider.configure.prompt=Configurer :
 provider.choose.placeholder=Choisissez un fournisseur...
+provider.setup.guide=Comment configurer {0}
 provider.apikey.stored=Clé API stockée en toute sécurité
 provider.apikey.enter=Entrer la clé API
 provider.apikey.already.stored=Déjà stockée

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -389,6 +389,7 @@ provider.setup.required.button=設定
 provider.select.prompt=プロバイダーを選択:
 provider.configure.prompt=設定:
 provider.choose.placeholder=プロバイダーを選択...
+provider.setup.guide={0}の設定方法
 provider.apikey.stored=API キーは安全に保存されています
 provider.apikey.enter=API キー入力
 provider.apikey.already.stored=すでに保存済み

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -389,6 +389,7 @@ provider.setup.required.button=설정
 provider.select.prompt=제공자 선택:
 provider.configure.prompt=구성:
 provider.choose.placeholder=제공자 선택...
+provider.setup.guide={0}를 설정하는 방법
 provider.apikey.stored=API 키가 안전하게 저장되었습니다
 provider.apikey.enter=API 키 입력
 provider.apikey.already.stored=이미 저장됨

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -389,6 +389,7 @@ provider.setup.required.button=Configurar
 provider.select.prompt=Selecionar provedor:
 provider.configure.prompt=Configurar provedor:
 provider.choose.placeholder=Escolha um provedor...
+provider.setup.guide=Como configurar {0}
 provider.apikey.stored=API Key armazenada com segurança
 provider.apikey.enter=Digite a API Key
 provider.apikey.already.stored=Já armazenada

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -388,6 +388,7 @@ provider.setup.required.button=Thiết lập
 provider.select.prompt=Chọn nhà cung cấp:
 provider.configure.prompt=Cấu hình:
 provider.choose.placeholder=Chọn nhà cung cấp...
+provider.setup.guide=Cách thiết lập {0}
 provider.apikey.stored=API key đã lưu an toàn
 provider.apikey.enter=Nhập API key
 provider.apikey.already.stored=Đã lưu

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -388,6 +388,7 @@ provider.setup.required.button=设置
 provider.select.prompt=选择服务商：
 provider.configure.prompt=配置：
 provider.choose.placeholder=请选择服务商...
+provider.setup.guide=如何设置 {0}
 provider.apikey.stored=API Key 已安全保存
 provider.apikey.enter=输入 API Key
 provider.apikey.already.stored=已保存

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -389,6 +389,7 @@ provider.setup.required.button=設定
 provider.select.prompt=選擇供應商：
 provider.configure.prompt=設定供應商：
 provider.choose.placeholder=選擇供應商...
+provider.setup.guide=如何設定 {0}
 provider.apikey.stored=API 金鑰已安全儲存
 provider.apikey.enter=輸入 API 金鑰
 provider.apikey.already.stored=已儲存


### PR DESCRIPTION
- Show a contextual help action when a provider is selected
- Add localized "How to set up {provider}" label across supported languages
- Improve discoverability of provider setup instructions from the dialog