### PR TITLE
feat(rag): add advanced RAG configuration and embedding model settings

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/chat/service/ChatSessionServiceIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/chat/service/ChatSessionServiceIT.kt
@@ -60,7 +60,6 @@ class ChatSessionServiceIT {
             service = ChatSessionService(
                 sessionRepository = sessionRepository,
                 messageRepository = messageRepository,
-                directiveRepository = directiveRepository,
                 sessionMemoryRepository = sessionMemoryRepository,
                 projectRepository = projectRepository,
                 appContext = appContext,

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/settings/AdvancedSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/settings/AdvancedSettingsSection.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,7 +41,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
+import io.askimo.core.config.AppConfig
 import io.askimo.core.logging.LogLevel
 import io.askimo.core.logging.LoggingService
 import io.askimo.desktop.i18n.stringResource
@@ -82,6 +85,9 @@ fun advancedSettingsSection() {
         logViewerCard(
             onViewLogs = { showLogViewerDialog = true },
         )
+
+        // RAG Configuration Section
+        ragConfigurationSection()
 
         // Developer Mode Section
         developerModeSection()
@@ -348,6 +354,473 @@ private fun developerModeSection() {
                     onCheckedChange = { DeveloperModePreferences.setActive(it) },
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ragConfigurationSection() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = ComponentColors.bannerCardColors(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            // Title
+            Text(
+                text = stringResource("settings.rag.title"),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+
+            // Description
+            Text(
+                text = stringResource("settings.rag.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+            )
+
+            // Vector Search Max Results
+            ragIntField(
+                label = stringResource("settings.rag.vector.max.results"),
+                hint = stringResource("settings.rag.vector.max.results.hint"),
+                value = AppConfig.rag.vectorSearchMaxResults,
+                onValueChange = { newValue ->
+                    AppConfig.updateField("rag.vectorSearchMaxResults", newValue)
+                },
+            )
+
+            // Vector Search Min Score
+            ragDoubleField(
+                label = stringResource("settings.rag.vector.min.score"),
+                hint = stringResource("settings.rag.vector.min.score.hint"),
+                value = AppConfig.rag.vectorSearchMinScore,
+                onValueChange = { newValue ->
+                    AppConfig.updateField("rag.vectorSearchMinScore", newValue)
+                },
+            )
+
+            // Hybrid Max Results
+            ragIntField(
+                label = stringResource("settings.rag.hybrid.max.results"),
+                hint = stringResource("settings.rag.hybrid.max.results.hint"),
+                value = AppConfig.rag.hybridMaxResults,
+                onValueChange = { newValue ->
+                    AppConfig.updateField("rag.hybridMaxResults", newValue)
+                },
+            )
+
+            // Rank Fusion Constant
+            ragIntField(
+                label = stringResource("settings.rag.rank.fusion.constant"),
+                hint = stringResource("settings.rag.rank.fusion.constant.hint"),
+                value = AppConfig.rag.rankFusionConstant,
+                onValueChange = { newValue ->
+                    AppConfig.updateField("rag.rankFusionConstant", newValue)
+                },
+            )
+
+            // Divider before embedding configuration
+            androidx.compose.material3.HorizontalDivider(
+                modifier = Modifier.padding(vertical = 8.dp),
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f),
+            )
+
+            // Embedding Configuration Section
+            Text(
+                text = stringResource("settings.rag.embedding.title"),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+
+            Text(
+                text = stringResource("settings.rag.embedding.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+            )
+
+            // Max Characters Per Chunk
+            ragIntField(
+                label = stringResource("settings.rag.embedding.max.chars.per.chunk"),
+                hint = stringResource("settings.rag.embedding.max.chars.per.chunk.hint"),
+                value = AppConfig.embedding.maxCharsPerChunk,
+                onValueChange = { newValue ->
+                    AppConfig.updateField("embedding.maxCharsPerChunk", newValue)
+                },
+            )
+
+            // Chunk Overlap
+            ragIntField(
+                label = stringResource("settings.rag.embedding.chunk.overlap"),
+                hint = stringResource("settings.rag.embedding.chunk.overlap.hint"),
+                value = AppConfig.embedding.chunkOverlap,
+                onValueChange = { newValue ->
+                    AppConfig.updateField("embedding.chunkOverlap", newValue)
+                },
+            )
+
+            // Preferred Dimension (optional)
+            ragOptionalIntField(
+                label = stringResource("settings.rag.embedding.preferred.dim"),
+                hint = stringResource("settings.rag.embedding.preferred.dim.hint"),
+                value = AppConfig.embedding.preferredDim,
+                onValueChange = { newValue ->
+                    AppConfig.updateField("embedding.preferredDim", newValue ?: "")
+                },
+            )
+
+            // Divider before embedding models section
+            androidx.compose.material3.HorizontalDivider(
+                modifier = Modifier.padding(vertical = 8.dp),
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f),
+            )
+
+            // Embedding Models Section
+            Text(
+                text = stringResource("settings.rag.embedding.models"),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+
+            Text(
+                text = stringResource("settings.rag.embedding.models.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+            )
+
+            // Embedding Model Selector
+            ragEmbeddingModelSelector()
+        }
+    }
+}
+
+@Composable
+private fun ragIntField(
+    label: String,
+    hint: String,
+    value: Int,
+    onValueChange: (Int) -> Unit,
+) {
+    var textValue by remember { mutableStateOf(value.toString()) }
+    var lastValidValue by remember { mutableStateOf(value) }
+
+    LaunchedEffect(value) {
+        // Update text when external value changes (e.g., reload)
+        if (value != lastValidValue) {
+            textValue = value.toString()
+            lastValidValue = value
+        }
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        androidx.compose.material3.OutlinedTextField(
+            value = textValue,
+            onValueChange = { newValue ->
+                textValue = newValue
+                // Only save if it's a valid integer
+                newValue.toIntOrNull()?.let { validInt ->
+                    lastValidValue = validInt
+                    onValueChange(validInt)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            textStyle = MaterialTheme.typography.bodyMedium,
+            singleLine = true,
+            isError = textValue.toIntOrNull() == null,
+            colors = ComponentColors.outlinedTextFieldColors(),
+        )
+        Text(
+            text = hint,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+        )
+    }
+}
+
+@Composable
+private fun ragDoubleField(
+    label: String,
+    hint: String,
+    value: Double,
+    onValueChange: (Double) -> Unit,
+) {
+    var textValue by remember { mutableStateOf(value.toString()) }
+    var lastValidValue by remember { mutableStateOf(value) }
+
+    LaunchedEffect(value) {
+        // Update text when external value changes (e.g., reload)
+        if (value != lastValidValue) {
+            textValue = value.toString()
+            lastValidValue = value
+        }
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        androidx.compose.material3.OutlinedTextField(
+            value = textValue,
+            onValueChange = { newValue ->
+                textValue = newValue
+                // Only save if it's a valid double
+                newValue.toDoubleOrNull()?.let { validDouble ->
+                    lastValidValue = validDouble
+                    onValueChange(validDouble)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            textStyle = MaterialTheme.typography.bodyMedium,
+            singleLine = true,
+            isError = textValue.toDoubleOrNull() == null,
+            colors = ComponentColors.outlinedTextFieldColors(),
+        )
+        Text(
+            text = hint,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+        )
+    }
+}
+
+@Composable
+private fun ragOptionalIntField(
+    label: String,
+    hint: String,
+    value: Int?,
+    onValueChange: (Int?) -> Unit,
+) {
+    var textValue by remember { mutableStateOf(value?.toString() ?: "") }
+    var lastValidValue by remember { mutableStateOf(value) }
+
+    LaunchedEffect(value) {
+        // Update text when external value changes (e.g., reload)
+        if (value != lastValidValue) {
+            textValue = value?.toString() ?: ""
+            lastValidValue = value
+        }
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        androidx.compose.material3.OutlinedTextField(
+            value = textValue,
+            onValueChange = { newValue ->
+                textValue = newValue
+                // If empty, set to null
+                if (newValue.isBlank()) {
+                    lastValidValue = null
+                    onValueChange(null)
+                } else {
+                    // Only save if it's a valid integer
+                    newValue.toIntOrNull()?.let { validInt ->
+                        lastValidValue = validInt
+                        onValueChange(validInt)
+                    }
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            textStyle = MaterialTheme.typography.bodyMedium,
+            singleLine = true,
+            isError = textValue.isNotBlank() && textValue.toIntOrNull() == null,
+            colors = ComponentColors.outlinedTextFieldColors(),
+        )
+        Text(
+            text = hint,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+        )
+    }
+}
+
+@Composable
+private fun ragEmbeddingModelSelector() {
+    // AI Provider options
+    val providers = listOf(
+        "OpenAI" to true,
+        "Anthropic" to false,
+        "Gemini" to true,
+        "X AI" to false,
+        "Ollama" to true,
+        "Docker" to true,
+        "LocalAI" to true,
+        "LMStudio" to true,
+    )
+
+    var selectedProvider by remember { mutableStateOf(providers[0].first) }
+    var dropdownExpanded by remember { mutableStateOf(false) }
+
+    // Get current value based on selected provider
+    val currentValue = when (selectedProvider) {
+        "OpenAI" -> AppConfig.embeddingModels.openai
+        "Gemini" -> AppConfig.embeddingModels.gemini
+        "Ollama" -> AppConfig.embeddingModels.ollama
+        "Docker" -> AppConfig.embeddingModels.docker
+        "LocalAI" -> AppConfig.embeddingModels.localai
+        "LMStudio" -> AppConfig.embeddingModels.lmstudio
+        "Anthropic", "X AI" -> "N/A"
+        else -> ""
+    }
+
+    val isSupported = providers.find { it.first == selectedProvider }?.second ?: false
+
+    var textValue by remember(selectedProvider, currentValue) { mutableStateOf(currentValue) }
+
+    LaunchedEffect(currentValue) {
+        textValue = currentValue
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        // Provider Dropdown and Model Field in a Row
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Provider Dropdown
+            Box(
+                modifier = Modifier.weight(1f),
+            ) {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickableCard { dropdownExpanded = true },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                    ),
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = selectedProvider,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Icon(
+                            Icons.Default.Edit,
+                            contentDescription = "Change provider",
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                }
+
+                ComponentColors.themedDropdownMenu(
+                    expanded = dropdownExpanded,
+                    onDismissRequest = { dropdownExpanded = false },
+                ) {
+                    providers.forEach { (providerName, supported) ->
+                        DropdownMenuItem(
+                            text = {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        text = providerName,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = if (supported) {
+                                            MaterialTheme.colorScheme.onSurface
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                                        },
+                                    )
+                                    if (!supported) {
+                                        Text(
+                                            text = "(Not supported)",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                                            fontStyle = FontStyle.Italic,
+                                        )
+                                    }
+                                }
+                            },
+                            onClick = {
+                                selectedProvider = providerName
+                                dropdownExpanded = false
+                            },
+                            leadingIcon = if (providerName == selectedProvider) {
+                                {
+                                    Icon(
+                                        Icons.Default.Check,
+                                        contentDescription = "Selected",
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            } else {
+                                null
+                            },
+                        )
+                    }
+                }
+            }
+
+            // Embedding Model Text Field
+            androidx.compose.material3.OutlinedTextField(
+                value = textValue,
+                onValueChange = { newValue ->
+                    if (isSupported) {
+                        textValue = newValue
+                        // Update the corresponding config field
+                        when (selectedProvider) {
+                            "OpenAI" -> AppConfig.updateField("embeddingModels.openai", newValue)
+                            "Gemini" -> AppConfig.updateField("embeddingModels.gemini", newValue)
+                            "Ollama" -> AppConfig.updateField("embeddingModels.ollama", newValue)
+                            "Docker" -> AppConfig.updateField("embeddingModels.docker", newValue)
+                            "LocalAI" -> AppConfig.updateField("embeddingModels.localai", newValue)
+                            "LMStudio" -> AppConfig.updateField("embeddingModels.lmstudio", newValue)
+                        }
+                    }
+                },
+                modifier = Modifier.weight(2f),
+                textStyle = MaterialTheme.typography.bodyMedium,
+                singleLine = true,
+                enabled = isSupported,
+                placeholder = {
+                    Text(
+                        text = if (isSupported) "Enter embedding model" else "Not supported",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                colors = ComponentColors.outlinedTextFieldColors(),
+            )
+        }
+
+        // Show not supported message
+        if (!isSupported) {
+            Text(
+                text = stringResource("settings.rag.embedding.not.supported", selectedProvider),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.5f),
+                fontStyle = FontStyle.Italic,
+            )
         }
     }
 }

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -500,3 +500,27 @@ settings.embedding.download_failed=❌ Failed to download embedding model: {0}. 
 settings.embedding.download_error=Error downloading model: {0}
 settings.embedding.anthropic_no_embedding=Anthropic does not provide embedding models
 settings.embedding.xai_no_embedding=xAI does not provide embedding models
+
+# RAG Configuration
+settings.rag.title=RAG Configuration
+settings.rag.description=Configure Retrieval-Augmented Generation parameters for project-based knowledge retrieval
+settings.rag.vector.max.results=Vector Search Max Results
+settings.rag.vector.max.results.hint=Maximum documents from vector search (default: 20)
+settings.rag.vector.min.score=Vector Search Min Score
+settings.rag.vector.min.score.hint=Minimum similarity score 0.0-1.0 (default: 0.3)
+settings.rag.hybrid.max.results=Hybrid Max Results
+settings.rag.hybrid.max.results.hint=Final document count after fusion (default: 15)
+settings.rag.rank.fusion.constant=Rank Fusion Constant
+settings.rag.rank.fusion.constant.hint=RRF constant for hybrid ranking (default: 60)
+settings.rag.embedding.title=Embedding Configuration
+settings.rag.embedding.description=Configure text chunking and embedding parameters
+settings.rag.embedding.max.chars.per.chunk=Max Characters Per Chunk
+settings.rag.embedding.max.chars.per.chunk.hint=Maximum characters in each text chunk (default: 1500)
+settings.rag.embedding.chunk.overlap=Chunk Overlap
+settings.rag.embedding.chunk.overlap.hint=Number of overlapping characters between chunks (default: 100)
+settings.rag.embedding.preferred.dim=Preferred Dimension
+settings.rag.embedding.preferred.dim.hint=Optional embedding dimension (leave empty for default)
+settings.rag.embedding.models=Embedding Models by Provider
+settings.rag.embedding.models.description=Configure which embedding model to use for each AI provider
+settings.rag.embedding.not.supported={0} does not support embedding models for RAG
+

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -270,7 +270,6 @@ sessions.error.rename.failed=Umbenennen fehlgeschlagen.
 session.resume.error.not.found=Sitzung nicht gefunden: {0}
 
 # Update Check
-menu.help.check.updates=Nach Updates suchen...
 update.dialog.title=Software-Update
 update.dialog.new.version.available=Eine neue Version von Askimo ist verfügbar!
 update.dialog.current.version.label=Aktuelle Version
@@ -491,3 +490,28 @@ settings.embedding.download_failed=❌ Einbettungsmodell konnte nicht herunterge
 settings.embedding.download_error=Fehler beim Herunterladen des Modells: {0}
 settings.embedding.anthropic_no_embedding=Anthropic stellt keine Einbettungsmodelle bereit
 settings.embedding.xai_no_embedding=xAI stellt keine Einbettungsmodelle bereit
+
+# RAG Configuration
+settings.rag.title=RAG-Konfiguration
+settings.rag.description=Konfiguration der Parameter für Retrieval-Augmented Generation zur projektbasierten Wissensabfrage
+settings.rag.vector.max.results=Maximale Ergebnisse der Vektorsuche
+settings.rag.vector.max.results.hint=Maximale Anzahl von Dokumenten aus der Vektorsuche (Standard: 20)
+settings.rag.vector.min.score=Minimaler Score der Vektorsuche
+settings.rag.vector.min.score.hint=Minimaler Ähnlichkeitswert 0,0–1,0 (Standard: 0,3)
+settings.rag.hybrid.max.results=Maximale Hybrid-Ergebnisse
+settings.rag.hybrid.max.results.hint=Endgültige Dokumentanzahl nach Fusion (Standard: 15)
+settings.rag.rank.fusion.constant=Rank-Fusion-Konstante
+settings.rag.rank.fusion.constant.hint=RRF-Konstante für hybrides Ranking (Standard: 60)
+settings.rag.embedding.title=Embedding-Konfiguration
+settings.rag.embedding.description=Konfigurieren Sie Parameter für Textsegmentierung und Embeddings
+settings.rag.embedding.max.chars.per.chunk=Maximale Zeichen pro Segment
+settings.rag.embedding.max.chars.per.chunk.hint=Maximale Anzahl an Zeichen pro Textsegment (Standard: 1500)
+settings.rag.embedding.chunk.overlap=Segmentüberlappung
+settings.rag.embedding.chunk.overlap.hint=Anzahl überlappender Zeichen zwischen Segmenten (Standard: 100)
+settings.rag.embedding.preferred.dim=Bevorzugte Dimension
+settings.rag.embedding.preferred.dim.hint=Optionale Embedding-Dimension (leer lassen für Standard)
+settings.rag.embedding.models=Embedding-Modelle nach Anbieter
+settings.rag.embedding.models.description=Konfigurieren Sie, welches Embedding-Modell für jeden KI-Anbieter verwendet wird
+settings.rag.embedding.not.supported={0} unterstützt keine Embedding-Modelle für RAG
+
+

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -270,7 +270,6 @@ sessions.error.rename.failed=Fallo al renombrar sesión.
 session.resume.error.not.found=Sesión no encontrada: {0}
 
 # Update Check
-menu.help.check.updates=Buscar actualizaciones...
 update.dialog.title=Actualización de software
 update.dialog.new.version.available=¡Hay una nueva versión de Askimo disponible!
 update.dialog.current.version.label=Versión actual
@@ -492,3 +491,27 @@ settings.embedding.download_failed=❌ No se pudo descargar el modelo de incrust
 settings.embedding.download_error=Error al descargar el modelo: {0}
 settings.embedding.anthropic_no_embedding=Anthropic no proporciona modelos de incrustación
 settings.embedding.xai_no_embedding=xAI no proporciona modelos de incrustación
+
+# RAG Configuration
+settings.rag.title=Configuración de RAG
+settings.rag.description=Configura los parámetros de Retrieval-Augmented Generation para la recuperación de conocimiento basada en proyectos
+settings.rag.vector.max.results=Máximo de resultados de búsqueda vectorial
+settings.rag.vector.max.results.hint=Número máximo de documentos de la búsqueda vectorial (predeterminado: 20)
+settings.rag.vector.min.score=Puntuación mínima de búsqueda vectorial
+settings.rag.vector.min.score.hint=Puntuación mínima de similitud 0.0–1.0 (predeterminado: 0.3)
+settings.rag.hybrid.max.results=Máximo de resultados híbridos
+settings.rag.hybrid.max.results.hint=Recuento final de documentos tras la fusión (predeterminado: 15)
+settings.rag.rank.fusion.constant=Constante de fusión de ranking
+settings.rag.rank.fusion.constant.hint=Constante RRF para el ranking híbrido (predeterminado: 60)
+settings.rag.embedding.title=Configuración de embeddings
+settings.rag.embedding.description=Configura los parámetros de segmentación de texto y embeddings
+settings.rag.embedding.max.chars.per.chunk=Máximo de caracteres por segmento
+settings.rag.embedding.max.chars.per.chunk.hint=Número máximo de caracteres en cada segmento de texto (predeterminado: 1500)
+settings.rag.embedding.chunk.overlap=Superposición de segmentos
+settings.rag.embedding.chunk.overlap.hint=Número de caracteres superpuestos entre segmentos (predeterminado: 100)
+settings.rag.embedding.preferred.dim=Dimensión preferida
+settings.rag.embedding.preferred.dim.hint=Dimensión opcional del embedding (dejar vacío para el valor predeterminado)
+settings.rag.embedding.models=Modelos de embedding por proveedor
+settings.rag.embedding.models.description=Configura qué modelo de embedding se utiliza para cada proveedor de IA
+settings.rag.embedding.not.supported={0} no admite modelos de embedding para RAG
+

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -491,3 +491,25 @@ settings.embedding.download_error=Erreur lors du téléchargement du modèle : {
 settings.embedding.anthropic_no_embedding=Anthropic ne fournit pas de modèles d’embedding
 settings.embedding.xai_no_embedding=xAI ne fournit pas de modèles d’embedding
 
+# RAG Configuration
+settings.rag.title=Configuration RAG
+settings.rag.description=Configurez les paramètres de la génération augmentée par la recherche pour la récupération de connaissances basée sur les projets
+settings.rag.vector.max.results=Nombre maximal de résultats de recherche vectorielle
+settings.rag.vector.max.results.hint=Nombre maximal de documents issus de la recherche vectorielle (par défaut : 20)
+settings.rag.vector.min.score=Score minimal de recherche vectorielle
+settings.rag.vector.min.score.hint=Score de similarité minimal 0,0–1,0 (par défaut : 0,3)
+settings.rag.hybrid.max.results=Résultats hybrides maximaux
+settings.rag.hybrid.max.results.hint=Nombre final de documents après fusion (par défaut : 15)
+settings.rag.rank.fusion.constant=Constante de fusion de classement
+settings.rag.rank.fusion.constant.hint=Constante RRF pour le classement hybride (par défaut : 60)
+settings.rag.embedding.title=Configuration des embeddings
+settings.rag.embedding.description=Configurez les paramètres de segmentation du texte et des embeddings
+settings.rag.embedding.max.chars.per.chunk=Nombre maximal de caractères par segment
+settings.rag.embedding.max.chars.per.chunk.hint=Nombre maximal de caractères dans chaque segment de texte (par défaut : 1500)
+settings.rag.embedding.chunk.overlap=Chevauchement des segments
+settings.rag.embedding.chunk.overlap.hint=Nombre de caractères chevauchants entre les segments (par défaut : 100)
+settings.rag.embedding.preferred.dim=Dimension préférée
+settings.rag.embedding.preferred.dim.hint=Dimension d’embedding optionnelle (laisser vide pour la valeur par défaut)
+settings.rag.embedding.models=Modèles d’embedding par fournisseur
+settings.rag.embedding.models.description=Configurez le modèle d’embedding à utiliser pour chaque fournisseur d’IA
+settings.rag.embedding.not.supported={0} ne prend pas en charge les modèles d’embedding pour le RAG

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -492,3 +492,25 @@ settings.embedding.download_error=モデルのダウンロード中にエラー�
 settings.embedding.anthropic_no_embedding=Anthropic は埋め込みモデルを提供していません
 settings.embedding.xai_no_embedding=xAI は埋め込みモデルを提供していません
 
+# RAG Configuration
+settings.rag.title=RAG 設定
+settings.rag.description=プロジェクトベースの知識検索のための Retrieval-Augmented Generation パラメータを設定します
+settings.rag.vector.max.results=ベクトル検索の最大結果数
+settings.rag.vector.max.results.hint=ベクトル検索から取得する最大ドキュメント数（デフォルト: 20）
+settings.rag.vector.min.score=ベクトル検索の最小スコア
+settings.rag.vector.min.score.hint=最小類似度スコア 0.0～1.0（デフォルト: 0.3）
+settings.rag.hybrid.max.results=ハイブリッド最大結果数
+settings.rag.hybrid.max.results.hint=融合後の最終ドキュメント数（デフォルト: 15）
+settings.rag.rank.fusion.constant=ランキング融合定数
+settings.rag.rank.fusion.constant.hint=ハイブリッドランキング用の RRF 定数（デフォルト: 60）
+settings.rag.embedding.title=埋め込み設定
+settings.rag.embedding.description=テキスト分割および埋め込みのパラメータを設定します
+settings.rag.embedding.max.chars.per.chunk=チャンクあたりの最大文字数
+settings.rag.embedding.max.chars.per.chunk.hint=各テキストチャンクの最大文字数（デフォルト: 1500）
+settings.rag.embedding.chunk.overlap=チャンクの重なり
+settings.rag.embedding.chunk.overlap.hint=チャンク間で重複する文字数（デフォルト: 100）
+settings.rag.embedding.preferred.dim=優先ディメンション
+settings.rag.embedding.preferred.dim.hint=任意の埋め込み次元（空欄の場合はデフォルト）
+settings.rag.embedding.models=プロバイダー別の埋め込みモデル
+settings.rag.embedding.models.description=各 AI プロバイダーで使用する埋め込みモデルを設定します
+settings.rag.embedding.not.supported={0} は RAG 用の埋め込みモデルをサポートしていません

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -492,3 +492,25 @@ settings.embedding.download_error=모델 다운로드 중 오류 발생: {0}
 settings.embedding.anthropic_no_embedding=Anthropic은 임베딩 모델을 제공하지 않습니다
 settings.embedding.xai_no_embedding=xAI는 임베딩 모델을 제공하지 않습니다
 
+# RAG Configuration
+settings.rag.title=RAG 구성
+settings.rag.description=프로젝트 기반 지식 검색을 위한 Retrieval-Augmented Generation 매개변수를 구성합니다
+settings.rag.vector.max.results=벡터 검색 최대 결과 수
+settings.rag.vector.max.results.hint=벡터 검색에서 가져올 최대 문서 수 (기본값: 20)
+settings.rag.vector.min.score=벡터 검색 최소 점수
+settings.rag.vector.min.score.hint=최소 유사도 점수 0.0–1.0 (기본값: 0.3)
+settings.rag.hybrid.max.results=하이브리드 최대 결과 수
+settings.rag.hybrid.max.results.hint=융합 후 최종 문서 수 (기본값: 15)
+settings.rag.rank.fusion.constant=랭크 퓨전 상수
+settings.rag.rank.fusion.constant.hint=하이브리드 랭킹을 위한 RRF 상수 (기본값: 60)
+settings.rag.embedding.title=임베딩 구성
+settings.rag.embedding.description=텍스트 분할 및 임베딩 매개변수를 구성합니다
+settings.rag.embedding.max.chars.per.chunk=청크당 최대 문자 수
+settings.rag.embedding.max.chars.per.chunk.hint=각 텍스트 청크의 최대 문자 수 (기본값: 1500)
+settings.rag.embedding.chunk.overlap=청크 중첩
+settings.rag.embedding.chunk.overlap.hint=청크 간 중첩되는 문자 수 (기본값: 100)
+settings.rag.embedding.preferred.dim=선호 차원
+settings.rag.embedding.preferred.dim.hint=선택적 임베딩 차원 (비워두면 기본값 사용)
+settings.rag.embedding.models=제공자별 임베딩 모델
+settings.rag.embedding.models.description=각 AI 제공자에 사용할 임베딩 모델을 구성합니다
+settings.rag.embedding.not.supported={0}은(는) RAG용 임베딩 모델을 지원하지 않습니다

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -491,3 +491,26 @@ settings.embedding.download_failed=❌ Falha ao baixar o modelo de embedding: {0
 settings.embedding.download_error=Erro ao baixar o modelo: {0}
 settings.embedding.anthropic_no_embedding=Anthropic não fornece modelos de embedding
 settings.embedding.xai_no_embedding=xAI não fornece modelos de embedding
+
+# RAG Configuration
+settings.rag.title=Configuração de RAG
+settings.rag.description=Configure os parâmetros de Retrieval-Augmented Generation para recuperação de conhecimento baseada em projetos
+settings.rag.vector.max.results=Máximo de resultados da busca vetorial
+settings.rag.vector.max.results.hint=Número máximo de documentos da busca vetorial (padrão: 20)
+settings.rag.vector.min.score=Pontuação mínima da busca vetorial
+settings.rag.vector.min.score.hint=Pontuação mínima de similaridade 0.0–1.0 (padrão: 0.3)
+settings.rag.hybrid.max.results=Máximo de resultados híbridos
+settings.rag.hybrid.max.results.hint=Contagem final de documentos após a fusão (padrão: 15)
+settings.rag.rank.fusion.constant=Constante de fusão de ranking
+settings.rag.rank.fusion.constant.hint=Constante RRF para ranking híbrido (padrão: 60)
+settings.rag.embedding.title=Configuração de embeddings
+settings.rag.embedding.description=Configure os parâmetros de segmentação de texto e embeddings
+settings.rag.embedding.max.chars.per.chunk=Máximo de caracteres por segmento
+settings.rag.embedding.max.chars.per.chunk.hint=Número máximo de caracteres em cada segmento de texto (padrão: 1500)
+settings.rag.embedding.chunk.overlap=Sobreposição de segmentos
+settings.rag.embedding.chunk.overlap.hint=Número de caracteres sobrepostos entre segmentos (padrão: 100)
+settings.rag.embedding.preferred.dim=Dimensão preferida
+settings.rag.embedding.preferred.dim.hint=Dimensão opcional do embedding (deixe em branco para o padrão)
+settings.rag.embedding.models=Modelos de embedding por provedor
+settings.rag.embedding.models.description=Configure qual modelo de embedding usar para cada provedor de IA
+settings.rag.embedding.not.supported={0} não oferece suporte a modelos de embedding para RAG

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -490,3 +490,25 @@ settings.embedding.download_error=Lỗi khi tải mô hình: {0}
 settings.embedding.anthropic_no_embedding=Anthropic không cung cấp mô hình embedding
 settings.embedding.xai_no_embedding=xAI không cung cấp mô hình embedding
 
+# RAG Configuration
+settings.rag.title=Cấu hình RAG
+settings.rag.description=Cấu hình các tham số Retrieval-Augmented Generation cho truy xuất tri thức theo dự án
+settings.rag.vector.max.results=Số kết quả tìm kiếm vector tối đa
+settings.rag.vector.max.results.hint=Số lượng tài liệu tối đa từ tìm kiếm vector (mặc định: 20)
+settings.rag.vector.min.score=Điểm tối thiểu của tìm kiếm vector
+settings.rag.vector.min.score.hint=Điểm tương đồng tối thiểu 0.0–1.0 (mặc định: 0.3)
+settings.rag.hybrid.max.results=Số kết quả hybrid tối đa
+settings.rag.hybrid.max.results.hint=Số lượng tài liệu cuối cùng sau khi hợp nhất (mặc định: 15)
+settings.rag.rank.fusion.constant=Hằng số hợp nhất xếp hạng
+settings.rag.rank.fusion.constant.hint=Hằng số RRF cho xếp hạng hybrid (mặc định: 60)
+settings.rag.embedding.title=Cấu hình embedding
+settings.rag.embedding.description=Cấu hình các tham số chia đoạn văn bản và embedding
+settings.rag.embedding.max.chars.per.chunk=Số ký tự tối đa mỗi đoạn
+settings.rag.embedding.max.chars.per.chunk.hint=Số ký tự tối đa trong mỗi đoạn văn bản (mặc định: 1500)
+settings.rag.embedding.chunk.overlap=Chồng lấp đoạn
+settings.rag.embedding.chunk.overlap.hint=Số ký tự chồng lấp giữa các đoạn (mặc định: 100)
+settings.rag.embedding.preferred.dim=Kích thước ưu tiên
+settings.rag.embedding.preferred.dim.hint=Kích thước embedding tùy chọn (để trống để dùng mặc định)
+settings.rag.embedding.models=Mô hình embedding theo nhà cung cấp
+settings.rag.embedding.models.description=Cấu hình mô hình embedding được sử dụng cho từng nhà cung cấp AI
+settings.rag.embedding.not.supported={0} không hỗ trợ mô hình embedding cho RAG

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -491,3 +491,25 @@ settings.embedding.download_error=下载模型时出错：{0}
 settings.embedding.anthropic_no_embedding=Anthropic 不提供嵌入模型
 settings.embedding.xai_no_embedding=xAI 不提供嵌入模型
 
+# RAG Configuration
+settings.rag.title=RAG 配置
+settings.rag.description=配置用于基于项目的知识检索的检索增强生成参数
+settings.rag.vector.max.results=向量搜索最大结果数
+settings.rag.vector.max.results.hint=向量搜索返回的最大文档数量（默认：20）
+settings.rag.vector.min.score=向量搜索最小分数
+settings.rag.vector.min.score.hint=最小相似度分数 0.0–1.0（默认：0.3）
+settings.rag.hybrid.max.results=混合搜索最大结果数
+settings.rag.hybrid.max.results.hint=融合后的最终文档数量（默认：15）
+settings.rag.rank.fusion.constant=排序融合常量
+settings.rag.rank.fusion.constant.hint=用于混合排序的 RRF 常量（默认：60）
+settings.rag.embedding.title=嵌入配置
+settings.rag.embedding.description=配置文本分块和嵌入参数
+settings.rag.embedding.max.chars.per.chunk=每个分块的最大字符数
+settings.rag.embedding.max.chars.per.chunk.hint=每个文本分块的最大字符数量（默认：1500）
+settings.rag.embedding.chunk.overlap=分块重叠
+settings.rag.embedding.chunk.overlap.hint=分块之间重叠的字符数量（默认：100）
+settings.rag.embedding.preferred.dim=首选维度
+settings.rag.embedding.preferred.dim.hint=可选的嵌入维度（留空使用默认值）
+settings.rag.embedding.models=按提供商划分的嵌入模型
+settings.rag.embedding.models.description=配置每个 AI 提供商使用的嵌入模型
+settings.rag.embedding.not.supported={0} 不支持用于 RAG 的嵌入模型

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -492,3 +492,25 @@ settings.embedding.download_error=下載模型時發生錯誤：{0}
 settings.embedding.anthropic_no_embedding=Anthropic 不提供嵌入模型
 settings.embedding.xai_no_embedding=xAI 不提供嵌入模型
 
+# RAG Configuration
+settings.rag.title=RAG 設定
+settings.rag.description=設定用於專案型知識檢索的檢索增強生成參數
+settings.rag.vector.max.results=向量搜尋最大結果數
+settings.rag.vector.max.results.hint=向量搜尋回傳的最大文件數量（預設：20）
+settings.rag.vector.min.score=向量搜尋最小分數
+settings.rag.vector.min.score.hint=最小相似度分數 0.0–1.0（預設：0.3）
+settings.rag.hybrid.max.results=混合搜尋最大結果數
+settings.rag.hybrid.max.results.hint=融合後的最終文件數量（預設：15）
+settings.rag.rank.fusion.constant=排名融合常數
+settings.rag.rank.fusion.constant.hint=用於混合排名的 RRF 常數（預設：60）
+settings.rag.embedding.title=嵌入設定
+settings.rag.embedding.description=設定文字分塊與嵌入參數
+settings.rag.embedding.max.chars.per.chunk=每個分塊的最大字元數
+settings.rag.embedding.max.chars.per.chunk.hint=每個文字分塊的最大字元數量（預設：1500）
+settings.rag.embedding.chunk.overlap=分塊重疊
+settings.rag.embedding.chunk.overlap.hint=分塊之間重疊的字元數量（預設：100）
+settings.rag.embedding.preferred.dim=偏好維度
+settings.rag.embedding.preferred.dim.hint=可選的嵌入維度（留空使用預設值）
+settings.rag.embedding.models=依供應商分類的嵌入模型
+settings.rag.embedding.models.description=設定每個 AI 供應商要使用的嵌入模型
+settings.rag.embedding.not.supported={0} 不支援用於 RAG 的嵌入模型

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatSessionRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatSessionRepository.kt
@@ -243,21 +243,6 @@ class ChatSessionRepository internal constructor(
     }
 
     /**
-     * Get all sessions belonging to a specific project.
-     */
-    fun getSessionsByProject(projectId: String): List<ChatSession> = transaction(database) {
-        ChatSessionsTable
-            .selectAll()
-            .where { ChatSessionsTable.projectId eq projectId }
-            .orderBy(
-                ChatSessionsTable.isStarred to SortOrder.DESC,
-                ChatSessionsTable.sortOrder to SortOrder.ASC,
-                ChatSessionsTable.updatedAt to SortOrder.DESC,
-            )
-            .map { it.toChatSession() }
-    }
-
-    /**
      * Get all sessions not belonging to any project (general chat sessions).
      */
     fun getSessionsWithoutProject(): List<ChatSession> = transaction(database) {

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ProjectRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ProjectRepository.kt
@@ -173,17 +173,4 @@ class ProjectRepository internal constructor(
         }
         return deleted
     }
-
-    /**
-     * Update the updatedAt timestamp of a project.
-     * This is typically called when a session in the project is updated.
-     *
-     * @param projectId The project id
-     * @return true if updated successfully
-     */
-    fun touchProject(projectId: String): Boolean = transaction(database) {
-        ProjectsTable.update({ ProjectsTable.id eq projectId }) {
-            it[updatedAt] = LocalDateTime.now()
-        } > 0
-    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -15,7 +15,6 @@ import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTOs
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDomain
-import io.askimo.core.chat.repository.ChatDirectiveRepository
 import io.askimo.core.chat.repository.ChatMessageRepository
 import io.askimo.core.chat.repository.ChatSessionRepository
 import io.askimo.core.chat.repository.PaginationDirection
@@ -81,14 +80,12 @@ data class ResumeSessionPaginatedResult(
  *
  * @param sessionRepository The chat session repository
  * @param messageRepository The chat message repository
- * @param directiveRepository The chat directive repository
  * @param sessionMemoryRepository The session memory repository
  * @param appContext The application context
  */
 class ChatSessionService(
     private val sessionRepository: ChatSessionRepository = DatabaseManager.getInstance().getChatSessionRepository(),
     private val messageRepository: ChatMessageRepository = DatabaseManager.getInstance().getChatMessageRepository(),
-    private val directiveRepository: ChatDirectiveRepository = DatabaseManager.getInstance().getChatDirectiveRepository(),
     private val sessionMemoryRepository: SessionMemoryRepository = DatabaseManager.getInstance().getSessionMemoryRepository(),
     private val projectRepository: ProjectRepository = DatabaseManager.getInstance().getProjectRepository(),
     private val appContext: AppContext,
@@ -107,7 +104,7 @@ class ChatSessionService(
         .removalListener<String, ChatClient> { sessionId, client, cause ->
             if (client != null && sessionId != null) {
                 log.debug("Evicting ChatClient for session {} (cause: {})", sessionId, cause)
-                client.clearMemory()
+                sessionMemoryRepository.deleteBySessionId(sessionId)
             }
         }
         .build()

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -314,6 +314,12 @@ object AppConfig {
           summarization_threshold: ${'$'}{ASKIMO_CHAT_SUMMARIZATION_THRESHOLD:0.75}
           enable_async_summarization: ${'$'}{ASKIMO_CHAT_ENABLE_ASYNC_SUMMARIZATION:true}
 
+        rag:
+          vector_search_max_results: ${'$'}{ASKIMO_RAG_VECTOR_SEARCH_MAX_RESULTS:20}
+          vector_search_min_score: ${'$'}{ASKIMO_RAG_VECTOR_SEARCH_MIN_SCORE:0.3}
+          hybrid_max_results: ${'$'}{ASKIMO_RAG_HYBRID_MAX_RESULTS:15}
+          rank_fusion_constant: ${'$'}{ASKIMO_RAG_RANK_FUSION_CONSTANT:60}
+
         developer:
           enabled: ${'$'}{ASKIMO_DEVELOPER_ENABLED:false}
           active: ${'$'}{ASKIMO_DEVELOPER_ACTIVE:false}
@@ -518,7 +524,9 @@ object AppConfig {
                 "retry" -> current.copy(retry = updateRetryField(current.retry, field, value))
                 "throttle" -> current.copy(throttle = updateThrottleField(current.throttle, field, value))
                 "embedding" -> current.copy(embedding = updateEmbeddingField(current.embedding, field, value))
+                "embeddingModels" -> current.copy(embeddingModels = updateEmbeddingModelsField(current.embeddingModels, field, value))
                 "chat" -> current.copy(chat = updateChatField(current.chat, field, value))
+                "rag" -> current.copy(rag = updateRagField(current.rag, field, value))
                 else -> {
                     log.displayError("Unknown config section: $section", null)
                     return
@@ -560,14 +568,32 @@ object AppConfig {
     private fun updateEmbeddingField(config: EmbeddingConfig, field: String, value: Any): EmbeddingConfig = when (field) {
         "maxCharsPerChunk" -> config.copy(maxCharsPerChunk = value as Int)
         "chunkOverlap" -> config.copy(chunkOverlap = value as Int)
-        "preferredDim" -> config.copy(preferredDim = value as? Int)
+        "preferredDim" -> config.copy(preferredDim = if (value is String && value.isBlank()) null else value as? Int)
+        else -> config
+    }
+
+    private fun updateEmbeddingModelsField(config: EmbeddingModelsConfig, field: String, value: Any): EmbeddingModelsConfig = when (field) {
+        "openai" -> config.copy(openai = value as String)
+        "docker" -> config.copy(docker = value as String)
+        "ollama" -> config.copy(ollama = value as String)
+        "localai" -> config.copy(localai = value as String)
+        "lmstudio" -> config.copy(lmstudio = value as String)
+        "gemini" -> config.copy(gemini = value as String)
         else -> config
     }
 
     private fun updateChatField(config: ChatConfig, field: String, value: Any): ChatConfig = when (field) {
         "maxTokens" -> config.copy(maxTokens = value as Int)
-        "summarizationThreshold" -> config.copy(summarizationThreshold = value as Double)
+        "summarizationThreshold" -> config.copy(summarizationThreshold = (value as Number).toDouble())
         "enableAsyncSummarization" -> config.copy(enableAsyncSummarization = value as Boolean)
+        else -> config
+    }
+
+    private fun updateRagField(config: RagConfig, field: String, value: Any): RagConfig = when (field) {
+        "vectorSearchMaxResults" -> config.copy(vectorSearchMaxResults = value as Int)
+        "vectorSearchMinScore" -> config.copy(vectorSearchMinScore = (value as Number).toDouble())
+        "hybridMaxResults" -> config.copy(hybridMaxResults = value as Int)
+        "rankFusionConstant" -> config.copy(rankFusionConstant = value as Int)
         else -> config
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClient.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClient.kt
@@ -29,14 +29,6 @@ interface ChatClient {
     ): TokenStream
 
     /**
-     * Sends a simple chat message and returns the complete response.
-     *
-     * @param prompt The user message to send
-     * @return The complete response from the AI
-     */
-    fun sendMessage(@UserMessage prompt: String): String
-
-    /**
      * Clear all memory from the current session.
      */
     fun clearMemory()


### PR DESCRIPTION
- Add Advanced Settings UI for tuning vector search, hybrid retrieval, and chunking
- Introduce new i18n strings for RAG settings across supported locales
- Add rag config defaults and dynamic update support in AppConfig
- Optimize resource segment persistence via batch insert with ignore for idempotency
- Remove unused chat repository methods and simplify session memory clearing logic
- Drop unused ChatClient sendMessage API and update tests accordingly

BREAKING CHANGE: ChatClient no longer exposes sendMessage(prompt); migrate callers to the streaming/chat completion APIs used by providers.