### PR TITLE
refactor(chat-memory): switch summarization to utility chat client

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/view/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/project/ProjectView.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.FileAttachmentDTO
-import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
@@ -161,18 +160,14 @@ fun projectView(
                             showDeleteDialog = true
                             showProjectMenu = false
                         },
-                        onReindexProject = if (AppConfig.developer.enabled && AppConfig.developer.active) {
-                            {
-                                EventBus.post(
-                                    ProjectReIndexEvent(
-                                        projectId = project.id,
-                                        reason = "Manual re-index requested by user from project menu",
-                                    ),
-                                )
-                                showProjectMenu = false
-                            }
-                        } else {
-                            null
+                        onReindexProject = {
+                            EventBus.post(
+                                ProjectReIndexEvent(
+                                    projectId = project.id,
+                                    reason = "Manual re-index requested by user from project menu",
+                                ),
+                            )
+                            showProjectMenu = false
                         },
                         onDismiss = { showProjectMenu = false },
                     )

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -6,8 +6,16 @@ package io.askimo.core.providers
 
 import io.askimo.core.context.AppContextFactory
 import io.askimo.core.logging.logger
+import io.askimo.core.memory.ConversationSummary
+import io.askimo.core.util.JsonUtils.json
 import io.askimo.core.util.RetryPresets
 import io.askimo.core.util.RetryUtils
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import java.util.concurrent.CountDownLatch
 
 /**
@@ -171,4 +179,137 @@ fun ChatClient.sendStreamingMessageWithCallback(
 
     // Should never reach here, but for completeness
     throw IllegalStateException("Failed to send message after ${maxContextRetries + 1} context retries")
+}
+
+/**
+ * Generates a structured summary of a conversation.
+ *
+ * This extension function analyzes conversation text and extracts:
+ * - Key facts as name-value pairs
+ * - Main topics discussed
+ * - Recent context summary
+ *
+ * The AI model is instructed to respond with JSON only, which is then parsed
+ * into a [ConversationSummary] object.
+ *
+ * @param conversationText The conversation text to summarize
+ * @return A ConversationSummary containing key facts, main topics, and recent context
+ */
+fun ChatClient.getSummary(conversationText: String): ConversationSummary {
+    val log = logger<ChatClient>()
+
+    val prompt = """
+        Analyze the following conversation and provide a structured summary in JSON format.
+        Extract key facts, main topics, and recent context.
+
+        Conversation:
+        $conversationText
+
+        Respond with valid JSON only (no markdown, no newlines in string values):
+        {
+            "keyFacts": {"fact_name": "fact_value"},
+            "mainTopics": ["topic1", "topic2"],
+            "recentContext": "brief summary of the most recent discussion"
+        }
+
+        IMPORTANT: Ensure all JSON is on a single line with no newlines inside string values.
+    """.trimIndent()
+
+    try {
+        var jsonText = this.sendStreamingMessageWithCallback(prompt)
+
+        // Remove markdown code blocks
+        jsonText = jsonText
+            .removePrefix("```json")
+            .removePrefix("```")
+            .removeSuffix("```")
+            .trim()
+
+        jsonText = cleanJsonResponse(jsonText)
+        jsonText = sanitizeArraysInKeyFacts(jsonText)
+
+        return json.decodeFromString<ConversationSummary>(jsonText)
+    } catch (e: Exception) {
+        log.error("Failed to generate conversation summary. Response was likely malformed.", e)
+        return ConversationSummary(
+            keyFacts = emptyMap(),
+            mainTopics = emptyList(),
+            recentContext = conversationText.takeLast(500),
+        )
+    }
+}
+
+/**
+ * Clean JSON response from AI to handle common formatting issues.
+ * Removes newlines inside string values while preserving structure.
+ */
+private fun cleanJsonResponse(jsonText: String): String {
+    // First, try to find the actual JSON object
+    val jsonStart = jsonText.indexOf('{')
+    val jsonEnd = jsonText.lastIndexOf('}')
+
+    if (jsonStart == -1 || jsonEnd == -1 || jsonStart >= jsonEnd) {
+        return jsonText // Return as-is if no valid JSON structure found
+    }
+
+    val jsonOnly = jsonText.substring(jsonStart, jsonEnd + 1)
+
+    // Remove newlines and excessive whitespace while preserving JSON structure
+    return jsonOnly
+        .replace("\n", " ") // Remove all newlines
+        .replace("\r", " ") // Remove carriage returns
+        .replace("\\s+".toRegex(), " ") // Collapse multiple spaces
+        .trim()
+}
+
+/**
+ * Sanitize arrays in keyFacts to comma-separated strings.
+ * Since ConversationSummary.keyFacts is Map<String, String>, we need to convert
+ * any array values to strings.
+ */
+private fun sanitizeArraysInKeyFacts(jsonText: String): String {
+    val log = logger<ChatClient>()
+
+    return try {
+        val jsonParser = Json { ignoreUnknownKeys = true }
+        val jsonElement = jsonParser.parseToJsonElement(jsonText)
+
+        if (jsonElement !is JsonObject) {
+            return jsonText
+        }
+
+        val keyFacts = jsonElement["keyFacts"]
+        if (keyFacts !is JsonObject) {
+            return jsonText
+        }
+
+        // Convert arrays in keyFacts to comma-separated strings
+        val sanitizedKeyFacts = keyFacts.entries.associate { (key, value) ->
+            key to when (value) {
+                is JsonArray -> {
+                    // Convert array to comma-separated string
+                    val arrayValues = value.jsonArray.mapNotNull {
+                        when (it) {
+                            is JsonPrimitive -> it.jsonPrimitive.content
+                            else -> null
+                        }
+                    }
+                    JsonPrimitive(arrayValues.joinToString(", "))
+                }
+                else -> value
+            }
+        }
+
+        // Rebuild JSON with sanitized keyFacts
+        val sanitizedJson = JsonObject(
+            jsonElement.toMap().toMutableMap().apply {
+                put("keyFacts", JsonObject(sanitizedKeyFacts))
+            },
+        )
+
+        sanitizedJson.toString()
+    } catch (e: Exception) {
+        log.debug("Failed to sanitize arrays in keyFacts, returning original: ${e.message}")
+        jsonText
+    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatModelFactory.kt
@@ -7,7 +7,6 @@ package io.askimo.core.providers
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.rag.RetrievalAugmentor
 import io.askimo.core.context.ExecutionMode
-import io.askimo.core.memory.ConversationSummary
 
 /**
  * Factory interface for creating chat model instances for a specific AI provider.
@@ -61,15 +60,6 @@ interface ChatModelFactory<T : ProviderSettings> {
      * @return Help text explaining how to set up or configure the provider
      */
     fun getNoModelsHelpText(): String = "Please check your provider configuration."
-
-    /**
-     * Creates a summarizer function for AI-powered conversation summarization.
-     * Returns null if AI summarization is not supported or not enabled for this provider.
-     *
-     * @param settings Provider-specific settings
-     * @return A function that takes conversation text and returns a ConversationSummary, or null
-     */
-    fun createSummarizer(settings: T): ((String) -> ConversationSummary)? = null
 
     /**
      * Creates an intent classification client for RAG decisions.

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.core.providers.gemini
 
-import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel
@@ -12,12 +11,9 @@ import dev.langchain4j.rag.RetrievalAugmentor
 import dev.langchain4j.service.AiServices
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
-import io.askimo.core.memory.ConversationSummary
-import io.askimo.core.memory.DefaultConversationSummarizer
 import io.askimo.core.providers.ChatClient
 import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.ChatRequestTransformers
-import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.GEMINI
 import io.askimo.core.providers.ProviderModelUtils
 import io.askimo.core.providers.ProviderModelUtils.fetchModels
@@ -33,7 +29,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
     private val log = logger<GeminiModelFactory>()
 
     companion object {
-        private const val CLASSIFICATION_MODEL = "gemini-1.5-flash"
+        private const val UTILITY_MODEL = "gemini-1.5-flash"
     }
 
     override fun availableModels(settings: GeminiSettings): List<String> {
@@ -137,23 +133,6 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
 
     private fun supportsSampling(model: String): Boolean = true
 
-    private fun createSummarizerModel(settings: GeminiSettings): GoogleAiGeminiChatModel = GoogleAiGeminiChatModel.builder()
-        .apiKey(safeApiKey(settings.apiKey))
-        .modelName(settings.summarizerModel)
-        .temperature(0.3)
-        .build()
-
-    override fun createSummarizer(settings: GeminiSettings): ((String) -> ConversationSummary)? {
-        if (!settings.enableAiSummarization) {
-            return null
-        }
-
-        val summarizerModel = createSummarizerModel(settings)
-        return DefaultConversationSummarizer.createSummarizer(ModelProvider.GEMINI) { prompt ->
-            summarizerModel.chat(UserMessage.from(prompt)).aiMessage().text()
-        }
-    }
-
     override fun createUtilityClient(
         settings: GeminiSettings,
         fallbackModel: String,
@@ -161,7 +140,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
         // Simple client for classification - no tools, no transformers, no custom messages
         val chatModel = GoogleAiGeminiChatModel.builder()
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(CLASSIFICATION_MODEL)
+            .modelName(UTILITY_MODEL)
             .timeout(Duration.ofSeconds(10))
             .build()
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.core.providers.openai
 
-import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
@@ -12,12 +11,9 @@ import dev.langchain4j.rag.RetrievalAugmentor
 import dev.langchain4j.service.AiServices
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
-import io.askimo.core.memory.ConversationSummary
-import io.askimo.core.memory.DefaultConversationSummarizer
 import io.askimo.core.providers.ChatClient
 import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.ChatRequestTransformers
-import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.OPENAI
 import io.askimo.core.providers.ProviderModelUtils
 import io.askimo.core.providers.ProviderModelUtils.fetchModels
@@ -32,7 +28,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
     private val log = logger<OpenAiModelFactory>()
 
     companion object {
-        private const val CLASSIFICATION_MODEL = "gpt-3.5-turbo"
+        private const val UTILITY_MODEL = "gpt-3.5-turbo"
     }
 
     override fun availableModels(settings: OpenAiSettings): List<String> {
@@ -126,17 +122,6 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
         return builder.build()
     }
 
-    override fun createSummarizer(settings: OpenAiSettings): ((String) -> ConversationSummary)? {
-        if (!settings.enableAiSummarization) {
-            return null
-        }
-
-        val summarizerModel = createSummarizerModel(settings)
-        return DefaultConversationSummarizer.createSummarizer(ModelProvider.OPENAI) { prompt ->
-            summarizerModel.chat(UserMessage.from(prompt)).aiMessage().text()
-        }
-    }
-
     override fun createUtilityClient(
         settings: OpenAiSettings,
         fallbackModel: String,
@@ -144,7 +129,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
         // Simple client for classification - no tools, no transformers, no custom messages
         val chatModel = OpenAiChatModel.builder()
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(CLASSIFICATION_MODEL)
+            .modelName(UTILITY_MODEL)
             .timeout(Duration.ofSeconds(10))
             .build()
 
@@ -157,14 +142,4 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
         val m = model.lowercase()
         return !(m.startsWith("o") || m.startsWith("gpt-5") || m.contains("reasoning"))
     }
-
-    /**
-     * Create a non-streaming chat model for background summarization tasks.
-     * Uses a cheaper model (default: gpt-4o-mini) to reduce costs.
-     */
-    private fun createSummarizerModel(settings: OpenAiSettings): OpenAiChatModel = OpenAiChatModel.builder()
-        .apiKey(safeApiKey(settings.apiKey))
-        .modelName(settings.summarizerModel)
-        .temperature(0.3)
-        .build()
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
@@ -20,8 +20,6 @@ data class OpenAiSettings(
     override var apiKey: String = "",
     override val defaultModel: String = "gpt-5.1",
     override var presets: Presets = Presets(Style.BALANCED, Verbosity.NORMAL),
-    val enableAiSummarization: Boolean = true,
-    val summarizerModel: String = "gpt-4o-mini", // Cheaper model for background summarization
 ) : ProviderSettings,
     HasApiKey {
     override fun describe(): List<String> = listOf(

--- a/shared/src/main/kotlin/io/askimo/core/rag/EmbeddingModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/EmbeddingModelFactory.kt
@@ -229,7 +229,7 @@ private fun buildDockerEmbeddingModel(settings: DockerAiSettings): EmbeddingMode
 
     return OpenAiEmbeddingModelBuilder()
         .apiKey("not-needed")
-        .baseUrl("$baseUrl/v1")
+        .baseUrl(baseUrl)
         .modelName(modelName)
         .build()
 }


### PR DESCRIPTION
- Remove per-provider summarizer factories and OpenAI summarization settings
- Generate structured summaries via ChatClient extensions for consistent behavior
- Cache and reuse a provider utility client in AppContext and refresh on model changes
- Use utility client for project retriever classification to align background tasks
- Always expose manual project re-index action from the project menu

BREAKING CHANGE: Removed ChatModelFactory.createSummarizer and OpenAiSettings.enableAiSummarization/summarizerModel; update integrations to use the utility client based summary API instead.