### PR TITLE
docs(readme): update branding assets and highlight built-in RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="public/askimo-logo.svg">
-    <img alt="Askimo - AI toolkit for your workflows." src="public/askimo-logo-dark.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="public/github-logo-dark.svg">
+    <img alt="Askimo - AI toolkit for your workflows." src="public/github-logo-light.svg">
   </picture>
 </p>
 
@@ -66,6 +66,7 @@ Askimo is a provider-agnostic AI toolkit that gives developers, writers, and res
 * **⚡ CLI for Power Users** - Pipe logs, automate workflows, and integrate AI into your dev pipeline
 * **🔒 Privacy-First Architecture** - All chat history stored locally on your machine, not in the cloud
 * **📦 No Vendor Lock-In** - Works with any OpenAI-compatible API endpoint
+* **🧠 Built-in RAG** - Connect your knowledge folders to give AI context from your documents, code, and notes without uploading anything to the cloud
 * **🎨 Custom Directives & Prompts** - Build reusable prompt libraries and automation recipes
 * **💾 Smart History & Search** - Never lose an important conversation - search, star, and export everything
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/settings/ProviderSelectionDialog.kt
@@ -433,7 +433,7 @@ fun providerSelectionDialog(
                                                         onClick = {
                                                             try {
                                                                 Desktop.getDesktop().browse(
-                                                                    URI("https://askimo.chat/blog/securing-user-data-in-askimo/"),
+                                                                    URI("https://askimo.chat/security"),
                                                                 )
                                                             } catch (_: Exception) {
                                                                 // Silently fail if browser cannot be opened

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.2.3
+projectVersion=1.2.4
 
 # About information
 author=Hai Nguyen

--- a/public/github-logo-dark.svg
+++ b/public/github-logo-dark.svg
@@ -1,0 +1,165 @@
+<svg width="1280" height="640" viewBox="0 0 1280 640" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <!-- Light background gradient -->
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#F8FAFC"/>
+            <stop offset="0.55" stop-color="#FFFFFF"/>
+            <stop offset="1" stop-color="#F1F5F9"/>
+        </linearGradient>
+
+        <!-- Subtle grid -->
+        <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M40 0H0V40" fill="none" stroke="#00000008" stroke-width="1"/>
+        </pattern>
+
+        <!-- Soft hub glow for light theme -->
+        <radialGradient id="glow" cx="50%" cy="50%" r="50%">
+            <stop offset="0" stop-color="#6366F133"/>
+            <stop offset="0.55" stop-color="#3B82F622"/>
+            <stop offset="1" stop-color="#00000000"/>
+        </radialGradient>
+    </defs>
+
+    <!-- Background -->
+    <rect width="1280" height="640" fill="url(#bg)"/>
+    <rect width="1280" height="640" fill="url(#grid)" opacity="0.6"/>
+
+    <!-- LEFT: Brand & message -->
+    <g font-family="Inter, SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif">
+        <text x="70" y="255" font-size="120" font-weight="900" fill="#0F172A" letter-spacing="4">
+            ASKIMO
+        </text>
+
+        <text x="74" y="315" font-size="40" font-weight="700" fill="#334155">
+            Desktop + CLI AI hub
+        </text>
+
+        <text x="74" y="365" font-size="34" font-weight="600" fill="#475569">
+            Built-in Knowledge Base • Multi-Provider
+        </text>
+    </g>
+
+    <!-- RIGHT: HUB SYSTEM (LIGHT MODE) -->
+
+    <!-- Ambient glow -->
+    <circle cx="980" cy="340" r="260" fill="url(#glow)"/>
+
+    <!-- Segmented integration ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="220"
+            fill="none"
+            stroke="#0F172A22"
+            stroke-width="3"
+            stroke-dasharray="18 10"
+    />
+
+    <!-- Primary authority ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="195"
+            fill="none"
+            stroke="#0F172A55"
+            stroke-width="3"
+    />
+
+    <!-- Inner energy ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="165"
+            fill="none"
+            stroke="#6366F166"
+            stroke-width="2"
+    />
+
+    <!-- Light core -->
+    <circle cx="980" cy="340" r="140" fill="#FFFFFF"/>
+
+    <!-- Provider pills -->
+    <g font-family="Inter, SF Pro Display, Arial"
+       font-size="18"
+       font-weight="750"
+       text-anchor="middle"
+       dominant-baseline="middle">
+
+        <!-- Highlighted -->
+        <g>
+            <rect x="915" y="95" width="130" height="38" rx="19"
+                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
+            <text x="980" y="114" fill="#0F172A">OpenAI</text>
+        </g>
+
+        <g>
+            <rect x="1115" y="155" width="150" height="38" rx="19"
+                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
+            <text x="1190" y="174" fill="#0F172A">Anthropic</text>
+        </g>
+
+        <g>
+            <rect x="1140" y="310" width="120" height="38" rx="19"
+                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
+            <text x="1200" y="329" fill="#0F172A">Gemini</text>
+        </g>
+
+        <!-- Secondary -->
+        <g>
+            <rect x="1090" y="470" width="170" height="38" rx="19"
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="1175" y="489" fill="#334155">LM Studio</text>
+        </g>
+
+        <g>
+            <rect x="915" y="540" width="130" height="38" rx="19"
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="980" y="559" fill="#334155">Ollama</text>
+        </g>
+
+        <g>
+            <rect x="720" y="470" width="165" height="38" rx="19"
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="802.5" y="489" fill="#334155">Docker AI</text>
+        </g>
+
+        <g>
+            <rect x="705" y="310" width="140" height="38" rx="19"
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="775" y="329" fill="#334155">LocalAI</text>
+        </g>
+
+        <g>
+            <rect x="760" y="155" width="90" height="38" rx="19"
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="805" y="174" fill="#334155">X</text>
+        </g>
+    </g>
+
+    <!-- Askimo logo (BLACK STROKE, CENTERED) -->
+    <g transform="translate(867.36 227.36) scale(0.22)"
+       fill="none"
+       stroke="#0F172A"
+       stroke-width="40"
+       stroke-linecap="round"
+       stroke-linejoin="round">
+        <polygon points="121,291 507,64 890,282 903,731 515,963 116,719" />
+        <path d="M254 395 L344 507" />
+        <path d="M257 620 L341 520" />
+        <path d="M361 560 L456 560" />
+        <circle cx="665" cy="509" r="79" />
+        <circle cx="529" cy="397" r="39" />
+        <path d="M665 509 L529 397" />
+        <circle cx="797" cy="625" r="39" />
+        <path d="M665 509 L797 625" />
+        <circle cx="667" cy="307" r="37" />
+        <path d="M665 509 L667 307" />
+        <circle cx="529" cy="625" r="35" />
+        <path d="M665 509 L529 625" />
+        <circle cx="671" cy="715" r="35" />
+        <path d="M665 509 L671 715" />
+        <circle cx="805" cy="409" r="34" />
+        <path d="M665 509 L805 409" />
+    </g>
+
+</svg>

--- a/public/github-logo-light.svg
+++ b/public/github-logo-light.svg
@@ -1,0 +1,166 @@
+<svg width="1280" height="640" viewBox="0 0 1280 640" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <!-- Background gradient -->
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#07090F"/>
+            <stop offset="0.55" stop-color="#0C0C0C"/>
+            <stop offset="1" stop-color="#0A0F1A"/>
+        </linearGradient>
+
+        <!-- Subtle grid -->
+        <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M40 0H0V40" fill="none" stroke="#FFFFFF10" stroke-width="1"/>
+        </pattern>
+
+        <!-- Hub glow -->
+        <radialGradient id="glow" cx="50%" cy="50%" r="50%">
+            <stop offset="0" stop-color="#7C3AED55"/>
+            <stop offset="0.55" stop-color="#3B82F633"/>
+            <stop offset="1" stop-color="#00000000"/>
+        </radialGradient>
+    </defs>
+
+    <!-- Background -->
+    <rect width="1280" height="640" fill="url(#bg)"/>
+    <rect width="1280" height="640" fill="url(#grid)" opacity="0.35"/>
+
+    <!-- LEFT: Brand & message -->
+    <g font-family="Inter, SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif">
+        <text x="70" y="255" font-size="120" font-weight="900" fill="#FFFFFF" letter-spacing="4">
+            ASKIMO
+        </text>
+
+        <text x="74" y="315" font-size="40" font-weight="700" fill="#D8D8D8">
+            Desktop + CLI AI hub
+        </text>
+
+        <text x="74" y="365" font-size="34" font-weight="600" fill="#BEBEBE">
+            Built-in Knowledge Base • Multi-Provider
+        </text>
+    </g>
+
+    <!-- RIGHT: IMPRESSIVE HUB SYSTEM -->
+
+    <!-- Ambient glow -->
+    <circle cx="980" cy="340" r="260" fill="url(#glow)"/>
+
+    <!-- Segmented integration ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="220"
+            fill="none"
+            stroke="#FFFFFF22"
+            stroke-width="3"
+            stroke-dasharray="18 10"
+    />
+
+    <!-- Primary authority ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="195"
+            fill="none"
+            stroke="#FFFFFF55"
+            stroke-width="3"
+    />
+
+    <!-- Inner energy ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="165"
+            fill="none"
+            stroke="#8B9CFF66"
+            stroke-width="2"
+    />
+
+    <!-- Dark core -->
+    <circle cx="980" cy="340" r="140" fill="#0B1220"/>
+
+    <!-- Provider pills -->
+    <g font-family="Inter, SF Pro Display, Arial"
+       font-size="18"
+       font-weight="750"
+       text-anchor="middle"
+       dominant-baseline="middle">
+
+        <!-- Highlighted -->
+        <g>
+            <rect x="915" y="95" width="130" height="38" rx="19"
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="980" y="114" fill="#FFFFFF">OpenAI</text>
+        </g>
+
+        <g>
+            <rect x="1115" y="155" width="150" height="38" rx="19"
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="1190" y="174" fill="#FFFFFF">Anthropic</text>
+        </g>
+
+        <g>
+            <rect x="1140" y="310" width="120" height="38" rx="19"
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="1200" y="329" fill="#FFFFFF">Gemini</text>
+        </g>
+
+        <!-- Secondary -->
+        <g>
+            <rect x="1090" y="470" width="170" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="1175" y="489" fill="#E0E0E0">LM Studio</text>
+        </g>
+
+        <g>
+            <rect x="915" y="540" width="130" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="980" y="559" fill="#E0E0E0">Ollama</text>
+        </g>
+
+        <g>
+            <rect x="720" y="470" width="165" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="802.5" y="489" fill="#E0E0E0">Docker AI</text>
+        </g>
+
+        <g>
+            <rect x="705" y="310" width="140" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="775" y="329" fill="#E0E0E0">LocalAI</text>
+        </g>
+
+        <g>
+            <rect x="760" y="155" width="90" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="805" y="174" fill="#E0E0E0">X</text>
+        </g>
+    </g>
+
+    <!-- Askimo logo PERFECTLY CENTERED -->
+    <!-- translate(980 - 0.22*512, 340 - 0.22*512) -->
+    <g transform="translate(867.36 227.36) scale(0.22)"
+       fill="none"
+       stroke="#FFFFFF"
+       stroke-width="40"
+       stroke-linecap="round"
+       stroke-linejoin="round">
+        <polygon points="121,291 507,64 890,282 903,731 515,963 116,719" />
+        <path d="M254 395 L344 507" />
+        <path d="M257 620 L341 520" />
+        <path d="M361 560 L456 560" />
+        <circle cx="665" cy="509" r="79" />
+        <circle cx="529" cy="397" r="39" />
+        <path d="M665 509 L529 397" />
+        <circle cx="797" cy="625" r="39" />
+        <path d="M665 509 L797 625" />
+        <circle cx="667" cy="307" r="37" />
+        <path d="M665 509 L667 307" />
+        <circle cx="529" cy="625" r="35" />
+        <path d="M665 509 L529 625" />
+        <circle cx="671" cy="715" r="35" />
+        <path d="M665 509 L671 715" />
+        <circle cx="805" cy="409" r="34" />
+        <path d="M665 509 L805 409" />
+    </g>
+
+</svg>

--- a/public/github-social.svg
+++ b/public/github-social.svg
@@ -1,0 +1,168 @@
+<svg width="1280" height="640" viewBox="0 0 1280 640" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <!-- Background gradient -->
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#07090F"/>
+            <stop offset="0.55" stop-color="#0C0C0C"/>
+            <stop offset="1" stop-color="#0A0F1A"/>
+        </linearGradient>
+
+        <!-- Subtle grid -->
+        <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M40 0H0V40" fill="none" stroke="#FFFFFF10" stroke-width="1"/>
+        </pattern>
+
+        <!-- STRONGER, PNG-FRIENDLY GLOW -->
+        <radialGradient id="glow" cx="50%" cy="50%" r="50%">
+            <stop offset="0" stop-color="#7C3AED" stop-opacity="0.55"/>
+            <stop offset="0.45" stop-color="#3B82F6" stop-opacity="0.30"/>
+            <stop offset="1" stop-color="#000000" stop-opacity="0"/>
+        </radialGradient>
+    </defs>
+
+    <!-- Background -->
+    <rect width="1280" height="640" fill="url(#bg)"/>
+    <rect width="1280" height="640" fill="url(#grid)" opacity="0.35"/>
+
+    <!-- LEFT: Brand & message -->
+    <g font-family="Inter, SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif">
+        <text x="70" y="255" font-size="120" font-weight="900" fill="#FFFFFF" letter-spacing="4">
+            ASKIMO
+        </text>
+
+        <text x="74" y="315" font-size="40" font-weight="700" fill="#D8D8D8">
+            Desktop + CLI AI hub
+        </text>
+
+        <text x="74" y="365" font-size="34" font-weight="600" fill="#BEBEBE">
+            Built-in Knowledge Base • Multi-Provider
+        </text>
+    </g>
+
+    <!-- RIGHT: IMPRESSIVE HUB (STACKED GLOW) -->
+
+    <!-- Glow stack (this is the key improvement) -->
+    <circle cx="980" cy="340" r="270" fill="url(#glow)" opacity="0.90"/>
+    <circle cx="980" cy="340" r="235" fill="url(#glow)" opacity="0.95"/>
+    <circle cx="980" cy="340" r="205" fill="url(#glow)" opacity="0.85"/>
+
+    <!-- Segmented integration ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="220"
+            fill="none"
+            stroke="#FFFFFF22"
+            stroke-width="3"
+            stroke-dasharray="18 10"
+    />
+
+    <!-- Primary authority ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="195"
+            fill="none"
+            stroke="#FFFFFF66"
+            stroke-width="3"
+    />
+
+    <!-- Inner energy ring -->
+    <circle
+            cx="980"
+            cy="340"
+            r="165"
+            fill="none"
+            stroke="#8B9CFF88"
+            stroke-width="2"
+    />
+
+    <!-- Dark core -->
+    <circle cx="980" cy="340" r="140" fill="#0B1220"/>
+
+    <!-- Provider pills (CRISP) -->
+    <g font-family="Inter, SF Pro Display, Arial"
+       font-size="18"
+       font-weight="750"
+       text-anchor="middle"
+       dominant-baseline="middle">
+
+        <!-- Highlighted -->
+        <g>
+            <rect x="915" y="95" width="130" height="38" rx="19"
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="980" y="114" fill="#FFFFFF">OpenAI</text>
+        </g>
+
+        <g>
+            <rect x="1115" y="155" width="150" height="38" rx="19"
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="1190" y="174" fill="#FFFFFF">Anthropic</text>
+        </g>
+
+        <g>
+            <rect x="1140" y="310" width="120" height="38" rx="19"
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="1200" y="329" fill="#FFFFFF">Gemini</text>
+        </g>
+
+        <!-- Secondary -->
+        <g>
+            <rect x="1090" y="470" width="170" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="1175" y="489" fill="#E0E0E0">LM Studio</text>
+        </g>
+
+        <g>
+            <rect x="915" y="540" width="130" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="980" y="559" fill="#E0E0E0">Ollama</text>
+        </g>
+
+        <g>
+            <rect x="720" y="470" width="165" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="802.5" y="489" fill="#E0E0E0">Docker AI</text>
+        </g>
+
+        <g>
+            <rect x="705" y="310" width="140" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="775" y="329" fill="#E0E0E0">LocalAI</text>
+        </g>
+
+        <g>
+            <rect x="760" y="155" width="90" height="38" rx="19"
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="805" y="174" fill="#E0E0E0">X</text>
+        </g>
+    </g>
+
+    <!-- Askimo logo (PERFECTLY CENTERED) -->
+    <!-- translate(980 − 0.22×512, 340 − 0.22×512) -->
+    <g transform="translate(867.36 227.36) scale(0.22)"
+       fill="none"
+       stroke="#FFFFFF"
+       stroke-width="40"
+       stroke-linecap="round"
+       stroke-linejoin="round">
+        <polygon points="121,291 507,64 890,282 903,731 515,963 116,719" />
+        <path d="M254 395 L344 507" />
+        <path d="M257 620 L341 520" />
+        <path d="M361 560 L456 560" />
+        <circle cx="665" cy="509" r="79" />
+        <circle cx="529" cy="397" r="39" />
+        <path d="M665 509 L529 397" />
+        <circle cx="797" cy="625" r="39" />
+        <path d="M665 509 L797 625" />
+        <circle cx="667" cy="307" r="37" />
+        <path d="M665 509 L667 307" />
+        <circle cx="529" cy="625" r="35" />
+        <path d="M665 509 L529 625" />
+        <circle cx="671" cy="715" r="35" />
+        <path d="M665 509 L671 715" />
+        <circle cx="805" cy="409" r="34" />
+        <path d="M665 509 L805 409" />
+    </g>
+
+</svg>


### PR DESCRIPTION
- Swap README logo references to new GitHub-friendly variants
- Add built-in RAG bullet to better communicate core capability
- Refresh security link in provider settings to point to current page
- Bump project version to 1.2.4
- Add new SVG assets for dark/light and social previews