### PR TITLE
refactor(config): migrate model configuration to nested 'models' structure

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/service/MermaidSvgService.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/service/MermaidSvgService.kt
@@ -165,7 +165,7 @@ class MermaidSvgService {
             val exitCode = process.waitFor(30, TimeUnit.SECONDS)
 
             if (!exitCode || process.exitValue() != 0) {
-                log.error("Mermaid CLI failed with exit code: {}, output: {}", process.exitValue(), output)
+                log.error("Mermaid CLI failed with exit code: {}, diagram{}, output: {}", process.exitValue(), diagram, output)
                 throw IOException("Failed to convert Mermaid diagram: CLI returned exit code ${process.exitValue()}")
             }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/chat/MessageComponents.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/chat/MessageComponents.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -75,6 +76,7 @@ import io.askimo.desktop.theme.ComponentColors
 import io.askimo.desktop.util.highlightSearchText
 import io.askimo.desktop.view.components.markdownText
 import io.askimo.desktop.view.components.themedTooltip
+import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -546,13 +548,18 @@ fun messageBubble(
 
                 // AI message action controls - positioned in the gap below the message, always visible
                 if (!message.isUser) {
+                    var showCopyFeedback by remember { mutableStateOf(false) }
+                    val coroutineScope = rememberCoroutineScope()
+
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.Start,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         // Add padding to align with AI message bubble (icon 32dp + spacer 8dp)
                         Spacer(modifier = Modifier.width(40.dp))
+
                         Card(
                             colors = CardDefaults.cardColors(
                                 containerColor = Color.Transparent,
@@ -572,6 +579,11 @@ fun messageBubble(
                                     IconButton(
                                         onClick = {
                                             clipboardManager.setText(AnnotatedString(message.content))
+                                            showCopyFeedback = true
+                                            coroutineScope.launch {
+                                                kotlinx.coroutines.delay(2000)
+                                                showCopyFeedback = false
+                                            }
                                         },
                                         modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
                                     ) {
@@ -634,16 +646,52 @@ fun messageBubble(
                                 }
                             }
                         }
+
+                        // Copy feedback - to the right of action buttons
+                        if (showCopyFeedback) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = stringResource("mermaid.feedback.copied"),
+                                modifier = Modifier
+                                    .background(
+                                        MaterialTheme.colorScheme.primaryContainer,
+                                        shape = MaterialTheme.shapes.small,
+                                    )
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                style = MaterialTheme.typography.labelLarge,
+                            )
+                        }
                     }
                 }
 
                 // User message action controls - reserve space, show controls on hover
                 if (message.isUser) {
+                    var showCopyFeedback by remember { mutableStateOf(false) }
+                    val coroutineScope = rememberCoroutineScope()
+
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
+                        // Copy feedback - to the left of action buttons
+                        if (showCopyFeedback) {
+                            Text(
+                                text = stringResource("mermaid.feedback.copied"),
+                                modifier = Modifier
+                                    .background(
+                                        MaterialTheme.colorScheme.primaryContainer,
+                                        shape = MaterialTheme.shapes.small,
+                                    )
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                style = MaterialTheme.typography.labelLarge,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+
                         Box(
                             modifier = Modifier.height(40.dp), // Always reserve this space
                             contentAlignment = Alignment.Center,
@@ -668,6 +716,11 @@ fun messageBubble(
                                             IconButton(
                                                 onClick = {
                                                     clipboardManager.setText(AnnotatedString(message.content))
+                                                    showCopyFeedback = true
+                                                    coroutineScope.launch {
+                                                        kotlinx.coroutines.delay(2000)
+                                                        showCopyFeedback = false
+                                                    }
                                                 },
                                                 modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
                                             ) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/project/ProjectsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/project/ProjectsView.kt
@@ -162,17 +162,22 @@ fun projectsView(
 
                 viewModel.pagedProjects?.isEmpty == true -> {
                     Column(
-                        modifier = Modifier.align(Alignment.Center),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(16.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.Center,
                     ) {
                         Text(
                             text = stringResource("projects.empty"),
                             style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                        Spacer(modifier = Modifier.height(8.dp))
                         Text(
                             text = stringResource("projects.empty.hint"),
                             style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/sessions/SessionsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/sessions/SessionsView.kt
@@ -160,17 +160,22 @@ fun sessionsView(
 
                 viewModel.pagedSessions?.isEmpty == true -> {
                     Column(
-                        modifier = Modifier.align(Alignment.Center),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(16.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.Center,
                     ) {
                         Text(
                             text = stringResource("sessions.empty"),
                             style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                        Spacer(modifier = Modifier.height(8.dp))
                         Text(
                             text = stringResource("sessions.empty.hint"),
                             style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/settings/AIProviderSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/settings/AIProviderSettingsSection.kt
@@ -160,29 +160,5 @@ fun aiProviderSettingsSection(viewModel: SettingsViewModel) {
                 }
             }
         }
-
-        // Information Card
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = ComponentColors.bannerCardColors(),
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = stringResource("settings.ai.provider.info"),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    text = stringResource("settings.ai.provider.info.description"),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
-        }
     }
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/view/settings/AdvancedSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/view/settings/AdvancedSettingsSection.kt
@@ -723,12 +723,12 @@ private fun ragEmbeddingModelSelector() {
 
     // Get current value based on selected provider
     val currentValue = when (selectedProvider) {
-        "OpenAI" -> AppConfig.embeddingModels.openai
-        "Gemini" -> AppConfig.embeddingModels.gemini
-        "Ollama" -> AppConfig.embeddingModels.ollama
-        "Docker" -> AppConfig.embeddingModels.docker
-        "LocalAI" -> AppConfig.embeddingModels.localai
-        "LMStudio" -> AppConfig.embeddingModels.lmstudio
+        "OpenAI" -> AppConfig.models.openai.embeddingModel
+        "Gemini" -> AppConfig.models.gemini.embeddingModel
+        "Ollama" -> AppConfig.models.ollama.embeddingModel
+        "Docker" -> AppConfig.models.docker.embeddingModel
+        "LocalAI" -> AppConfig.models.localai.embeddingModel
+        "LMStudio" -> AppConfig.models.lmstudio.embeddingModel
         "Anthropic", "X AI" -> "N/A"
         else -> ""
     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/ChatViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/ChatViewModel.kt
@@ -481,6 +481,9 @@ class ChatViewModel(
 
                 if (threadId == null) {
                     errorMessage = "Please wait for the current response to complete before asking another question."
+                    isLoading = false
+                    isThinking = false
+                    stopThinkingTimer()
                     return@launch
                 }
 
@@ -492,13 +495,13 @@ class ChatViewModel(
             } catch (e: Exception) {
                 if (currentSessionId.value == sessionId) {
                     errorMessage = ErrorHandler.getUserFriendlyError(e, "sending message")
+                    // Only stop thinking timer on error
+                    isThinking = false
+                    stopThinkingTimer()
                 } else {
                     EventBus.emit(SendMessageErrorEvent(e))
                 }
-            } finally {
                 isLoading = false
-                isThinking = false
-                stopThinkingTimer()
             }
         }
     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SessionsViewModel.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * ViewModel for managing sessions view state and operations.
@@ -143,7 +145,6 @@ class SessionsViewModel(
     fun loadRecentSessions() {
         scope.launch {
             try {
-                // Query sessions without projects directly from database
                 val sessionsWithoutProject = withContext(Dispatchers.IO) {
                     sessionService.getSessionsWithoutProject()
                 }
@@ -405,8 +406,8 @@ class SessionsViewModel(
 
                 // Use simple default filename pattern instead of session title
                 // to avoid long filenames that cause errors
-                val timestamp = java.time.LocalDateTime.now().format(
-                    java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"),
+                val timestamp = LocalDateTime.now().format(
+                    DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"),
                 )
                 val defaultFilename = "chat_export_$timestamp"
 
@@ -534,9 +535,7 @@ class SessionsViewModel(
             }
 
             result.onSuccess {
-                // Show success message
                 successMessage = "${LocalizationManager.getString("session.export.success.message")} $fullPath"
-                // Close dialog on success
                 dismissExportDialog()
             }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SettingsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/viewmodel/SettingsViewModel.kt
@@ -694,7 +694,7 @@ class SettingsViewModel(
                 val result = withContext(Dispatchers.IO) {
                     when (provider) {
                         ModelProvider.OLLAMA -> {
-                            val modelName = AppConfig.embeddingModels.ollama
+                            val modelName = AppConfig.models.ollama.embeddingModel
                             LocalModelValidator.checkModelExists(
                                 provider,
                                 baseUrl,
@@ -702,7 +702,7 @@ class SettingsViewModel(
                             )
                         }
                         ModelProvider.DOCKER -> {
-                            val modelName = AppConfig.embeddingModels.docker
+                            val modelName = AppConfig.models.docker.embeddingModel
                             LocalModelValidator.checkModelExists(
                                 provider,
                                 baseUrl,
@@ -710,7 +710,7 @@ class SettingsViewModel(
                             )
                         }
                         ModelProvider.LOCALAI -> {
-                            val modelName = AppConfig.embeddingModels.localai
+                            val modelName = AppConfig.models.localai.embeddingModel
                             LocalModelValidator.checkModelExists(
                                 provider,
                                 baseUrl,
@@ -718,7 +718,7 @@ class SettingsViewModel(
                             )
                         }
                         ModelProvider.LMSTUDIO -> {
-                            val modelName = AppConfig.embeddingModels.lmstudio
+                            val modelName = AppConfig.models.lmstudio.embeddingModel
                             LocalModelValidator.checkModelExists(
                                 provider,
                                 baseUrl,
@@ -784,7 +784,7 @@ class SettingsViewModel(
         isCheckingEmbeddingModel = true
         scope.launch {
             try {
-                val modelName = AppConfig.embeddingModels.ollama
+                val modelName = AppConfig.models.ollama.embeddingModel
                 val success = withContext(Dispatchers.IO) {
                     LocalModelValidator.pullOllamaModel(baseUrl, modelName)
                 }

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -176,8 +176,6 @@ settings.error=Failed to save settings: {0}
 settings.provider.change.button=Change
 settings.model.change.button=Change
 settings.change.button=Change
-settings.ai.provider.info=Provider Configuration
-settings.ai.provider.info.description=Configure your AI provider, select a model, and adjust provider-specific settings. Changes take effect immediately.
 
 # Theme
 theme.light=Light

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -176,8 +176,6 @@ settings.chat.config=Chat-Konfiguration
 settings.provider.change.button=Ändern
 settings.model.change.button=Ändern
 settings.change.button=Ändern
-settings.ai.provider.info=Anbieter-Konfiguration
-settings.ai.provider.info.description=Konfigurieren Sie Ihren KI-Anbieter, wählen Sie ein Modell und passen Sie anbieterspezifische Einstellungen an. Änderungen werden sofort wirksam.
 
 # Theme
 theme.light=Hell

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -176,8 +176,6 @@ settings.chat.config=Configuración del chat
 settings.provider.change.button=Cambiar
 settings.model.change.button=Cambiar
 settings.change.button=Cambiar
-settings.ai.provider.info=Configuración del proveedor
-settings.ai.provider.info.description=Configure su proveedor de IA, seleccione un modelo y ajuste la configuración específica del proveedor. Los cambios se aplican inmediatamente.
 
 # Theme
 theme.light=Claro

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -176,8 +176,6 @@ settings.chat.config=Configuration du chat
 settings.provider.change.button=Modifier
 settings.model.change.button=Modifier
 settings.change.button=Modifier
-settings.ai.provider.info=Configuration du fournisseur
-settings.ai.provider.info.description=Configurez votre fournisseur d'IA, sélectionnez un modèle et ajustez les paramètres spécifiques au fournisseur. Les modifications prennent effet immédiatement.
 
 # Theme
 theme.light=Clair

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -176,8 +176,6 @@ settings.chat.config=チャット設定
 settings.provider.change.button=変更
 settings.model.change.button=変更
 settings.change.button=変更
-settings.ai.provider.info=プロバイダー設定
-settings.ai.provider.info.description=AIプロバイダーを設定し、モデルを選択し、プロバイダー固有の設定を調整します。変更は即座に反映されます。
 
 # Theme
 theme.light=ライト

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -177,8 +177,6 @@ settings.chat.config=채팅 구성
 settings.provider.change.button=변경
 settings.model.change.button=변경
 settings.change.button=변경
-settings.ai.provider.info=제공자 구성
-settings.ai.provider.info.description=AI 제공자를 구성하고 모델을 선택하며 제공자별 설정을 조정합니다. 변경 사항은 즉시 적용됩니다.
 
 # Theme
 theme.light=라이트

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -176,8 +176,6 @@ settings.chat.config=Configuração do chat
 settings.provider.change.button=Alterar
 settings.model.change.button=Alterar
 settings.change.button=Alterar
-settings.ai.provider.info=Configuração do provedor
-settings.ai.provider.info.description=Configure seu provedor de IA, selecione um modelo e ajuste as configurações específicas do provedor. As alterações entram em vigor imediatamente.
 
 # Theme
 theme.light=Claro

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -176,8 +176,6 @@ settings.chat.config=Cấu hình trò chuyện
 settings.provider.change.button=Thay đổi
 settings.model.change.button=Thay đổi
 settings.change.button=Thay đổi
-settings.ai.provider.info=Cấu hình nhà cung cấp
-settings.ai.provider.info.description=Cấu hình nhà cung cấp AI, chọn mô hình và điều chỉnh cài đặt. Thay đổi có hiệu lực ngay lập tức.
 
 # Theme
 theme.light=Sáng

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -176,8 +176,6 @@ settings.chat.config=聊天配置
 settings.provider.change.button=更改
 settings.model.change.button=更改
 settings.change.button=更改
-settings.ai.provider.info=服务商配置
-settings.ai.provider.info.description=配置您的AI服务商，选择模型并调整服务商特定设置。更改立即生效。
 
 # Theme
 theme.light=浅色

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -176,8 +176,6 @@ settings.chat.config=聊天設定
 settings.provider.change.button=變更
 settings.model.change.button=變更
 settings.change.button=變更
-settings.ai.provider.info=供應商設定
-settings.ai.provider.info.description=設定您的AI供應商，選擇模型並調整供應商特定設定。變更立即生效。
 
 # Theme
 theme.light=亮色

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -31,15 +31,6 @@ data class EmbeddingConfig(
     val preferredDim: Int? = null,
 )
 
-data class EmbeddingModelsConfig(
-    val openai: String = "text-embedding-3-small",
-    val docker: String = "ai/qwen3-embedding:0.6B-F16",
-    val ollama: String = "nomic-embed-text:latest",
-    val localai: String = "nomic-embed-text:latest",
-    val lmstudio: String = "nomic-embed-text:latest",
-    val gemini: String = "text-embedding-004",
-)
-
 data class RetryConfig(
     val attempts: Int = 4,
     val baseDelayMs: Long = 150,
@@ -232,25 +223,85 @@ data class ProxyConfig(
     val authToken: String = "",
 )
 
+data class AnthropicModelConfig(
+    val availableModels: List<String> = listOf(
+        "claude-opus-4-1",
+        "claude-opus-4-0",
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-0",
+        "claude-3-7-sonnet-latest",
+        "claude-3-5-haiku-latest",
+    ),
+    val utilityModel: String = "claude-3-haiku-20240307",
+    val utilityModelTimeoutSeconds: Long = 45,
+)
+
+data class GeminiModelConfig(
+    val utilityModel: String = "gemini-1.5-flash",
+    val utilityModelTimeoutSeconds: Long = 45,
+    val embeddingModel: String = "text-embedding-004",
+)
+
+data class OpenAiModelConfig(
+    val utilityModel: String = "gpt-3.5-turbo",
+    val utilityModelTimeoutSeconds: Long = 45,
+    val embeddingModel: String = "text-embedding-3-small",
+)
+
+data class OllamaModelConfig(
+    val utilityModelTimeoutSeconds: Long = 45,
+    val embeddingModel: String = "nomic-embed-text:latest",
+)
+
+data class DockerModelConfig(
+    val utilityModelTimeoutSeconds: Long = 45,
+    val embeddingModel: String = "ai/qwen3-embedding:0.6B-F16",
+)
+
+data class LocalAiModelConfig(
+    val utilityModelTimeoutSeconds: Long = 45,
+    val embeddingModel: String = "nomic-embed-text:latest",
+)
+
+data class LmStudioModelConfig(
+    val utilityModelTimeoutSeconds: Long = 45,
+    val embeddingModel: String = "nomic-embed-text:latest",
+)
+
+data class XAiModelConfig(
+    val utilityModelTimeoutSeconds: Long = 45,
+)
+
+data class ModelsConfig(
+    val anthropic: AnthropicModelConfig = AnthropicModelConfig(),
+    val gemini: GeminiModelConfig = GeminiModelConfig(),
+    val openai: OpenAiModelConfig = OpenAiModelConfig(),
+    val ollama: OllamaModelConfig = OllamaModelConfig(),
+    val docker: DockerModelConfig = DockerModelConfig(),
+    val localai: LocalAiModelConfig = LocalAiModelConfig(),
+    val lmstudio: LmStudioModelConfig = LmStudioModelConfig(),
+    val xai: XAiModelConfig = XAiModelConfig(),
+)
+
 data class AppConfigData(
     val embedding: EmbeddingConfig = EmbeddingConfig(),
-    val embeddingModels: EmbeddingModelsConfig = EmbeddingModelsConfig(),
     val retry: RetryConfig = RetryConfig(),
     val throttle: ThrottleConfig = ThrottleConfig(),
     val indexing: IndexingConfig = IndexingConfig(),
     val developer: DeveloperConfig = DeveloperConfig(),
     val chat: ChatConfig = ChatConfig(),
     val rag: RagConfig = RagConfig(),
+    val models: ModelsConfig = ModelsConfig(),
 )
 
 object AppConfig {
     val embedding: EmbeddingConfig get() = delegate.embedding
-    val embeddingModels: EmbeddingModelsConfig get() = delegate.embeddingModels
     val retry: RetryConfig get() = delegate.retry
     val indexing: IndexingConfig get() = delegate.indexing
     val developer: DeveloperConfig get() = delegate.developer
     val chat: ChatConfig get() = delegate.chat
     val rag: RagConfig get() = delegate.rag
+    val models: ModelsConfig get() = delegate.models
 
     val proxy: ProxyConfig by lazy { loadProxyFromEnv() }
 
@@ -274,12 +325,6 @@ object AppConfig {
           chunk_overlap:       ${'$'}{ASKIMO_EMBED_CHUNK_OVERLAP:200}
           preferred_dim:       ${'$'}{ASKIMO_EMBED_DIM:}
 
-        embedding_models:
-          openai:    ${'$'}{ASKIMO_EMBED_MODEL_OPENAI:text-embedding-3-small}
-          docker:    ${'$'}{ASKIMO_EMBED_MODEL_DOCKER:text-embedding-3-small}
-          ollama:    ${'$'}{ASKIMO_EMBED_MODEL_OLLAMA:nomic-embed-text:latest}
-          localai:   ${'$'}{ASKIMO_EMBED_MODEL_LOCALAI:text-embedding-3-small}
-          lmstudio:  ${'$'}{ASKIMO_EMBED_MODEL_LMSTUDIO:text-embedding-3-small}
 
         retry:
           attempts:      ${'$'}{ASKIMO_EMBED_RETRY_ATTEMPTS:4}
@@ -307,6 +352,34 @@ object AppConfig {
           vector_search_min_score: ${'$'}{ASKIMO_RAG_VECTOR_SEARCH_MIN_SCORE:0.3}
           hybrid_max_results: ${'$'}{ASKIMO_RAG_HYBRID_MAX_RESULTS:15}
           rank_fusion_constant: ${'$'}{ASKIMO_RAG_RANK_FUSION_CONSTANT:60}
+
+        models:
+          anthropic:
+            available_models: ${'$'}{ASKIMO_ANTHROPIC_MODELS:claude-opus-4-1,claude-opus-4-0,claude-sonnet-4-5,claude-sonnet-4-0,claude-3-7-sonnet-latest,claude-3-5-haiku-latest}
+            utility_model: ${'$'}{ASKIMO_ANTHROPIC_UTILITY_MODEL:claude-3-haiku-20240307}
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_ANTHROPIC_UTILITY_TIMEOUT:45}
+          gemini:
+            utility_model: ${'$'}{ASKIMO_GEMINI_UTILITY_MODEL:gemini-1.5-flash}
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_GEMINI_UTILITY_TIMEOUT:45}
+            embedding_model: ${'$'}{ASKIMO_GEMINI_EMBEDDING_MODEL:text-embedding-004}
+          openai:
+            utility_model: ${'$'}{ASKIMO_OPENAI_UTILITY_MODEL:gpt-3.5-turbo}
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_OPENAI_UTILITY_TIMEOUT:45}
+            embedding_model: ${'$'}{ASKIMO_OPENAI_EMBEDDING_MODEL:text-embedding-3-small}
+          ollama:
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_OLLAMA_UTILITY_TIMEOUT:45}
+            embedding_model: ${'$'}{ASKIMO_OLLAMA_EMBEDDING_MODEL:nomic-embed-text:latest}
+          docker:
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_DOCKER_UTILITY_TIMEOUT:45}
+            embedding_model: ${'$'}{ASKIMO_DOCKER_EMBEDDING_MODEL:ai/qwen3-embedding:0.6B-F16}
+          localai:
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_LOCALAI_UTILITY_TIMEOUT:45}
+            embedding_model: ${'$'}{ASKIMO_LOCALAI_EMBEDDING_MODEL:nomic-embed-text:latest}
+          lmstudio:
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_LMSTUDIO_UTILITY_TIMEOUT:45}
+            embedding_model: ${'$'}{ASKIMO_LMSTUDIO_EMBEDDING_MODEL:nomic-embed-text:latest}
+          xai:
+            utility_model_timeout_seconds: ${'$'}{ASKIMO_XAI_UTILITY_TIMEOUT:45}
 
         developer:
           enabled: ${'$'}{ASKIMO_DEVELOPER_ENABLED:false}
@@ -438,14 +511,6 @@ object AppConfig {
                 chunkOverlap = envInt("ASKIMO_EMBED_CHUNK_OVERLAP", 200),
                 preferredDim = envNullableInt("ASKIMO_EMBED_DIM"),
             )
-        val embModels =
-            EmbeddingModelsConfig(
-                openai = env("ASKIMO_EMBED_MODEL_OPENAI", "text-embedding-3-small"),
-                docker = env("ASKIMO_EMBED_MODEL_DOCKER", "text-embedding-3-small"),
-                ollama = env("ASKIMO_EMBED_MODEL_OLLAMA", "nomic-embed-text:latest"),
-                localai = env("ASKIMO_EMBED_MODEL_LOCALAI", "text-embedding-3-small"),
-                lmstudio = env("ASKIMO_EMBED_MODEL_LMSTUDIO", "text-embedding-3-small"),
-            )
         val r =
             RetryConfig(
                 attempts = envInt("ASKIMO_EMBED_RETRY_ATTEMPTS", 4),
@@ -476,7 +541,81 @@ object AppConfig {
                 enableAsyncSummarization = System.getenv("ASKIMO_CHAT_ENABLE_ASYNC_SUMMARIZATION")?.toBoolean() ?: true,
             )
 
-        return AppConfigData(emb, embModels, r, t, idx, dev, chat)
+        val rag =
+            RagConfig(
+                vectorSearchMaxResults = envInt("ASKIMO_RAG_VECTOR_SEARCH_MAX_RESULTS", 20),
+                vectorSearchMinScore = envDouble("ASKIMO_RAG_VECTOR_SEARCH_MIN_SCORE", 0.3),
+                hybridMaxResults = envInt("ASKIMO_RAG_HYBRID_MAX_RESULTS", 15),
+                rankFusionConstant = envInt("ASKIMO_RAG_RANK_FUSION_CONSTANT", 60),
+            )
+
+        val anthropicModelConfig =
+            AnthropicModelConfig(
+                availableModels =
+                envList(
+                    "ASKIMO_ANTHROPIC_MODELS",
+                    "claude-opus-4-1,claude-opus-4-0,claude-sonnet-4-5,claude-sonnet-4-0,claude-3-7-sonnet-latest,claude-3-5-haiku-latest",
+                ).toList(),
+                utilityModel = env("ASKIMO_ANTHROPIC_UTILITY_MODEL", "claude-3-haiku-20240307"),
+                utilityModelTimeoutSeconds = envLong("ASKIMO_ANTHROPIC_UTILITY_TIMEOUT", 45L),
+            )
+
+        val geminiModelConfig =
+            GeminiModelConfig(
+                utilityModel = env("ASKIMO_GEMINI_UTILITY_MODEL", "gemini-1.5-flash"),
+                utilityModelTimeoutSeconds = envLong("ASKIMO_GEMINI_UTILITY_TIMEOUT", 45L),
+                embeddingModel = env("ASKIMO_GEMINI_EMBEDDING_MODEL", "text-embedding-004"),
+            )
+
+        val openaiModelConfig =
+            OpenAiModelConfig(
+                utilityModel = env("ASKIMO_OPENAI_UTILITY_MODEL", "gpt-3.5-turbo"),
+                utilityModelTimeoutSeconds = envLong("ASKIMO_OPENAI_UTILITY_TIMEOUT", 45L),
+                embeddingModel = env("ASKIMO_OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"),
+            )
+
+        val ollamaModelConfig =
+            OllamaModelConfig(
+                utilityModelTimeoutSeconds = envLong("ASKIMO_OLLAMA_UTILITY_TIMEOUT", 45L),
+                embeddingModel = env("ASKIMO_OLLAMA_EMBEDDING_MODEL", "nomic-embed-text:latest"),
+            )
+
+        val dockerModelConfig =
+            DockerModelConfig(
+                utilityModelTimeoutSeconds = envLong("ASKIMO_DOCKER_UTILITY_TIMEOUT", 45L),
+                embeddingModel = env("ASKIMO_DOCKER_EMBEDDING_MODEL", "ai/qwen3-embedding:0.6B-F16"),
+            )
+
+        val localaiModelConfig =
+            LocalAiModelConfig(
+                utilityModelTimeoutSeconds = envLong("ASKIMO_LOCALAI_UTILITY_TIMEOUT", 45L),
+                embeddingModel = env("ASKIMO_LOCALAI_EMBEDDING_MODEL", "nomic-embed-text:latest"),
+            )
+
+        val lmstudioModelConfig =
+            LmStudioModelConfig(
+                utilityModelTimeoutSeconds = envLong("ASKIMO_LMSTUDIO_UTILITY_TIMEOUT", 45L),
+                embeddingModel = env("ASKIMO_LMSTUDIO_EMBEDDING_MODEL", "nomic-embed-text:latest"),
+            )
+
+        val xaiModelConfig =
+            XAiModelConfig(
+                utilityModelTimeoutSeconds = envLong("ASKIMO_XAI_UTILITY_TIMEOUT", 45L),
+            )
+
+        val models =
+            ModelsConfig(
+                anthropic = anthropicModelConfig,
+                gemini = geminiModelConfig,
+                openai = openaiModelConfig,
+                ollama = ollamaModelConfig,
+                docker = dockerModelConfig,
+                localai = localaiModelConfig,
+                lmstudio = lmstudioModelConfig,
+                xai = xaiModelConfig,
+            )
+
+        return AppConfigData(emb, r, t, idx, dev, chat, rag, models)
     }
 
     /** Load proxy configuration from environment variables only - never persisted to file */
@@ -512,9 +651,9 @@ object AppConfig {
                 "retry" -> current.copy(retry = updateRetryField(current.retry, field, value))
                 "throttle" -> current.copy(throttle = updateThrottleField(current.throttle, field, value))
                 "embedding" -> current.copy(embedding = updateEmbeddingField(current.embedding, field, value))
-                "embeddingModels" -> current.copy(embeddingModels = updateEmbeddingModelsField(current.embeddingModels, field, value))
                 "chat" -> current.copy(chat = updateChatField(current.chat, field, value))
                 "rag" -> current.copy(rag = updateRagField(current.rag, field, value))
+                "models" -> current.copy(models = updateModelsField(current.models, field, value))
                 else -> {
                     log.displayError("Unknown config section: $section", null)
                     return
@@ -560,16 +699,6 @@ object AppConfig {
         else -> config
     }
 
-    private fun updateEmbeddingModelsField(config: EmbeddingModelsConfig, field: String, value: Any): EmbeddingModelsConfig = when (field) {
-        "openai" -> config.copy(openai = value as String)
-        "docker" -> config.copy(docker = value as String)
-        "ollama" -> config.copy(ollama = value as String)
-        "localai" -> config.copy(localai = value as String)
-        "lmstudio" -> config.copy(lmstudio = value as String)
-        "gemini" -> config.copy(gemini = value as String)
-        else -> config
-    }
-
     private fun updateChatField(config: ChatConfig, field: String, value: Any): ChatConfig = when (field) {
         "maxTokens" -> config.copy(maxTokens = value as Int)
         "summarizationThreshold" -> config.copy(summarizationThreshold = (value as Number).toDouble())
@@ -583,6 +712,14 @@ object AppConfig {
         "hybridMaxResults" -> config.copy(hybridMaxResults = value as Int)
         "rankFusionConstant" -> config.copy(rankFusionConstant = value as Int)
         else -> config
+    }
+
+    private fun updateModelsField(config: ModelsConfig, field: String, value: Any): ModelsConfig {
+        // For models section, we expect nested paths like "anthropic.utilityModel"
+        // This is handled differently - would need 3-part path support
+        // For now, we'll keep it simple and not support runtime updates to models config
+        log.displayError("Runtime updates to models config not yet supported", null)
+        return config
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
@@ -26,19 +27,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
 
     private val log = logger<AnthropicModelFactory>()
 
-    companion object {
-        private const val UTILITY_MODEL = "claude-3-haiku-20240307"
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
-
-    override fun availableModels(settings: AnthropicSettings): List<String> = listOf(
-        "claude-opus-4-1",
-        "claude-opus-4-0",
-        "claude-sonnet-4-5",
-        "claude-sonnet-4-0",
-        "claude-3-7-sonnet-latest",
-        "claude-3-5-haiku-latest",
-    )
+    override fun availableModels(settings: AnthropicSettings): List<String> = AppConfig.models.anthropic.availableModels
 
     override fun defaultSettings(): AnthropicSettings = AnthropicSettings()
 
@@ -78,9 +67,9 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
 
     private fun createSecondaryChatModel(settings: AnthropicSettings): ChatModel = AnthropicChatModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
-        .modelName(UTILITY_MODEL)
+        .modelName(AppConfig.models.anthropic.utilityModel)
         .baseUrl(settings.baseUrl)
-        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+        .timeout(Duration.ofSeconds(AppConfig.models.anthropic.utilityModelTimeoutSeconds))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.displayError
@@ -26,10 +27,6 @@ import java.time.Duration
 
 class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
     private val log = logger<DockerAiModelFactory>()
-
-    companion object {
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
 
     override fun availableModels(settings: DockerAiSettings): List<String> = try {
         val process =
@@ -110,7 +107,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey("docker-ai")
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+        .timeout(Duration.ofSeconds(AppConfig.models.docker.utilityModelTimeoutSeconds))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
@@ -27,11 +28,6 @@ import java.time.Duration
 class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
 
     private val log = logger<GeminiModelFactory>()
-
-    companion object {
-        private const val UTILITY_MODEL = "gemini-1.5-flash"
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
 
     override fun availableModels(settings: GeminiSettings): List<String> {
         val apiKey = settings.apiKey.takeIf { it.isNotBlank() } ?: return emptyList()
@@ -121,8 +117,8 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
 
     private fun createSecondaryChatModel(settings: GeminiSettings): ChatModel = GoogleAiGeminiChatModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
-        .modelName(UTILITY_MODEL)
-        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+        .modelName(AppConfig.models.gemini.utilityModel)
+        .timeout(Duration.ofSeconds(AppConfig.models.gemini.utilityModelTimeoutSeconds))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
@@ -11,6 +11,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
@@ -28,10 +29,6 @@ import java.time.Duration
 class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
 
     private val log = logger<LmStudioModelFactory>()
-
-    companion object {
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
 
     override fun availableModels(settings: LmStudioSettings): List<String> = fetchModels(
         apiKey = "lm-studio",
@@ -96,7 +93,7 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
             .baseUrl(settings.baseUrl)
             .apiKey("lm-studio")
             .modelName(AppContext.getInstance().params.model)
-            .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+            .timeout(Duration.ofSeconds(AppConfig.models.lmstudio.utilityModelTimeoutSeconds))
             .httpClientBuilder(jdkHttpClientBuilder)
             .build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.providers.AiServiceBuilder
@@ -23,10 +24,6 @@ import io.askimo.core.telemetry.TelemetryChatModelListener
 import java.time.Duration
 
 class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
-
-    companion object {
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
 
     override fun availableModels(settings: LocalAiSettings): List<String> {
         val baseUrl = settings.baseUrl.takeIf { it.isNotBlank() } ?: return emptyList()
@@ -79,7 +76,7 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey("localai")
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+        .timeout(Duration.ofSeconds(AppConfig.models.localai.utilityModelTimeoutSeconds))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
@@ -25,10 +26,6 @@ import java.time.Duration
 
 class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
     private val log = logger<OllamaModelFactory>()
-
-    companion object {
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
 
     override fun availableModels(settings: OllamaSettings): List<String> {
         val baseUrl = settings.baseUrl.takeIf { it.isNotBlank() } ?: return emptyList()
@@ -93,7 +90,7 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey("ollama")
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+        .timeout(Duration.ofSeconds(AppConfig.models.ollama.utilityModelTimeoutSeconds))
         .logger(log)
         .logRequests(log.isDebugEnabled)
         .build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
@@ -26,11 +27,6 @@ import java.time.Duration
 
 class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
     private val log = logger<OpenAiModelFactory>()
-
-    companion object {
-        private const val UTILITY_MODEL = "gpt-3.5-turbo"
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
 
     override fun availableModels(settings: OpenAiSettings): List<String> {
         val apiKey = settings.apiKey.takeIf { it.isNotBlank() } ?: return emptyList()
@@ -93,8 +89,8 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
 
     private fun createSecondaryChatModel(settings: OpenAiSettings): ChatModel = OpenAiChatModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
-        .modelName(UTILITY_MODEL)
-        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+        .modelName(AppConfig.models.openai.utilityModel)
+        .timeout(Duration.ofSeconds(AppConfig.models.openai.utilityModelTimeoutSeconds))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.logger
@@ -26,10 +27,6 @@ import java.time.Duration
 
 class XAiModelFactory : ChatModelFactory<XAiSettings> {
     private val log = logger<XAiModelFactory>()
-
-    companion object {
-        private const val UTILITY_MODEL_TIMEOUT_SECONDS = 45L
-    }
 
     override fun availableModels(settings: XAiSettings): List<String> {
         val apiKey = settings.apiKey.takeIf { it.isNotBlank() } ?: return emptyList()
@@ -87,7 +84,7 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
         .baseUrl(settings.baseUrl)
         .apiKey(safeApiKey(settings.apiKey))
         .modelName(AppContext.getInstance().params.model)
-        .timeout(Duration.ofSeconds(UTILITY_MODEL_TIMEOUT_SECONDS))
+        .timeout(Duration.ofSeconds(AppConfig.models.xai.utilityModelTimeoutSeconds))
         .build()
 
     override fun createUtilityClient(

--- a/shared/src/main/kotlin/io/askimo/core/rag/EmbeddingModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/EmbeddingModelFactory.kt
@@ -51,7 +51,7 @@ private val log = logger("EmbeddingModelFactory")
 fun getModelTokenLimit(appContext: AppContext): Int = try {
     when (val provider = appContext.getActiveProvider()) {
         OPENAI -> {
-            val modelName = AppConfig.embeddingModels.openai.lowercase()
+            val modelName = AppConfig.models.openai.embeddingModel.lowercase()
             when {
                 modelName.contains("text-embedding-3") -> 8191
                 modelName.contains("ada-002") -> 8191
@@ -60,7 +60,7 @@ fun getModelTokenLimit(appContext: AppContext): Int = try {
         }
 
         GEMINI -> {
-            val modelName = AppConfig.embeddingModels.gemini.lowercase()
+            val modelName = AppConfig.models.gemini.embeddingModel.lowercase()
             when {
                 modelName.contains("embedding-001") -> 2048
                 modelName.contains("text-embedding-004") -> 2048
@@ -72,10 +72,10 @@ fun getModelTokenLimit(appContext: AppContext): Int = try {
         // They often use the same model names with different prefixes
         OLLAMA, DOCKER, LOCALAI, LMSTUDIO -> {
             val modelName = when (provider) {
-                OLLAMA -> AppConfig.embeddingModels.ollama
-                DOCKER -> AppConfig.embeddingModels.docker
-                LOCALAI -> AppConfig.embeddingModels.localai
-                LMSTUDIO -> AppConfig.embeddingModels.lmstudio
+                OLLAMA -> AppConfig.models.ollama.embeddingModel
+                DOCKER -> AppConfig.models.docker.embeddingModel
+                LOCALAI -> AppConfig.models.localai.embeddingModel
+                LMSTUDIO -> AppConfig.models.lmstudio.embeddingModel
                 else -> ""
             }.lowercase()
 
@@ -132,7 +132,7 @@ fun getModelTokenLimit(appContext: AppContext): Int = try {
 fun getEmbeddingModel(appContext: AppContext): EmbeddingModel = when (appContext.getActiveProvider()) {
     OPENAI -> {
         val openAiKey = (appContext.getCurrentProviderSettings() as OpenAiSettings).apiKey
-        val modelName = AppConfig.embeddingModels.openai
+        val modelName = AppConfig.models.openai.embeddingModel
         OpenAiEmbeddingModelBuilder()
             .apiKey(safeApiKey(openAiKey))
             .modelName(modelName)
@@ -185,7 +185,7 @@ fun getEmbeddingModel(appContext: AppContext): EmbeddingModel = when (appContext
 
 private fun buildOllamaEmbeddingModel(settings: OllamaSettings): EmbeddingModel {
     val baseUrl = settings.baseUrl.removeSuffix("/")
-    val modelName = AppConfig.embeddingModels.ollama
+    val modelName = AppConfig.models.ollama.embeddingModel
 
     ensureModelAvailable(OLLAMA, baseUrl, modelName)
 
@@ -198,13 +198,13 @@ private fun buildOllamaEmbeddingModel(settings: OllamaSettings): EmbeddingModel 
 
 private fun buildGeminiEmbeddingModel(settings: GeminiSettings): EmbeddingModel {
     val apiKey = settings.apiKey
-    val modelName = AppConfig.embeddingModels.gemini
+    val modelName = AppConfig.models.gemini.embeddingModel
 
     log.display(
         """
         ℹ️  Using Gemini for embeddings
            • Embedding model: $modelName
-           • Configure in askimo.yml: embedding_models.gemini
+           • Configure in askimo.yml: models.gemini.embedding_model
         """.trimIndent(),
     )
 
@@ -216,14 +216,14 @@ private fun buildGeminiEmbeddingModel(settings: GeminiSettings): EmbeddingModel 
 
 private fun buildDockerEmbeddingModel(settings: DockerAiSettings): EmbeddingModel {
     val baseUrl = settings.baseUrl.removeSuffix("/")
-    val modelName = AppConfig.embeddingModels.docker
+    val modelName = AppConfig.models.docker.embeddingModel
 
     log.display(
         """
         ℹ️  Using Docker AI for embeddings
            • Docker AI URL: $baseUrl
            • Embedding model: $modelName
-           • Configure in askimo.yml: embedding_models.docker
+           • Configure in askimo.yml: models.docker.embedding_model
         """.trimIndent(),
     )
 
@@ -238,14 +238,14 @@ private fun buildDockerEmbeddingModel(settings: DockerAiSettings): EmbeddingMode
 
 private fun buildLocalAiEmbeddingModel(settings: LocalAiSettings): EmbeddingModel {
     val baseUrl = settings.baseUrl.removeSuffix("/")
-    val modelName = AppConfig.embeddingModels.localai
+    val modelName = AppConfig.models.localai.embeddingModel
 
     log.display(
         """
         ℹ️  Using LocalAI for embeddings
            • LocalAI URL: $baseUrl
            • Embedding model: $modelName
-           • Configure in askimo.yml: embedding_models.localai
+           • Configure in askimo.yml: models.localai.embedding_model
         """.trimIndent(),
     )
 
@@ -260,14 +260,14 @@ private fun buildLocalAiEmbeddingModel(settings: LocalAiSettings): EmbeddingMode
 
 private fun buildLmStudioEmbeddingModel(settings: LmStudioSettings): EmbeddingModel {
     val baseUrl = settings.baseUrl.removeSuffix("/")
-    val modelName = AppConfig.embeddingModels.lmstudio
+    val modelName = AppConfig.models.lmstudio.embeddingModel
 
     log.display(
         """
         ℹ️  Using LMStudio for embeddings
            • LMStudio URL: $baseUrl
            • Embedding model: $modelName
-           • Configure in askimo.yml: embedding_models.lmstudio
+           • Configure in askimo.yml: models.lmstudio.embedding_model
         """.trimIndent(),
     )
     ensureModelAvailable(LMSTUDIO, baseUrl, modelName)


### PR DESCRIPTION
- Update AppConfig to use nested 'models' section instead of 'embedding_models'.
- Refactor model factories to reference AppConfig.models.*.
- Update UI strings and error logs to reflect new config keys.
- Clean up unused imports and deprecated code.
- Adjust session and settings view logic for new configuration.

BREAKING CHANGE: The AppConfig model configuration structure has changed from embedding_models to models. Update askimo.yml accordingly.