### PR TITLE
refactor(rag-indexing): introduce provider registry for indexing coordinators

### DIFF
--- a/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
@@ -54,6 +54,7 @@ class AppContext private constructor(
         fun initialize(mode: ExecutionMode, params: AppContextParams? = null): AppContext {
             require(instance == null) { "AppContext already initialized" }
             executionMode = mode
+
             synchronized(this) {
                 val contextParams = params ?: AppContextConfigManager.load()
                 return AppContext(contextParams).also { instance = it }
@@ -68,13 +69,6 @@ class AppContext private constructor(
          * @throws IllegalStateException if AppContext has not been initialized
          */
         fun getInstance(): AppContext = instance ?: error("AppContext not initialized. Call AppContext.initialize() first.")
-
-        /**
-         * Gets the execution mode for the application.
-         *
-         * @return The current execution mode
-         */
-        fun getExecutionMode(): ExecutionMode = executionMode
 
         /**
          * Resets the singleton instance. Useful for testing or when configuration changes require a fresh instance.

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProvider.kt
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.rag.indexing
+
+import dev.langchain4j.data.segment.TextSegment
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.store.embedding.EmbeddingStore
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
+import io.askimo.core.context.AppContext
+
+/**
+ * Provider interface for creating IndexingCoordinator instances.
+ * Implement this interface to add support for new knowledge source types.
+ *
+ * Providers can be registered:
+ * 1. Programmatically via [IndexingCoordinatorProviderRegistry.registerProvider]
+ * 2. Automatically via Java ServiceLoader mechanism
+ */
+interface IndexingCoordinatorProvider {
+    /**
+     * Returns the type of KnowledgeSourceConfig this provider handles.
+     * This is used to match providers to knowledge sources.
+     *
+     * @return The Class object representing the supported KnowledgeSourceConfig type
+     */
+    fun supportedType(): Class<out KnowledgeSourceConfig>
+
+    /**
+     * Creates an IndexingCoordinator for the given knowledge source.
+     *
+     * @param projectId The project ID
+     * @param projectName The project name
+     * @param knowledgeSource The knowledge source configuration
+     * @param embeddingStore The embedding store for storing vectors
+     * @param embeddingModel The embedding model for generating embeddings
+     * @param appContext The application context
+     * @return A configured IndexingCoordinator instance
+     * @throws IllegalArgumentException if the knowledge source type is not supported
+     */
+    fun createCoordinator(
+        projectId: String,
+        projectName: String,
+        knowledgeSource: KnowledgeSourceConfig,
+        embeddingStore: EmbeddingStore<TextSegment>,
+        embeddingModel: EmbeddingModel,
+        appContext: AppContext,
+    ): IndexingCoordinator
+}

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProviderRegistry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProviderRegistry.kt
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.rag.indexing
+
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
+import io.askimo.core.rag.indexing.providers.LocalFilesIndexingProvider
+import io.askimo.core.rag.indexing.providers.LocalFoldersIndexingProvider
+import java.util.ServiceLoader
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Registry for IndexingCoordinatorProvider instances.
+ * Manages the mapping between KnowledgeSourceConfig types and their providers.
+ *
+ * This registry is self-initializing:
+ * - Built-in providers are registered automatically
+ * - External providers are discovered via Java ServiceLoader
+ *
+ * The initialization happens lazily on first access to ensure minimal startup overhead.
+ */
+object IndexingCoordinatorProviderRegistry {
+    private val providers = ConcurrentHashMap<Class<out KnowledgeSourceConfig>, IndexingCoordinatorProvider>()
+
+    @Volatile
+    private var initialized = false
+
+    init {
+        ensureInitialized()
+    }
+
+    /**
+     * Ensures the registry is initialized.
+     * This is called automatically but can be called explicitly if needed.
+     */
+    private fun ensureInitialized() {
+        if (!initialized) {
+            synchronized(this) {
+                if (!initialized) {
+                    // Register built-in providers
+                    registerBuiltInProviders()
+
+                    // Auto-discover providers via ServiceLoader
+                    loadProvidersFromServiceLoader()
+
+                    initialized = true
+                }
+            }
+        }
+    }
+
+    /**
+     * Register built-in providers that come with Askimo core.
+     */
+    private fun registerBuiltInProviders() {
+        registerProvider(LocalFoldersIndexingProvider())
+        registerProvider(LocalFilesIndexingProvider())
+    }
+
+    /**
+     * Auto-discover and register providers via ServiceLoader.
+     */
+    private fun loadProvidersFromServiceLoader() {
+        try {
+            val loader = ServiceLoader.load(IndexingCoordinatorProvider::class.java)
+            loader.forEach { provider ->
+                registerProvider(provider)
+            }
+        } catch (e: Exception) {
+            // Log error but don't fail initialization
+            System.err.println("Failed to load providers from ServiceLoader: ${e.message}")
+        }
+    }
+
+    /**
+     * Register a provider for a specific knowledge source type.
+     * If a provider for this type already exists, it will be replaced.
+     *
+     * @param provider The provider to register
+     */
+    fun registerProvider(provider: IndexingCoordinatorProvider) {
+        providers[provider.supportedType()] = provider
+    }
+
+    /**
+     * Get provider for a knowledge source.
+     * Returns null if no provider is registered for this type.
+     *
+     * @param knowledgeSource The knowledge source to find a provider for
+     * @return The provider if found, null otherwise
+     */
+    fun getProvider(knowledgeSource: KnowledgeSourceConfig): IndexingCoordinatorProvider? {
+        ensureInitialized()
+        return providers[knowledgeSource::class.java]
+    }
+
+    /**
+     * Get all registered providers.
+     *
+     * @return List of all registered providers
+     */
+    fun getAllProviders(): List<IndexingCoordinatorProvider> {
+        ensureInitialized()
+        return providers.values.toList()
+    }
+
+    /**
+     * Check if a provider is registered for a specific knowledge source type.
+     *
+     * @param type The knowledge source type to check
+     * @return true if a provider is registered, false otherwise
+     */
+    fun hasProvider(type: Class<out KnowledgeSourceConfig>): Boolean {
+        ensureInitialized()
+        return providers.containsKey(type)
+    }
+
+    /**
+     * Remove all registered providers and reset initialization.
+     * Primarily useful for testing.
+     */
+    fun clear() {
+        synchronized(this) {
+            providers.clear()
+            initialized = false
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFilesIndexingProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFilesIndexingProvider.kt
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.rag.indexing.providers
+
+import dev.langchain4j.data.segment.TextSegment
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.store.embedding.EmbeddingStore
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
+import io.askimo.core.chat.domain.LocalFilesKnowledgeSourceConfig
+import io.askimo.core.context.AppContext
+import io.askimo.core.rag.indexing.IndexingCoordinator
+import io.askimo.core.rag.indexing.IndexingCoordinatorProvider
+import io.askimo.core.rag.indexing.LocalFilesIndexingCoordinator
+import java.nio.file.Paths
+
+/**
+ * Provider for creating IndexingCoordinator instances for local file knowledge sources.
+ */
+class LocalFilesIndexingProvider : IndexingCoordinatorProvider {
+    override fun supportedType(): Class<out KnowledgeSourceConfig> = LocalFilesKnowledgeSourceConfig::class.java
+
+    override fun createCoordinator(
+        projectId: String,
+        projectName: String,
+        knowledgeSource: KnowledgeSourceConfig,
+        embeddingStore: EmbeddingStore<TextSegment>,
+        embeddingModel: EmbeddingModel,
+        appContext: AppContext,
+    ): IndexingCoordinator {
+        val config = knowledgeSource as LocalFilesKnowledgeSourceConfig
+        val filePaths = config.resourceIdentifiers.map { Paths.get(it) }
+
+        return LocalFilesIndexingCoordinator(
+            projectId = projectId,
+            projectName = projectName,
+            filePaths = filePaths,
+            embeddingStore = embeddingStore,
+            embeddingModel = embeddingModel,
+            appContext = appContext,
+        )
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFoldersIndexingProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFoldersIndexingProvider.kt
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.rag.indexing.providers
+
+import dev.langchain4j.data.segment.TextSegment
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.store.embedding.EmbeddingStore
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
+import io.askimo.core.chat.domain.LocalFoldersKnowledgeSourceConfig
+import io.askimo.core.context.AppContext
+import io.askimo.core.rag.indexing.IndexingCoordinator
+import io.askimo.core.rag.indexing.IndexingCoordinatorProvider
+import io.askimo.core.rag.indexing.LocalFoldersIndexingCoordinator
+import java.nio.file.Paths
+
+/**
+ * Provider for creating IndexingCoordinator instances for local folder knowledge sources.
+ */
+class LocalFoldersIndexingProvider : IndexingCoordinatorProvider {
+    override fun supportedType(): Class<out KnowledgeSourceConfig> = LocalFoldersKnowledgeSourceConfig::class.java
+
+    override fun createCoordinator(
+        projectId: String,
+        projectName: String,
+        knowledgeSource: KnowledgeSourceConfig,
+        embeddingStore: EmbeddingStore<TextSegment>,
+        embeddingModel: EmbeddingModel,
+        appContext: AppContext,
+    ): IndexingCoordinator {
+        val config = knowledgeSource as LocalFoldersKnowledgeSourceConfig
+        val paths = config.resourceIdentifiers.map { Paths.get(it) }
+
+        return LocalFoldersIndexingCoordinator(
+            projectId = projectId,
+            projectName = projectName,
+            paths = paths,
+            embeddingStore = embeddingStore,
+            embeddingModel = embeddingModel,
+            appContext = appContext,
+        )
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/tools/chart/ChartTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/chart/ChartTools.kt
@@ -98,13 +98,39 @@ CRITICAL MERMAID SYNTAX RULES (DO NOT VIOLATE):
 - ER diagram relationships MUST use valid cardinality (e.g., ||--o{, }o--||, ||--|{)
 - classDiagram stereotypes (e.g., <<interface>>, <<abstract>>, <<component>>) MUST be inside the class body
 
-XYCHART-BETA EXAMPLE (VALID):
+XYCHART-BETA CRITICAL RULES:
+1. For categorical x-axis (years, months, names, categories), ALWAYS use array syntax:
+   x-axis [2010, 2011, 2012, 2013, 2014, 2015]
+   x-axis ["Jan", "Feb", "Mar", "Apr", "May"]
+   x-axis ["Product A", "Product B", "Product C"]
+
+2. For continuous numeric x-axis with label only (rare):
+   x-axis "Time (ms)"
+
+3. The number of x-axis categories MUST match the number of data points in line/bar
+4. Y-axis always uses range syntax: y-axis "Label" min --> max
+
+XYCHART-BETA EXAMPLE WITH CATEGORICAL X-AXIS (MOST COMMON):
 xychart-beta
-    title "Sales Data"
-    x-axis "Month"
+    title "Stock Price 2010-2015"
+    x-axis [2010, 2011, 2012, 2013, 2014, 2015]
+    y-axis "Price (USD)" 0 --> 1000
+    line [320, 520, 650, 800, 470, 850]
+
+XYCHART-BETA EXAMPLE WITH MONTH LABELS:
+xychart-beta
+    title "Monthly Sales"
+    x-axis ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
     y-axis "Revenue" 0 --> 1000
-    line [100, 200, 150, 300, 250]
-    bar [80, 180, 120, 280, 230]
+    line [100, 200, 150, 300, 250, 280]
+    bar [80, 180, 120, 280, 230, 260]
+
+WRONG (DO NOT DO THIS):
+xychart-beta
+    title "Stock Price 2010-2015"
+    x-axis "Year"  ❌ Missing category array! This will render incorrectly.
+    y-axis "Price (USD)" 0 --> 1000
+    line [320, 520, 650, 800, 470, 850]
 
 
 BLOCK-BETA EXAMPLE (VALID):


### PR DESCRIPTION
- Replace factory branching with pluggable provider registry
- Add provider interface and registry to support extensible knowledge sources
- Implement local-files and local-folders indexing providers
- Reduce AppContext surface by removing execution mode accessor
- Expand Mermaid xychart-beta guidance to prevent invalid categorical axes