### PR TITLE
fix(content-sanitizer): sanitize extracted content to prevent variable template issues

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/session/SessionManager.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/session/SessionManager.kt
@@ -239,6 +239,13 @@ class SessionManager(
                 val savedMessage = chatSessionService.saveAiResponse(sessionId, failedResponse, isFailed = true)
                 thread.setSavedMessage(savedMessage)
 
+                if (failedResponse != partialResponse) {
+                    val remainingContent = failedResponse.substring(partialResponse.length)
+                    if (remainingContent.isNotEmpty()) {
+                        thread.appendChunk(remainingContent)
+                    }
+                }
+
                 // Mark as complete so the ChatViewModel's completion monitoring triggers
                 // and replaces the temporary message with the saved one from database
                 thread.markComplete()

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/ContentSanitizer.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/ContentSanitizer.kt
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.chat.util
+
+/**
+ * Sanitizes content to prevent conflicts with template engines.
+ * Escapes template variable syntax (e.g., {{variable}}) by adding spaces.
+ */
+object ContentSanitizer {
+
+    /**
+     * Sanitize template variables in content by escaping mustache syntax.
+     * Replaces {{ with { { and }} with } } to prevent template engine errors.
+     */
+    fun sanitizeTemplateVariables(content: String): String = content
+        .replace("{{", "{ {")
+        .replace("}}", "} }")
+}

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/FileContentExtractor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/FileContentExtractor.kt
@@ -38,7 +38,7 @@ object FileContentExtractor {
         if (FileTypeSupport.isTextExtractable(extension) &&
             extension in (FileTypeSupport.TEXT_EXTENSIONS + FileTypeSupport.CODE_EXTENSIONS)
         ) {
-            return file.readText()
+            return ContentSanitizer.sanitizeTemplateVariables(file.readText())
         }
 
         val mimeType = detectMimeType(file)
@@ -63,19 +63,19 @@ object FileContentExtractor {
                 mimeType.contains("application/vnd.ms-outlook") ||
                 // RTF
                 mimeType.contains("rtf") -> {
-                extractUsingTika(file)
+                ContentSanitizer.sanitizeTemplateVariables(extractUsingTika(file))
             }
             // Plain text files (includes CSV, TSV, etc.)
             mimeType.startsWith("text/") ||
                 mimeType in SUPPORTED_APPLICATION_TYPES -> {
-                file.readText()
+                ContentSanitizer.sanitizeTemplateVariables(file.readText())
             }
             // Fallback: Extension-based check for files Tika misdetects
             // This handles .md, .gradle.kts, .gitignore, and other text files
             mimeType == "application/octet-stream" ||
                 mimeType.startsWith("application/x-") -> {
                 if (extension in FileTypeSupport.DOCUMENT_EXTENSIONS) {
-                    extractUsingTika(file)
+                    ContentSanitizer.sanitizeTemplateVariables(extractUsingTika(file))
                 } else {
                     throw UnsupportedOperationException("Cannot extract content from: $mimeType (extension: .$extension)")
                 }

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
@@ -82,7 +82,7 @@ object UrlContentExtractor {
                     ExtractedUrlContent(
                         url = normalizedUrl,
                         title = extractTitleFromUrl(normalizedUrl),
-                        content = text.trim(),
+                        content = ContentSanitizer.sanitizeTemplateVariables(text.trim()),
                         contentType = contentType,
                     )
                 }
@@ -120,7 +120,7 @@ object UrlContentExtractor {
         return ExtractedUrlContent(
             url = url,
             title = title,
-            content = finalContent,
+            content = ContentSanitizer.sanitizeTemplateVariables(finalContent),
             contentType = "text/html",
         )
     }
@@ -155,7 +155,7 @@ object UrlContentExtractor {
                 return ExtractedUrlContent(
                     url = url,
                     title = title,
-                    content = extractedText,
+                    content = ContentSanitizer.sanitizeTemplateVariables(extractedText),
                     contentType = contentType,
                 )
             }


### PR DESCRIPTION
- Add ContentSanitizer to strip template variables from raw text.
- Update FileContentExtractor to run sanitizer on every read or extracted fragment.
- Update UrlContentExtractor so downloaded and extracted content is also sanitized.
- Add logic in SessionManager to append leftover response chunks when partial and full responses differ.