### PR TITLE
feat(chat): extract and include URL content in chat context

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,3 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryErro
 kotlin.daemon.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 org.gradle.parallel=true
 org.gradle.caching=true
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ tika = "3.2.3"
 lucene = "10.3.2"
 langchain4j-extra = "1.10.0-beta18"
 caffeine = "3.2.3"
+okhttp = "5.3.2"
+jsoup = "1.22.1"
 
 [libraries]
 # JLine
@@ -66,6 +68,12 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 
 # Caffeine Cache
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version.ref = "caffeine" }
+
+# HTTP Client
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+
+# HTML Parser
+jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 
 # Logging
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
         exclude(group = "org.eclipse.angus", module = "angus-activation")
     }
 
+    implementation(libs.okhttp)
+    implementation(libs.jsoup)
+
     implementation(libs.bundles.commonmark)
 
     // Testing

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
@@ -1,0 +1,253 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.chat.util
+
+import io.askimo.core.logging.logger
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.apache.tika.metadata.Metadata
+import org.apache.tika.parser.AutoDetectParser
+import org.apache.tika.sax.BodyContentHandler
+import org.jsoup.Jsoup
+import java.io.ByteArrayInputStream
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+/**
+ * Result of URL content extraction.
+ */
+data class ExtractedUrlContent(
+    val url: String,
+    val title: String?,
+    val content: String,
+    val contentType: String,
+)
+
+/**
+ * Utility for extracting text content from URLs.
+ * Uses OkHttp for fetching, Jsoup for HTML parsing, and Apache Tika for other formats.
+ * Supports HTML pages, PDF documents, plain text, and other text-based formats.
+ */
+object UrlContentExtractor {
+
+    private val log = logger<UrlContentExtractor>()
+
+    private val parser = AutoDetectParser()
+
+    private val httpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .followRedirects(true)
+        .build()
+
+    /**
+     * Extract text content from a URL.
+     * Supports HTML, PDF, plain text, JSON, XML, and other text-based formats.
+     *
+     * @param url The URL to extract content from
+     * @return ExtractedUrlContent containing the title and cleaned text content
+     * @throws Exception if the URL cannot be fetched or the format is unsupported
+     */
+    fun extractContent(url: String): ExtractedUrlContent {
+        val normalizedUrl = normalizeUrl(url)
+
+        val request = Request.Builder()
+            .url(normalizedUrl)
+            .header("User-Agent", "Mozilla/5.0 (compatible; Askimo/1.0; +https://askimo.chat)")
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw Exception("Failed to fetch URL: HTTP ${response.code}")
+            }
+
+            val contentType = response.header("Content-Type") ?: "application/octet-stream"
+            val bytes = response.body.use { body ->
+                body.source().readByteArray()
+            } ?: throw Exception("Empty response body")
+
+            return when {
+                contentType.contains("text/html", ignoreCase = true) -> {
+                    extractHtmlContent(normalizedUrl, bytes)
+                }
+                contentType.contains("application/pdf", ignoreCase = true) -> {
+                    extractPdfContent(normalizedUrl, bytes)
+                }
+                contentType.startsWith("text/", ignoreCase = true) ||
+                    contentType.contains("json", ignoreCase = true) ||
+                    contentType.contains("xml", ignoreCase = true) -> {
+                    val text = String(bytes, Charsets.UTF_8)
+                    ExtractedUrlContent(
+                        url = normalizedUrl,
+                        title = extractTitleFromUrl(normalizedUrl),
+                        content = text.trim(),
+                        contentType = contentType,
+                    )
+                }
+                else -> {
+                    extractUsingTika(normalizedUrl, bytes, contentType)
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract content from HTML using Jsoup.
+     * Removes scripts, styles, navigation, ads, and other non-content elements.
+     */
+    private fun extractHtmlContent(url: String, bytes: ByteArray): ExtractedUrlContent {
+        val html = String(bytes, Charsets.UTF_8)
+        val doc = Jsoup.parse(html, url)
+
+        // Extract title
+        val title = doc.title().takeIf { it.isNotBlank() }
+
+        // Remove unwanted elements
+        doc.select("script, style, nav, header, footer, aside, .ad, .advertisement, .sidebar, .menu, .navigation").remove()
+
+        val mainContent = doc.select("article, main, .content, .post, .entry, #content").firstOrNull()
+            ?: doc.body()
+
+        val cleanText = mainContent?.text()?.trim() ?: ""
+
+        val finalContent = if (cleanText.length < 100) {
+            doc.body()?.text()?.trim() ?: cleanText
+        } else {
+            cleanText
+        }
+
+        return ExtractedUrlContent(
+            url = url,
+            title = title,
+            content = finalContent,
+            contentType = "text/html",
+        )
+    }
+
+    /**
+     * Extract content from PDF using Tika.
+     */
+    private fun extractPdfContent(url: String, bytes: ByteArray): ExtractedUrlContent {
+        val content = extractUsingTika(url, bytes, "application/pdf")
+        return content.copy(
+            title = content.title ?: extractTitleFromUrl(url),
+        )
+    }
+
+    /**
+     * Extract content using Tika parser.
+     */
+    private fun extractUsingTika(url: String, bytes: ByteArray, contentType: String): ExtractedUrlContent {
+        try {
+            ByteArrayInputStream(bytes).use { stream ->
+                val handler = BodyContentHandler(-1) // -1 = no character limit
+                val metadata = Metadata()
+                metadata.set("resourceName", url)
+                metadata.set("Content-Type", contentType)
+
+                parser.parse(stream, handler, metadata)
+
+                val extractedText = handler.toString().trim()
+                val title = metadata.get("title")?.takeIf { it.isNotBlank() }
+                    ?: extractTitleFromUrl(url)
+
+                return ExtractedUrlContent(
+                    url = url,
+                    title = title,
+                    content = extractedText,
+                    contentType = contentType,
+                )
+            }
+        } catch (e: Exception) {
+            throw Exception("Failed to parse content from URL: $url", e)
+        }
+    }
+
+    /**
+     * Check if a URL is supported for content extraction.
+     *
+     * @param url The URL to check
+     * @return true if the URL is supported, false otherwise
+     */
+    fun isSupported(url: String): Boolean = try {
+        val uri = URI(url.trim())
+
+        uri.scheme in listOf("http", "https")
+    } catch (_: Exception) {
+        try {
+            val normalizedUrl = normalizeUrl(url)
+            val uri = URI(normalizedUrl)
+            uri.scheme in listOf("http", "https")
+        } catch (e2: Exception) {
+            log.debug("URL validation failed for: $url", e2)
+            false
+        }
+    }
+
+    /**
+     * Check if a string is a valid URL.
+     */
+    fun isUrl(text: String): Boolean = URL_REGEX.matches(text.trim())
+
+    /**
+     * Extract all URLs from a message.
+     */
+    fun extractUrls(message: String): List<String> = URL_REGEX.findAll(message)
+        .map { it.value }
+        .filter { isSupported(it) }
+        .toList()
+
+    /**
+     * Normalize URL by adding protocol if missing.
+     */
+    private fun normalizeUrl(url: String): String {
+        val trimmed = url.trim()
+        return if (trimmed.contains("://")) {
+            trimmed
+        } else {
+            "https://$trimmed"
+        }
+    }
+
+    /**
+     * Extract a title from URL (last path segment or domain).
+     */
+    private fun extractTitleFromUrl(url: String): String = try {
+        val uri = URI(url)
+        val path = uri.path.trim('/')
+
+        if (path.isNotBlank()) {
+            path.split('/').last()
+                .replace(Regex("[_-]"), " ")
+                .replaceFirstChar { it.uppercase() }
+        } else {
+            uri.host
+        }
+    } catch (_: Exception) {
+        url
+    }
+
+    /**
+     * Get a user-friendly message for unsupported URLs.
+     */
+    fun getUnsupportedMessage(url: String): String = try {
+        val uri = URI(normalizeUrl(url))
+        when (uri.scheme) {
+            "ftp", "ftps" -> "FTP links are not supported"
+            "file" -> "Local file URLs are not supported"
+            else -> "Unsupported URL scheme: ${uri.scheme}"
+        }
+    } catch (_: Exception) {
+        "Invalid URL format"
+    }
+
+    /**
+     * Regex pattern for detecting URLs in text.
+     */
+    private val URL_REGEX = Regex(
+        """https?://[^\s<>"{}|\\^`\[\]]+""",
+        RegexOption.IGNORE_CASE,
+    )
+}

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -206,6 +206,7 @@ data class ChatConfig(
     val maxTokens: Int = 8000,
     val summarizationThreshold: Double = 0.75,
     val enableAsyncSummarization: Boolean = true,
+    val summarizationTimeoutSeconds: Long = 60,
 )
 
 /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -25,6 +25,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
 
     companion object {
         private const val UTILITY_MODEL = "claude-3-haiku-20240307"
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
     }
 
     override fun availableModels(settings: AnthropicSettings): List<String> = listOf(
@@ -73,7 +74,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         .apiKey(safeApiKey(settings.apiKey))
         .modelName(UTILITY_MODEL)
         .baseUrl(settings.baseUrl)
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -25,6 +25,10 @@ import java.time.Duration
 class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
     private val log = logger<DockerAiModelFactory>()
 
+    companion object {
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
+    }
+
     override fun availableModels(settings: DockerAiSettings): List<String> = try {
         val process =
             ProcessBuilderExt("docker", "model", "ls", "--openai")
@@ -101,7 +105,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey("docker-ai")
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -27,6 +27,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
 
     companion object {
         private const val UTILITY_MODEL = "gemini-1.5-flash"
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
     }
 
     override fun availableModels(settings: GeminiSettings): List<String> {
@@ -115,7 +116,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
     private fun createSecondaryChatModel(settings: GeminiSettings): ChatModel = GoogleAiGeminiChatModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
         .modelName(UTILITY_MODEL)
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
@@ -27,6 +27,10 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
 
     private val log = logger<LmStudioModelFactory>()
 
+    companion object {
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
+    }
+
     override fun availableModels(settings: LmStudioSettings): List<String> = fetchModels(
         apiKey = "lm-studio",
         url = "${settings.baseUrl}/v1/models",
@@ -87,7 +91,7 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
             .baseUrl(settings.baseUrl)
             .apiKey("lm-studio")
             .modelName(AppContext.getInstance().params.model)
-            .timeout(Duration.ofSeconds(10))
+            .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
             .httpClientBuilder(jdkHttpClientBuilder)
             .build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
@@ -22,6 +22,10 @@ import java.time.Duration
 
 class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
 
+    companion object {
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
+    }
+
     override fun availableModels(settings: LocalAiSettings): List<String> {
         val baseUrl = settings.baseUrl.takeIf { it.isNotBlank() } ?: return emptyList()
 
@@ -71,7 +75,7 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey("localai")
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -24,6 +24,10 @@ import java.time.Duration
 class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
     private val log = logger<OllamaModelFactory>()
 
+    companion object {
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
+    }
+
     override fun availableModels(settings: OllamaSettings): List<String> {
         val baseUrl = settings.baseUrl.takeIf { it.isNotBlank() } ?: return emptyList()
 
@@ -84,7 +88,7 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey("ollama")
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
         .logger(log)
         .logRequests(log.isDebugEnabled)
         .build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -26,6 +26,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
 
     companion object {
         private const val UTILITY_MODEL = "gpt-3.5-turbo"
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
     }
 
     override fun availableModels(settings: OpenAiSettings): List<String> {
@@ -87,7 +88,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
     private fun createSecondaryChatModel(settings: OpenAiSettings): ChatModel = OpenAiChatModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
         .modelName(UTILITY_MODEL)
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
@@ -25,6 +25,10 @@ import java.time.Duration
 class XAiModelFactory : ChatModelFactory<XAiSettings> {
     private val log = logger<XAiModelFactory>()
 
+    companion object {
+        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
+    }
+
     override fun availableModels(settings: XAiSettings): List<String> {
         val apiKey = settings.apiKey.takeIf { it.isNotBlank() } ?: return emptyList()
         val url = "${settings.baseUrl.trimEnd('/')}/models"
@@ -78,7 +82,7 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey(safeApiKey(settings.apiKey))
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(10))
+        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/test/kotlin/io/askimo/core/chat/util/UrlContentExtractorTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/chat/util/UrlContentExtractorTest.kt
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.chat.util
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class UrlContentExtractorTest {
+
+    @Test
+    fun `should detect valid URLs`() {
+        assertTrue(UrlContentExtractor.isUrl("https://example.com"))
+        assertTrue(UrlContentExtractor.isUrl("http://example.com/path"))
+        assertTrue(UrlContentExtractor.isUrl("https://docs.oracle.com/javase/8/docs/api/"))
+        assertFalse(UrlContentExtractor.isUrl("not a url"))
+        assertFalse(UrlContentExtractor.isUrl("example.com"))
+    }
+
+    @Test
+    fun `should extract URLs from message`() {
+        val message = """
+            Check out this link: https://example.com
+            And also https://github.com/user/repo
+        """.trimIndent()
+
+        val urls = UrlContentExtractor.extractUrls(message)
+        assertEquals(2, urls.size)
+        assertTrue(urls.contains("https://example.com"))
+        assertTrue(urls.contains("https://github.com/user/repo"))
+    }
+
+    @Test
+    fun `should normalize URLs`() {
+        assertTrue(UrlContentExtractor.isSupported("https://example.com"))
+        assertTrue(UrlContentExtractor.isSupported("http://example.com"))
+        assertFalse(UrlContentExtractor.isSupported("ftp://example.com"))
+        assertFalse(UrlContentExtractor.isSupported("file:///path/to/file"))
+    }
+
+    @Test
+    fun `should provide unsupported messages`() {
+        val ftpMessage = UrlContentExtractor.getUnsupportedMessage("ftp://example.com")
+        assertTrue(ftpMessage.contains("FTP"))
+
+        val fileMessage = UrlContentExtractor.getUnsupportedMessage("file:///path")
+        assertTrue(fileMessage.contains("Local file"))
+    }
+
+    @Test
+    fun `should extract content from HTML page`() {
+        // This test requires network access - skip in CI
+        if (System.getenv("CI") != null) {
+            return
+        }
+
+        try {
+            val result = UrlContentExtractor.extractContent("https://example.com")
+            assertNotNull(result)
+            assertNotNull(result.content)
+            assertTrue(result.content.isNotBlank())
+            assertEquals("https://example.com", result.url)
+        } catch (e: Exception) {
+            // Network tests can fail - that's okay
+            println("Network test skipped: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
- Add UrlContentExtractor using OkHttp and Jsoup to fetch and parse pages
- Enrich ChatSessionService prompts with extracted URL title and body text
- Expose configurable summarization timeout via AppConfig
- Increase default summarization timeout to reduce premature cancellations
- Fix summarization lock release to avoid deadlocks on timeout
- Extend utility-model HTTP timeouts across providers for longer operations