### PR TITLE
**feat(shared): refactor chat session service to use mode from app context**

### DIFF
--- a/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
@@ -291,7 +291,7 @@ fun main(args: Array<String>) {
                 }
             } else {
                 val prompt = parsedLine.line()
-                val output = sendChatMessage(mode, prompt, reader.terminal, chatSessionService)
+                val output = sendChatMessage(prompt, reader.terminal, chatSessionService)
                 CliInteractiveContext.setLastResponse(output)
                 reader.terminal.writer().println()
                 reader.terminal.writer().flush()
@@ -311,7 +311,6 @@ private fun sendNonInteractiveChatMessage(
 ): String = streamChatResponse(chatClient, prompt, terminal)
 
 private fun sendChatMessage(
-    mode: ExecutionMode,
     prompt: String,
     terminal: Terminal,
     chatSessionService: ChatSessionService,
@@ -319,7 +318,6 @@ private fun sendChatMessage(
     var currentSession = CliInteractiveContext.currentChatSession
     if (currentSession == null) {
         val session = chatSessionService.createSession(
-            mode,
             ChatSession(
                 id = "",
                 title = "New Chat",
@@ -329,7 +327,7 @@ private fun sendChatMessage(
         currentSession = session
     }
     val promptWithContext = chatSessionService.prepareContextAndGetPromptForChat(sessionId = currentSession.id, userMessage = prompt)
-    val chatClient = chatSessionService.getOrCreateClientForSession(mode, currentSession.id)
+    val chatClient = chatSessionService.getOrCreateClientForSession(currentSession.id)
     val output = streamChatResponse(chatClient, promptWithContext, terminal)
     chatSessionService.saveAiResponse(currentSession.id, output)
     return output

--- a/cli/src/main/kotlin/io/askimo/cli/commands/NewSessionCommandHandler.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/commands/NewSessionCommandHandler.kt
@@ -7,7 +7,6 @@ package io.askimo.cli.commands
 import io.askimo.cli.context.CliInteractiveContext
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.service.ChatSessionService
-import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.display
 import io.askimo.core.logging.logger
 import org.jline.reader.ParsedLine
@@ -19,7 +18,6 @@ class NewSessionCommandHandler(private val chatSessionService: ChatSessionServic
 
     override fun handle(line: ParsedLine) {
         val session = chatSessionService.createSession(
-            ExecutionMode.STATEFUL_TOOLS_MODE,
             ChatSession(
                 id = "",
                 title = "New Chat",

--- a/cli/src/main/kotlin/io/askimo/cli/commands/ResumeSessionCommandHandler.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/commands/ResumeSessionCommandHandler.kt
@@ -6,7 +6,6 @@ package io.askimo.cli.commands
 
 import io.askimo.cli.context.CliInteractiveContext
 import io.askimo.core.chat.service.ChatSessionService
-import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.display
 import io.askimo.core.logging.logger
 import org.jline.reader.ParsedLine
@@ -30,7 +29,7 @@ class ResumeSessionCommandHandler(private val sessionService: ChatSessionService
             return
         } else {
             CliInteractiveContext.setCurrentSession(session)
-            val result = sessionService.resumeSession(ExecutionMode.STATEFUL_TOOLS_MODE, sessionId)
+            val result = sessionService.resumeSession(sessionId)
             if (result.success) {
                 log.display("✅ Resumed chat session: $sessionId")
                 if (result.messages.isNotEmpty()) {

--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -2448,13 +2448,17 @@
     "queryAllDeclaredMethods": true,
     "queryAllDeclaredConstructors": true,
     "methods": [
-      { "name": "<init>", "parameterTypes": ["int", "double", "boolean"] },
+      {
+        "name": "<init>",
+        "parameterTypes": ["int", "double", "boolean", "long"]
+      },
       {
         "name": "<init>",
         "parameterTypes": [
           "int",
           "double",
           "boolean",
+          "long",
           "int",
           "kotlin.jvm.internal.DefaultConstructorMarker"
         ]
@@ -2696,7 +2700,8 @@
     "queryAllDeclaredConstructors": true,
     "methods": [
       { "name": "<init>", "parameterTypes": [] },
-      { "name": "autoPullsMissingModelAndEmbeds", "parameterTypes": [] }
+      { "name": "autoPullsMissingModelAndEmbeds", "parameterTypes": [] },
+      { "name": "setUp", "parameterTypes": [] }
     ]
   },
   {
@@ -2828,7 +2833,8 @@
     "methods": [
       { "name": "<init>", "parameterTypes": [] },
       { "name": "canCallCountEntriesTool", "parameterTypes": [] },
-      { "name": "canCreateChatServiceAndStream", "parameterTypes": [] }
+      { "name": "canCreateChatServiceAndStream", "parameterTypes": [] },
+      { "name": "setUp", "parameterTypes": [] }
     ]
   },
   {
@@ -3440,6 +3446,12 @@
   },
   {
     "name": "io.askimo.testcontainers.SharedOllama",
+    "allDeclaredClasses": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.askimo.testcontainers.TestContainersConfig",
     "allDeclaredClasses": true,
     "queryAllDeclaredMethods": true,
     "queryAllPublicMethods": true
@@ -4446,7 +4458,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$SIA4Govd",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$H27aXEsW",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/cli/src/test/kotlin/io/askimo/core/chat/service/ChatSessionServiceIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/chat/service/ChatSessionServiceIT.kt
@@ -248,7 +248,7 @@ class ChatSessionServiceIT {
         )
 
         // When
-        val result = service.resumeSession(ExecutionMode.STATEFUL_MODE, session.id)
+        val result = service.resumeSession(session.id)
 
         // Then
         assertTrue(result.success)
@@ -266,7 +266,7 @@ class ChatSessionServiceIT {
         val session = sessionRepository.createSession(ChatSession(id = "", title = "Empty Session"))
 
         // When
-        val result = service.resumeSession(ExecutionMode.STATEFUL_MODE, session.id)
+        val result = service.resumeSession(session.id)
 
         // Then
         assertTrue(result.success)
@@ -312,7 +312,7 @@ class ChatSessionServiceIT {
         )
 
         // When
-        val result = service.resumeSession(ExecutionMode.STATEFUL_MODE, session.id)
+        val result = service.resumeSession(session.id)
 
         // Then
         assertEquals(3, result.messages.size)
@@ -349,7 +349,7 @@ class ChatSessionServiceIT {
         service.markMessageAsOutdated(message2.id)
 
         // When
-        val result = service.resumeSession(ExecutionMode.STATEFUL_MODE, session.id)
+        val result = service.resumeSession(session.id)
 
         // Then
         assertEquals(2, result.messages.size)
@@ -375,7 +375,7 @@ class ChatSessionServiceIT {
         }
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 10)
+        val result = service.resumeSessionPaginated(session.id, limit = 10)
 
         // Then
         assertTrue(result.success)
@@ -405,7 +405,7 @@ class ChatSessionServiceIT {
         }
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 5)
+        val result = service.resumeSessionPaginated(session.id, limit = 5)
 
         // Then
         assertEquals(5, result.messages.size)
@@ -424,7 +424,7 @@ class ChatSessionServiceIT {
         val session = sessionRepository.createSession(ChatSession(id = "", title = "Empty Paginated"))
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 10)
+        val result = service.resumeSessionPaginated(session.id, limit = 10)
 
         // Then
         assertTrue(result.success)
@@ -453,7 +453,7 @@ class ChatSessionServiceIT {
         }
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 10)
+        val result = service.resumeSessionPaginated(session.id, limit = 10)
 
         // Then
         assertTrue(result.success)
@@ -468,7 +468,7 @@ class ChatSessionServiceIT {
         val nonExistentId = "non-existent-session-id"
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, nonExistentId, limit = 10)
+        val result = service.resumeSessionPaginated(nonExistentId, limit = 10)
 
         // Then
         assertTrue(result.success)
@@ -509,7 +509,7 @@ class ChatSessionServiceIT {
         )
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 10)
+        val result = service.resumeSessionPaginated(session.id, limit = 10)
 
         // Then
         assertTrue(result.success)
@@ -534,7 +534,7 @@ class ChatSessionServiceIT {
         }
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 1)
+        val result = service.resumeSessionPaginated(session.id, limit = 1)
 
         // Then
         assertEquals(1, result.messages.size)
@@ -561,7 +561,7 @@ class ChatSessionServiceIT {
         }
 
         // When
-        val result = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 1000)
+        val result = service.resumeSessionPaginated(session.id, limit = 1000)
 
         // Then
         assertEquals(10, result.messages.size)
@@ -586,7 +586,7 @@ class ChatSessionServiceIT {
         )
 
         // When
-        val result = service.resumeSession(ExecutionMode.STATEFUL_MODE, session.id)
+        val result = service.resumeSession(session.id)
 
         // Then
         assertTrue(result.success)
@@ -612,14 +612,14 @@ class ChatSessionServiceIT {
         }
 
         // When - Load first page
-        val firstResult = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 5)
+        val firstResult = service.resumeSessionPaginated(session.id, limit = 5)
 
         // Then - First page should be consistent
         assertEquals(5, firstResult.messages.size)
         assertTrue(firstResult.hasMore)
 
         // When - Load again (should get same results for first page)
-        val secondResult = service.resumeSessionPaginated(ExecutionMode.STATEFUL_MODE, session.id, limit = 5)
+        val secondResult = service.resumeSessionPaginated(session.id, limit = 5)
 
         // Then - Results should be identical
         assertEquals(firstResult.messages.size, secondResult.messages.size)

--- a/cli/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
@@ -4,10 +4,12 @@
  */
 package io.askimo.core.providers.ollama
 
+import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.providers.ChatClient
 import io.askimo.core.providers.sendStreamingMessageWithCallback
 import io.askimo.testcontainers.SharedOllama
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -23,6 +25,12 @@ import kotlin.test.assertTrue
 @Testcontainers
 @TestInstance(Lifecycle.PER_CLASS)
 class OllamaModelFactoryTest {
+
+    @BeforeEach
+    fun setUp() {
+        AppContext.reset()
+        AppContext.initialize(mode = ExecutionMode.STATELESS_MODE)
+    }
 
     private fun setupOllamaContainer(): String {
         val ollama = SharedOllama.container

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -168,7 +168,7 @@ fun detectMacOSDarkMode(): Boolean {
 private val log = logger("Main")
 
 fun main() {
-    AppContext.initialize(ExecutionMode.STATEFUL_TOOLS_MODE)
+    AppContext.initialize(ExecutionMode.STATEFUL_CHARTS_MODE)
 
     startKoin {
         modules(allDesktopModules)
@@ -340,7 +340,6 @@ fun app(frameWindowScope: FrameWindowScope? = null) {
                 sessionManager,
                 {
                     chatSessionService.createSession(
-                        ExecutionMode.STATEFUL_CHARTS_MODE,
                         ChatSession(
                             id = "",
                             title = "New Chat",

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/ChatViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/ChatViewModel.kt
@@ -13,7 +13,6 @@ import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTO
 import io.askimo.core.chat.repository.PaginationDirection
 import io.askimo.core.chat.service.ChatSessionService
-import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
 import io.askimo.desktop.util.ErrorHandler
 import kotlinx.coroutines.CoroutineScope
@@ -564,7 +563,6 @@ class ChatViewModel(
 
                 val result = withContext(Dispatchers.IO) {
                     chatSessionService.resumeSessionPaginated(
-                        ExecutionMode.STATEFUL_CHARTS_MODE,
                         sessionId,
                         MESSAGE_PAGE_SIZE,
                     )

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionManager.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionManager.kt
@@ -11,7 +11,6 @@ import io.askimo.core.chat.domain.ChatMessage
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.service.ChatSessionService
-import io.askimo.core.context.ExecutionMode
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.SessionCreatedEvent
 import io.askimo.core.exception.ExceptionHandler
@@ -164,7 +163,6 @@ class SessionManager(
             runBlocking {
                 withContext(Dispatchers.IO) {
                     chatSessionService.createSession(
-                        ExecutionMode.STATEFUL_CHARTS_MODE,
                         ChatSession(
                             id = sessionId,
                             title = userMessage,
@@ -214,7 +212,7 @@ class SessionManager(
         streamingScope.launch(thread.job) {
             try {
                 val fullResponse = chatSessionService
-                    .getOrCreateClientForSession(ExecutionMode.STATEFUL_MODE, sessionId)
+                    .getOrCreateClientForSession(sessionId)
                     .sendStreamingMessageWithCallback(promptWithContext) { token ->
                         streamingScope.launch {
                             thread.appendChunk(token)
@@ -359,7 +357,6 @@ class SessionManager(
             try {
                 // Create a new session associated with the project
                 val newSession = chatSessionService.createSession(
-                    ExecutionMode.STATEFUL_MODE,
                     ChatSession(
                         id = "",
                         title = message,

--- a/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
@@ -228,7 +228,6 @@ class AppContext private constructor(
      */
     fun createStatefulChatSession(
         sessionId: String,
-        executionMode: ExecutionMode,
         retriever: ContentRetriever? = null,
         memory: ChatMemory,
     ): ChatClient {


### PR DESCRIPTION
Remove dependency on ExecutionMode in ChatSessionService by using mode from AppContext. Update all direct calls to use the mode from the AppContext instance.