### PR TITLE
feat(rag): emit indexing events and enrich chunks with line metadata

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -704,7 +704,8 @@
     "name": "com.github.dockerjava.api.model.PeerNode",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true
+    "queryAllDeclaredConstructors": true,
+    "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
   {
     "name": "com.github.dockerjava.api.model.Ports",
@@ -958,6 +959,7 @@
       { "name": "getMessages", "parameterTypes": [] },
       { "name": "getMetadata", "parameterTypes": [] },
       { "name": "getModel", "parameterTypes": [] },
+      { "name": "getOutputFormat", "parameterTypes": [] },
       { "name": "getStopSequences", "parameterTypes": [] },
       { "name": "getSystem", "parameterTypes": [] },
       { "name": "getTemperature", "parameterTypes": [] },
@@ -1236,6 +1238,7 @@
       { "name": "logprobs", "parameterTypes": [] },
       { "name": "maxOutputTokens", "parameterTypes": [] },
       { "name": "presencePenalty", "parameterTypes": [] },
+      { "name": "responseJsonSchema", "parameterTypes": [] },
       { "name": "responseLogprobs", "parameterTypes": [] },
       { "name": "responseMimeType", "parameterTypes": [] },
       { "name": "responseSchema", "parameterTypes": [] },
@@ -1300,7 +1303,8 @@
     "name": "dev.langchain4j.model.openai.internal.chat.AssistantMessage",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true
+    "queryAllDeclaredConstructors": true,
+    "methods": [{ "name": "customParameters", "parameterTypes": [] }]
   },
   {
     "name": "dev.langchain4j.model.openai.internal.chat.AssistantMessage$Builder",
@@ -1396,12 +1400,6 @@
     "name": "dev.langchain4j.model.openai.internal.chat.Role",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true
-  },
-  {
-    "name": "dev.langchain4j.model.openai.internal.chat.SystemMessage",
-    "allDeclaredFields": true,
-    "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true
   },
   {
     "name": "dev.langchain4j.model.openai.internal.chat.Tool",
@@ -3292,6 +3290,15 @@
       },
       { "name": "readFile", "parameterTypes": ["java.lang.String"] },
       {
+        "name": "totalSizeByType",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String",
+          "java.lang.String",
+          "java.lang.Boolean"
+        ]
+      },
+      {
         "name": "writeFile",
         "parameterTypes": ["java.lang.String", "java.lang.String"]
       }
@@ -4280,7 +4287,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$zAoTLCkA",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$Eh9DsdEp",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/components/FooterBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/components/FooterBar.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import io.askimo.core.VersionInfo
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.getConfigInfo
 import io.askimo.core.event.Event
@@ -241,6 +242,13 @@ private fun notificationIcon(onShowUpdateDetails: () -> Unit) {
 
     LaunchedEffect(Unit) {
         EventBus.userEvents.collect { event ->
+            // Skip IndexingInProgressEvent unless developer mode is enabled and active
+            if (event is IndexingInProgressEvent) {
+                if (!(AppConfig.developer.enabled && AppConfig.developer.active)) {
+                    return@collect // Skip this event
+                }
+            }
+
             // Special handling for IndexingInProgressEvent: replace old progress event for same project
             if (event is IndexingInProgressEvent) {
                 // Find and remove any existing progress event for the same project

--- a/desktop/src/test/resources/logback-test.xml
+++ b/desktop/src/test/resources/logback-test.xml
@@ -23,23 +23,12 @@
         </encoder>
     </appender>
 
-    <!-- Suppress third-party library logs except errors -->
-    <logger name="org.eclipse.jetty" level="ERROR"/>
-    <logger name="org.testcontainers" level="ERROR"/>
-    <logger name="com.zaxxer.hikari" level="ERROR"/>
-    <logger name="org.jetbrains.exposed" level="ERROR"/>
-    <logger name="org.jetbrains" level="ERROR"/>
-    <logger name="io.netty" level="ERROR"/>
-    <logger name="org.apache.http" level="ERROR"/>
-    <logger name="kotlinx.coroutines" level="ERROR"/>
-
-    <!-- Askimo application logging (more verbose for tests) -->
-    <logger name="io.askimo" level="DEBUG"/>
-
-    <!-- Root logger configuration for tests -->
-    <root level="WARN">
+    <root level="ERROR">
         <appender-ref ref="CONSOLE" />
         <appender-ref ref="FILE" />
     </root>
+
+    <!-- Askimo application logging - controlled by LOGBACK_LEVEL env var -->
+    <logger name="io.askimo" level="${LOGBACK_LEVEL:-DEBUG}" />
 </configuration>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.2.0
+projectVersion=1.2.1
 
 # About information
 author=Hai Nguyen

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 graalvm-plugin = "0.11.3"
 jline = "3.30.6"
-langchain4j = "1.9.1"
+langchain4j = "1.10.0"
 commonmark = "0.27.0"
 kotlinxSerializationJson = "1.9.0"
 kotlinxCoroutines = "1.9.0"
@@ -24,7 +24,7 @@ koin = "4.1.1"
 jlatexmath = "1.0.7"
 tika = "3.2.3"
 lucene = "10.3.2"
-langchain4j-extra = "1.9.1-beta17"
+langchain4j-extra = "1.10.0-beta18"
 caffeine = "3.2.3"
 
 [libraries]

--- a/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
@@ -5,9 +5,7 @@
 package io.askimo.core.context
 
 import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.input.PromptTemplate
 import dev.langchain4j.rag.DefaultRetrievalAugmentor
-import dev.langchain4j.rag.content.injector.DefaultContentInjector
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.providers.ChatClient
@@ -16,6 +14,7 @@ import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.NoopProviderSettings
 import io.askimo.core.providers.ProviderRegistry
 import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.rag.MetadataAwareContentInjector
 import java.util.Locale
 
 /**
@@ -193,21 +192,6 @@ class AppContext(
         .builder()
         .contentRetriever(retriever)
         .contentInjector(
-            DefaultContentInjector
-                .builder()
-                .promptTemplate(
-                    PromptTemplate.from(
-                        """
-                        You are grounded by the following retrieved context. Prefer it over general knowledge.
-                        If the answer is not present, say so.
-
-                        === Retrieved Context ===
-                        {{contents}}
-                        === End Context ===
-
-                        {{userMessage}}
-                        """.trimIndent(),
-                    ),
-                ).build(),
+            MetadataAwareContentInjector(),
         ).build()
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
 import dev.langchain4j.rag.RetrievalAugmentor
 import dev.langchain4j.service.AiServices
 import io.askimo.core.context.ExecutionMode
+import io.askimo.core.logging.logger
 import io.askimo.core.providers.ChatClient
 import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.ChatRequestTransformers
@@ -20,6 +21,9 @@ import io.askimo.core.util.SystemPrompts.systemMessage
 import io.askimo.tools.fs.LocalFsTools
 
 class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
+
+    private val log = logger<AnthropicModelFactory>()
+
     override fun availableModels(settings: AnthropicSettings): List<String> = listOf(
         "claude-opus-4-1",
         "claude-opus-4-0",
@@ -44,6 +48,8 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
                 .builder()
                 .apiKey(safeApiKey(settings.apiKey))
                 .modelName(model)
+                .logger(log)
+                .logRequests(log.isDebugEnabled)
                 .baseUrl(settings.baseUrl)
                 .build()
 
@@ -83,7 +89,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
                     ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(sessionId, chatRequest, memoryId)
                 }
         if (retrievalAugmentor != null) {
-            builder.retrievalAugmentor(retrievalAugmentor)
+            builder.retrievalAugmentor(retrievalAugmentor).storeRetrievedContentInChatMemory(false)
         }
 
         return builder.build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -77,6 +77,8 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
                 .builder()
                 .baseUrl("${settings.baseUrl}/v1")
                 .modelName(model)
+                .logger(log)
+                .logRequests(log.isDebugEnabled)
                 .timeout(Duration.ofMinutes(5))
                 .apply {
                     val s = samplingFor(settings.presets.style)
@@ -120,7 +122,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
                     ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(sessionId, chatRequest, memoryId)
                 }
         if (retrievalAugmentor != null) {
-            builder.retrievalAugmentor(retrievalAugmentor)
+            builder.retrievalAugmentor(retrievalAugmentor).storeRetrievedContentInChatMemory(false)
         }
         return builder.build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -58,6 +58,8 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
                 .builder()
                 .apiKey(safeApiKey(settings.apiKey))
                 .modelName(model)
+                .logger(log)
+                .logRequests(log.isDebugEnabled)
                 .apply {
                     if (supportsSampling(model)) {
                         val s = samplingFor(settings.presets.style)
@@ -115,7 +117,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
                     ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(sessionId, chatRequest, memoryId)
                 }
         if (retrievalAugmentor != null) {
-            builder.retrievalAugmentor(retrievalAugmentor)
+            builder.retrievalAugmentor(retrievalAugmentor).storeRetrievedContentInChatMemory(false)
         }
 
         return builder.build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.rag.RetrievalAugmentor
 import dev.langchain4j.service.AiServices
 import io.askimo.core.context.ExecutionMode
+import io.askimo.core.logging.logger
 import io.askimo.core.providers.ChatClient
 import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.ChatRequestTransformers
@@ -24,6 +25,8 @@ import java.net.http.HttpClient
 import java.time.Duration
 
 class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
+
+    private val log = logger<LmStudioModelFactory>()
 
     override fun availableModels(settings: LmStudioSettings): List<String> = fetchModels(
         apiKey = "lm-studio",
@@ -53,6 +56,8 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
                 .baseUrl(settings.baseUrl)
                 .apiKey("lm-studio")
                 .modelName(model)
+                .logger(log)
+                .logRequests(log.isDebugEnabled)
                 .timeout(Duration.ofMinutes(5))
                 .httpClientBuilder(jdkHttpClientBuilder)
                 .apply {
@@ -97,7 +102,7 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
                     ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(sessionId, chatRequest, memoryId)
                 }
         if (retrievalAugmentor != null) {
-            builder.retrievalAugmentor(retrievalAugmentor)
+            builder.retrievalAugmentor(retrievalAugmentor).storeRetrievedContentInChatMemory(false)
         }
 
         return builder.build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
@@ -93,7 +93,7 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
                     ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(sessionId, chatRequest, memoryId)
                 }
         if (retrievalAugmentor != null) {
-            builder.retrievalAugmentor(retrievalAugmentor)
+            builder.retrievalAugmentor(retrievalAugmentor).storeRetrievedContentInChatMemory(false)
         }
 
         return builder.build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -76,6 +76,8 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
                 .baseUrl("${settings.baseUrl}/v1")
                 .modelName(model)
                 .timeout(Duration.ofMinutes(5))
+                .logger(log)
+                .logRequests(log.isDebugEnabled)
                 .apply {
                     val s = samplingFor(settings.presets.style)
                     temperature(s.temperature)
@@ -120,7 +122,7 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
                     ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(sessionId, chatRequest, memoryId)
                 }
         if (retrievalAugmentor != null) {
-            builder.retrievalAugmentor(retrievalAugmentor)
+            builder.retrievalAugmentor(retrievalAugmentor).storeRetrievedContentInChatMemory(false)
         }
         return builder.build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -72,6 +72,8 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
                 .builder()
                 .apiKey(safeApiKey(settings.apiKey))
                 .modelName(model)
+                .logger(log)
+                .logRequests(log.isDebugEnabled)
                 .apply {
                     if (supportsSampling(model)) {
                         val s = samplingFor(settings.presets.style)
@@ -117,6 +119,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
                 }
         if (retrievalAugmentor != null) {
             builder.retrievalAugmentor(retrievalAugmentor)
+                .storeRetrievedContentInChatMemory(false)
         }
         return builder.build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/rag/MetadataAwareContentInjector.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/MetadataAwareContentInjector.kt
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.rag
+
+import dev.langchain4j.data.message.ChatMessage
+import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.rag.content.Content
+import dev.langchain4j.rag.content.injector.ContentInjector
+import io.askimo.core.logging.logger
+
+/**
+ * ContentInjector that includes metadata (file paths, line numbers) when formatting
+ * retrieved chunks into the prompt. This allows the AI to cite exact sources.
+ */
+class MetadataAwareContentInjector : ContentInjector {
+
+    private val log = logger<MetadataAwareContentInjector>()
+
+    override fun inject(
+        contents: List<Content?>?,
+        chatMessage: ChatMessage?,
+    ): ChatMessage? {
+        if (contents.isNullOrEmpty() || chatMessage == null) {
+            log.debug("No contents to inject or null chat message")
+            return chatMessage
+        }
+
+        // Only process UserMessage - other message types pass through unchanged
+        if (chatMessage !is UserMessage) {
+            log.debug("Skipping non-user message type: {}", chatMessage.type())
+            return chatMessage
+        }
+
+        val validContents = contents.filterNotNull()
+        if (validContents.isEmpty()) {
+            log.debug("All contents were null")
+            return chatMessage
+        }
+
+        // Format context with metadata
+        val formattedContext = validContents.joinToString("\n\n---\n\n") { content ->
+            val segment = content.textSegment()
+            val meta = segment.metadata()
+
+            buildString {
+                // Source citation header
+                append("**Source:** ")
+                val fileName = meta.getString("file_name") ?: "unknown"
+                append("`$fileName`")
+
+                // Add file path if available
+                val filePath = meta.getString("file_path")
+                if (filePath != null && filePath != fileName) {
+                    append(" (`$filePath`)")
+                }
+
+                // Add line numbers if available
+                val startLine = meta.getInteger("start_line")
+                val endLine = meta.getInteger("end_line")
+                if (startLine != null && endLine != null) {
+                    append(" (lines $startLine-$endLine)")
+                }
+
+                append("\n\n")
+                append(segment.text())
+            }
+        }
+
+        val enhancedPrompt = """
+            |Use the following context to answer the question.
+            |
+            |IMPORTANT: When answering, you MUST cite your sources by referencing:
+            |- The file name (shown as `filename`)
+            |- Line numbers (if provided, shown as "lines X-Y")
+            |
+            |Format citations like: "According to `filename` (lines X-Y), ..." or "In `filename`, ..."
+            |
+            |Context:
+            |
+            |$formattedContext
+            |
+            |---
+            |
+            |Question: ${chatMessage.singleText() ?: ""}
+        """.trimMargin()
+
+        log.debug("Injected {} chunks with metadata into prompt", validContents.size)
+
+        return UserMessage.from(enhancedPrompt)
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/rag/extraction/LocalFileContentExtractor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/extraction/LocalFileContentExtractor.kt
@@ -41,4 +41,13 @@ class LocalFileContentExtractor : ContentExtractor<FileResourceIdentifier> {
             null
         }
     }
+
+    /**
+     * Check if a file is a text-based file where line numbers are meaningful.
+     * Returns false for binary files like PDF, DOCX, etc.
+     */
+    fun isTextFile(resourceIdentifier: FileResourceIdentifier): Boolean {
+        val file = resourceIdentifier.filePath.toFile()
+        return UtilFileContentExtractor.isTextFile(file)
+    }
 }


### PR DESCRIPTION
- Trigger project indexing/re-indexing when knowledge sources are added or changed
- Add metadata-aware content injector to preserve chunk metadata in prompts
- Store start/end line numbers for text-based file chunks to improve citations
- Skip noisy indexing-in-progress notifications unless developer mode is active
- Upgrade langchain4j to 1.10.0 and adjust native-image reflection config
- Reduce test log noise while allowing LOGBACK_LEVEL override for debugging