### PR TITLE
refactor(theme): standardize button components and neutral icon colors

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,13 +22,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -86,6 +82,9 @@ import io.askimo.core.providers.ModelProvider
 import io.askimo.core.util.ProcessBuilderExt
 import io.askimo.desktop.chat.ChatViewModel
 import io.askimo.desktop.chat.chatView
+import io.askimo.desktop.common.components.dangerButton
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.dialog.errorDialog
 import io.askimo.desktop.common.dialog.updateCheckDialog
 import io.askimo.desktop.common.i18n.provideLocalization
@@ -1064,21 +1063,18 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                         title = { Text(stringResource("menu.quit") + "?") },
                         text = { Text(stringResource("session.delete.confirm")) },
                         confirmButton = {
-                            Button(
+                            dangerButton(
                                 onClick = {
                                     showQuitDialog = false
                                     exitProcess(0)
                                 },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("action.yes"))
                             }
                         },
                         dismissButton = {
-                            TextButton(
+                            secondaryButton(
                                 onClick = { showQuitDialog = false },
-                                colors = ComponentColors.primaryTextButtonColors(),
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("action.no"))
                             }
@@ -1093,7 +1089,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                         title = { Text(stringResource("menu.invalidate.caches.title")) },
                         text = { Text(stringResource("menu.invalidate.caches.message")) },
                         confirmButton = {
-                            Button(
+                            dangerButton(
                                 onClick = {
                                     showInvalidateCacheDialog = false
                                     // Post the invalidate cache event
@@ -1101,16 +1097,13 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                     // Show success dialog
                                     showCacheDeletedDialog = true
                                 },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("action.yes"))
                             }
                         },
                         dismissButton = {
-                            TextButton(
+                            secondaryButton(
                                 onClick = { showInvalidateCacheDialog = false },
-                                colors = ComponentColors.primaryTextButtonColors(),
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("action.cancel"))
                             }
@@ -1125,9 +1118,8 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                         title = { Text(stringResource("menu.invalidate.caches.success.title")) },
                         text = { Text(stringResource("menu.invalidate.caches.success.message")) },
                         confirmButton = {
-                            Button(
+                            primaryButton(
                                 onClick = { showCacheDeletedDialog = false },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("action.ok"))
                             }
@@ -1145,7 +1137,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                         title = { Text(stringResource("backup.import.confirm.title")) },
                         text = { Text(stringResource("backup.import.confirm.message")) },
                         confirmButton = {
-                            Button(
+                            primaryButton(
                                 onClick = {
                                     showImportBackupConfirm = false
                                     pendingImportBackupPath?.let { path ->
@@ -1173,19 +1165,16 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                         }
                                     }
                                 },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("action.yes"))
                             }
                         },
                         dismissButton = {
-                            TextButton(
+                            secondaryButton(
                                 onClick = {
                                     showImportBackupConfirm = false
                                     pendingImportBackupPath = null
                                 },
-                                colors = ComponentColors.primaryTextButtonColors(),
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("action.cancel"))
                             }
@@ -1210,16 +1199,11 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                             )
                         },
                         confirmButton = {
-                            Button(
+                            primaryButton(
                                 onClick = {
                                     showProviderSetupDialog = false
                                     settingsViewModel.onChangeProvider(isInitialSetup = true)
                                 },
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.primary,
-                                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                                ),
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Text(stringResource("provider.setup.required.button"))
                             }
@@ -1356,14 +1340,9 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                     }
                                 }
 
-                                Button(
+                                primaryButton(
                                     onClick = { sessionsViewModel.dismissSuccessMessage() },
-                                    modifier = Modifier
-                                        .align(Alignment.End)
-                                        .pointerHoverIcon(PointerIcon.Hand),
-                                    colors = ButtonDefaults.buttonColors(
-                                        containerColor = MaterialTheme.colorScheme.primary,
-                                    ),
+                                    modifier = Modifier.align(Alignment.End),
                                 ) {
                                     Text(stringResource("action.ok"))
                                 }
@@ -1421,24 +1400,17 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.End,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
-                                    TextButton(
+                                    secondaryButton(
                                         onClick = { sessionsViewModel.cancelOverwrite() },
-                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                     ) {
                                         Text(stringResource("action.cancel"))
                                     }
 
-                                    Spacer(modifier = Modifier.width(8.dp))
-
-                                    Button(
+                                    dangerButton(
                                         onClick = { sessionsViewModel.confirmOverwrite() },
-                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                        colors = ButtonDefaults.buttonColors(
-                                            containerColor = MaterialTheme.colorScheme.error,
-                                        ),
                                     ) {
                                         Text(stringResource("file.overwrite.confirm"))
                                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatInputField.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatInputField.kt
@@ -204,7 +204,7 @@ fun chatInputField(
                         Icon(
                             Icons.Default.Edit,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                         Text(
                             text = editingMessage.timestamp?.let { timestamp ->
@@ -266,6 +266,7 @@ fun chatInputField(
                     Icon(
                         Icons.Default.AttachFile,
                         contentDescription = "Attach file",
+                        tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }
             }
@@ -400,6 +401,7 @@ fun chatInputField(
                             } else {
                                 stringResource("message.send")
                             },
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 }
@@ -433,13 +435,13 @@ private fun fileAttachmentItem(
                     imageVector = Icons.Default.AttachFile,
                     contentDescription = null,
                     modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = MaterialTheme.colorScheme.onSurface,
                 )
                 Column {
                     Text(
                         text = attachment.fileName,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
                     Text(
                         text = formatFileSize(attachment.size),
@@ -458,7 +460,7 @@ private fun fileAttachmentItem(
                     imageVector = Icons.Default.Close,
                     contentDescription = stringResource("chat.attachment.remove"),
                     modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatView.kt
@@ -6,6 +6,7 @@ package io.askimo.desktop.chat
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,6 +31,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -280,6 +282,7 @@ fun chatView(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
             .focusRequester(chatViewFocusRequester)
             .focusable()
             .onPreviewKeyEvent { keyEvent ->
@@ -435,7 +438,9 @@ fun chatView(
                                             onClick = {
                                                 onNavigateToProject?.invoke(project.id)
                                             },
-                                            colors = ComponentColors.primaryTextButtonColors(),
+                                            colors = ButtonDefaults.textButtonColors(
+                                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            ),
                                         ) {
                                             Text(
                                                 text = project.name.take(3).uppercase(),
@@ -450,7 +455,7 @@ fun chatView(
                                 Icon(
                                     imageVector = Icons.Default.ChevronRight,
                                     contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                     modifier = Modifier.size(20.dp),
                                 )
                             }
@@ -468,7 +473,7 @@ fun chatView(
 
                             val statusColor = when (ragIndexingStatus) {
                                 "failed" -> MaterialTheme.colorScheme.error
-                                "completed" -> MaterialTheme.colorScheme.primary
+                                "completed" -> MaterialTheme.colorScheme.onSurface
                                 "inprogress" -> MaterialTheme.colorScheme.tertiary
                                 "started" -> MaterialTheme.colorScheme.onSurfaceVariant
                                 else -> MaterialTheme.colorScheme.onSurfaceVariant
@@ -514,7 +519,7 @@ fun chatView(
                         // Session title
                         Text(
                             text = sessionTitle ?: "New Chat",
-                            style = MaterialTheme.typography.titleMedium,
+                            style = MaterialTheme.typography.titleLarge,
                             color = MaterialTheme.colorScheme.onSurface,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
@@ -560,7 +565,8 @@ fun chatView(
                                                 Text(
                                                     text = selectedDirectiveObj.name,
                                                     style = MaterialTheme.typography.labelMedium,
-                                                    color = MaterialTheme.colorScheme.primary,
+                                                    color = MaterialTheme.colorScheme.onSurface,
+                                                    fontWeight = FontWeight.Bold,
                                                 )
                                                 Text(
                                                     text = selectedDirectiveObj.content,
@@ -575,7 +581,9 @@ fun chatView(
                                 TextButton(
                                     onClick = { directiveDropdownExpanded = true },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                    colors = ComponentColors.primaryTextButtonColors(),
+                                    colors = ButtonDefaults.textButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.onSurface,
+                                    ),
                                 ) {
                                     Text(
                                         text = selectedDirectiveObj?.name?.take(30)?.let {
@@ -613,7 +621,7 @@ fun chatView(
                                             Icon(
                                                 Icons.Default.Check,
                                                 contentDescription = "Selected",
-                                                tint = MaterialTheme.colorScheme.primary,
+                                                tint = MaterialTheme.colorScheme.onSurface,
                                             )
                                         }
                                     } else {
@@ -640,7 +648,8 @@ fun chatView(
                                                         Text(
                                                             text = directive.name,
                                                             style = MaterialTheme.typography.labelMedium,
-                                                            color = MaterialTheme.colorScheme.primary,
+                                                            color = MaterialTheme.colorScheme.onSurface,
+                                                            fontWeight = FontWeight.Bold,
                                                         )
                                                         Text(
                                                             text = directive.content,
@@ -667,7 +676,7 @@ fun chatView(
                                                         Icon(
                                                             Icons.Default.Check,
                                                             contentDescription = "Selected",
-                                                            tint = MaterialTheme.colorScheme.primary,
+                                                            tint = MaterialTheme.colorScheme.onSurface,
                                                         )
                                                     }
                                                 } else {
@@ -694,13 +703,13 @@ fun chatView(
                                             Icon(
                                                 Icons.Default.Add,
                                                 contentDescription = "New directive",
-                                                tint = MaterialTheme.colorScheme.primary,
+                                                tint = MaterialTheme.colorScheme.onSurface,
                                                 modifier = Modifier.size(20.dp),
                                             )
                                             Text(
                                                 text = stringResource("chat.directive.new"),
                                                 style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.primary,
+                                                color = MaterialTheme.colorScheme.onSurface,
                                             )
                                         }
                                     },
@@ -721,13 +730,13 @@ fun chatView(
                                             Icon(
                                                 Icons.Default.Edit,
                                                 contentDescription = "Manage directives",
-                                                tint = MaterialTheme.colorScheme.primary,
+                                                tint = MaterialTheme.colorScheme.onSurface,
                                                 modifier = Modifier.size(20.dp),
                                             )
                                             Text(
                                                 text = stringResource("chat.directive.manage"),
                                                 style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.primary,
+                                                color = MaterialTheme.colorScheme.onSurface,
                                             )
                                         }
                                     },

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/components/Buttons.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/components/Buttons.kt
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.desktop.common.components
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+
+/**
+ * Primary action button with filled background.
+ * Use for main/confirm actions in dialogs and forms.
+ *
+ * Features:
+ * - Filled background with primary accent color
+ * - White text for maximum contrast (from theme)
+ * - Hand cursor on hover
+ * - High visual prominence
+ *
+ * @param onClick Called when the button is clicked
+ * @param modifier The modifier to be applied to the button
+ * @param enabled Whether the button is enabled
+ * @param content The button content (typically Text)
+ */
+@Composable
+fun primaryButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+        ),
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
+        content = content,
+    )
+}
+
+/**
+ * Secondary action button with outlined style.
+ * Use for dismiss/cancel actions in dialogs and forms.
+ *
+ * Features:
+ * - Outlined style with subtle background
+ * - Hand cursor on hover
+ * - Lower visual prominence than PrimaryButton
+ *
+ * @param onClick Called when the button is clicked
+ * @param modifier The modifier to be applied to the button
+ * @param enabled Whether the button is enabled
+ * @param content The button content (typically Text)
+ */
+@Composable
+fun secondaryButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled,
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
+        content = content,
+    )
+}
+
+/**
+ * Danger button for destructive actions.
+ * Use for delete, remove, or other dangerous operations.
+ *
+ * Features:
+ * - Filled background with error/danger color (from theme)
+ * - White text for maximum contrast (from theme)
+ * - Hand cursor on hover
+ * - High visual prominence with warning color
+ *
+ * @param onClick Called when the button is clicked
+ * @param modifier The modifier to be applied to the button
+ * @param enabled Whether the button is enabled
+ * @param content The button content (typically Text)
+ */
+@Composable
+fun dangerButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.error,
+            contentColor = MaterialTheme.colorScheme.onError,
+        ),
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
+        content = content,
+    )
+}
+
+/**
+ * Link button for navigational actions and external links.
+ * Use for hyperlinks, website URLs, and secondary navigation.
+ *
+ * Features:
+ * - Transparent background
+ * - Text color matches theme (white in dark mode, black in light mode)
+ * - Hand cursor on hover
+ * - Lower visual prominence than primary/secondary buttons
+ *
+ * @param onClick Called when the button is clicked
+ * @param modifier The modifier to be applied to the button
+ * @param enabled Whether the button is enabled
+ * @param content The button content (typically Text with optional Icon)
+ */
+@Composable
+fun linkButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    TextButton(
+        onClick = onClick,
+        enabled = enabled,
+        colors = ButtonDefaults.textButtonColors(
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
+        content = content,
+    )
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/dialog/ErrorDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/dialog/ErrorDialog.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -27,6 +26,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import io.askimo.desktop.common.components.primaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 
@@ -97,11 +97,9 @@ fun errorDialog(
             }
         },
         confirmButton = {
-            Button(
+            primaryButton(
                 onClick = onDismiss,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .pointerHoverIcon(PointerIcon.Hand),
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(stringResource("action.ok"))
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/dialog/UpdateDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/dialog/UpdateDialog.kt
@@ -14,20 +14,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.askimo.core.service.UpdateInfo
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.ui.markdownText
@@ -119,7 +117,7 @@ private fun newVersionDialog(
                     text = stringResource("update.dialog.new.version.available"),
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
 
                 // Version info card
@@ -200,17 +198,15 @@ private fun newVersionDialog(
             }
         },
         confirmButton = {
-            Button(
+            primaryButton(
                 onClick = onDownload,
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             ) {
                 Text(stringResource("update.dialog.download"))
             }
         },
         dismissButton = {
-            OutlinedButton(
+            secondaryButton(
                 onClick = onLater,
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             ) {
                 Text(stringResource("update.dialog.later"))
             }
@@ -260,9 +256,8 @@ private fun upToDateDialog(
             }
         },
         confirmButton = {
-            Button(
+            primaryButton(
                 onClick = onDismiss,
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             ) {
                 Text(stringResource("action.ok"))
             }
@@ -298,9 +293,8 @@ private fun errorDialog(
             }
         },
         confirmButton = {
-            Button(
+            primaryButton(
                 onClick = onDismiss,
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             ) {
                 Text(stringResource("action.ok"))
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/theme/AccentColor.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/theme/AccentColor.kt
@@ -7,6 +7,9 @@ package io.askimo.desktop.common.theme
 import androidx.compose.ui.graphics.Color
 
 enum class AccentColor(val displayName: String, val lightColor: Color, val darkColor: Color) {
+    // Modern neutral - gray in light mode, darker in dark mode
+    MODERN_GRAY("Modern Gray", Color(0xFF707070), Color(0xFF0D0D0D)),
+
     // Deep/Dark variants - rich, bold colors
     DEEP_BLUE("Deep Blue", Color(0xFF003D82), Color(0xFF1E88E5)),
     DEEP_PURPLE("Deep Purple", Color(0xFF5B21B6), Color(0xFF9333EA)),

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/theme/ComponentColors.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/theme/ComponentColors.kt
@@ -140,19 +140,22 @@ object ComponentColors {
     )
 
     /**
-     * Outlined text field colors that match the theme's divider colors
-     * - Unfocused border: outlineVariant (matches dividers)
-     * - Focused border: primary (accent color)
-     * - Text: onSurface
-     * - Placeholder: onSurfaceVariant
+     * Provides themed colors for outlined text fields with good contrast.
+     * - Focused border: onSurface (matches text color for consistency)
+     * - Unfocused border: outlineVariant (subtle)
+     * - Focused label: onSurface (matches text color)
+     * - Unfocused label: onSurfaceVariant (muted)
+     * - Cursor: onSurface (matches text color)
+     * - Text: onSurface (default, good contrast)
+     * - Placeholder: onSurfaceVariant (muted)
      */
     @Composable
     fun outlinedTextFieldColors(): TextFieldColors = OutlinedTextFieldDefaults.colors(
-        focusedBorderColor = MaterialTheme.colorScheme.primary,
+        focusedBorderColor = MaterialTheme.colorScheme.onSurface,
         unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
-        focusedLabelColor = MaterialTheme.colorScheme.primary,
+        focusedLabelColor = MaterialTheme.colorScheme.onSurface,
         unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        cursorColor = MaterialTheme.colorScheme.primary,
+        cursorColor = MaterialTheme.colorScheme.onSurface,
     )
 
     /**

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/theme/Theme.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/theme/Theme.kt
@@ -172,13 +172,24 @@ val DarkColorScheme = darkColorScheme(
 fun getLightColorScheme(accentColor: AccentColor): ColorScheme {
     val baseScheme = LightColorScheme
     return baseScheme.copy(
+        // Keep primary as accent color for backgrounds/highlights
         primary = accentColor.lightColor,
+        onPrimary = Color.White, // White text on primary background
         primaryContainer = accentColor.lightColor.copy(alpha = 0.3f),
         onPrimaryContainer = Color.Black,
         secondaryContainer = accentColor.lightColor.copy(alpha = 0.15f),
         onSecondaryContainer = Color.Black,
         inversePrimary = accentColor.darkColor,
         surfaceTint = accentColor.lightColor,
+
+        // Error colors for danger buttons - darker red with white text
+        error = Color(0xFFD32F2F), // Material Design Red 700
+        onError = Color.White, // White text on error background
+
+        // Text colors should always be black in light mode
+        onSurface = Color.Black,
+        onBackground = Color.Black,
+        onSurfaceVariant = Color(0xFF424242), // Slightly lighter for secondary text
     )
 }
 
@@ -188,13 +199,24 @@ fun getLightColorScheme(accentColor: AccentColor): ColorScheme {
 fun getDarkColorScheme(accentColor: AccentColor): ColorScheme {
     val baseScheme = DarkColorScheme
     return baseScheme.copy(
+        // Keep primary as accent color for backgrounds/highlights
         primary = accentColor.darkColor,
+        onPrimary = Color.White, // White text on primary background
         primaryContainer = accentColor.darkColor.copy(alpha = 0.3f),
         onPrimaryContainer = Color.White,
         secondaryContainer = accentColor.darkColor.copy(alpha = 0.15f),
         onSecondaryContainer = Color.White,
         inversePrimary = accentColor.lightColor,
         surfaceTint = accentColor.darkColor,
+
+        // Error colors for danger buttons - darker red with white text
+        error = Color(0xFFD32F2F), // Material Design Red 700 (same as light mode for consistency)
+        onError = Color.White, // White text on error background
+
+        // Text colors should always be white in dark mode
+        onSurface = Color.White,
+        onBackground = Color.White,
+        onSurfaceVariant = Color(0xFFE0E0E0), // Slightly darker white for secondary text
     )
 }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/ui/MarkdownText.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/ui/MarkdownText.kt
@@ -162,7 +162,7 @@ private fun renderNode(node: Node, viewportTopY: Float? = null) {
 @Composable
 private fun renderParagraph(paragraph: Paragraph) {
     val inlineCodeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
-    val linkColor = MaterialTheme.colorScheme.primary
+    val linkColor = MaterialTheme.colorScheme.tertiary
 
     // Extract raw text to check for LaTeX
     val rawText = extractTextContent(paragraph)
@@ -399,7 +399,7 @@ private fun fixMarkdownMangledLatex(latex: String): String {
 @Composable
 private fun renderHeading(heading: Heading) {
     val inlineCodeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
-    val linkColor = MaterialTheme.colorScheme.primary
+    val linkColor = MaterialTheme.colorScheme.tertiary
 
     val style = when (heading.level) {
         1 -> MaterialTheme.typography.headlineMedium
@@ -459,7 +459,7 @@ private fun renderListItem(
     marker: String,
     inlineCodeBg: Color,
 ) {
-    val linkColor = MaterialTheme.colorScheme.primary
+    val linkColor = MaterialTheme.colorScheme.tertiary
 
     Column(modifier = Modifier.padding(vertical = 2.dp)) {
         // First, collect inline content and nested blocks

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/ui/MermaidChartRenderer.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/ui/MermaidChartRenderer.kt
@@ -427,7 +427,7 @@ private fun mermaidSetupInstructions(
             Text(
                 text = setupLink,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
+                color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/AddMcpIntegrationDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/AddMcpIntegrationDialog.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
@@ -31,7 +30,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -54,6 +52,8 @@ import io.askimo.core.mcp.config.McpRuntimeValidator
 import io.askimo.core.mcp.config.McpServersConfig
 import io.askimo.core.mcp.config.RuntimeValidationResult
 import io.askimo.core.mcp.config.ValidationSeverity
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -177,11 +177,9 @@ fun addMcpIntegrationDialog(
                                 onClick = {
                                     selectedServer = server
                                     showServerDropdown = false
-                                    // Initialize parameter values with defaults
                                     parameterValues.value = server.parameters.associate { param ->
                                         param.key to (param.defaultValue ?: "")
                                     }
-                                    // Generate default instance name
                                     instanceName = server.name
                                 },
                             )
@@ -324,16 +322,15 @@ fun addMcpIntegrationDialog(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("dialog.cancel"))
                     }
 
                     Spacer(modifier = Modifier.width(Spacing.small))
 
-                    Button(
+                    primaryButton(
                         onClick = {
                             selectedServer?.let { server ->
                                 // Start validation
@@ -358,7 +355,6 @@ fun addMcpIntegrationDialog(
                             }
                         },
                         enabled = selectedServer != null && instanceName.isNotBlank() && !isValidating,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         if (isValidating) {
                             Text(stringResource("mcp.validation.validating"))

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/AddReferenceMaterialDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/AddReferenceMaterialDialog.kt
@@ -14,15 +14,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,6 +33,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ProjectRefreshEvent
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import java.util.UUID
@@ -129,7 +128,7 @@ fun addReferenceMaterialDialog(
                                     Icon(
                                         imageVector = typeInfo.icon,
                                         contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.primary,
+                                        tint = MaterialTheme.colorScheme.onSurface,
                                     )
                                 },
                                 modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
@@ -165,17 +164,15 @@ fun addReferenceMaterialDialog(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        colors = ComponentColors.primaryTextButtonColors(),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("project.new.dialog.button.cancel"))
                     }
 
                     Spacer(modifier = Modifier.width(8.dp))
 
-                    Button(
+                    primaryButton(
                         onClick = {
                             if (knowledgeSources.isNotEmpty()) {
                                 onAdd(knowledgeSources)
@@ -191,10 +188,6 @@ fun addReferenceMaterialDialog(
                             }
                         },
                         enabled = knowledgeSources.isNotEmpty(),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                        ),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("projects.sources.add.dialog.button.add"))
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/DeleteProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/DeleteProjectDialog.kt
@@ -14,22 +14,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import io.askimo.desktop.common.components.dangerButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
-import io.askimo.desktop.common.theme.ComponentColors
 
 /**
  * Reusable delete project confirmation dialog.
@@ -86,22 +82,16 @@ fun deleteProjectDialog(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        colors = ComponentColors.primaryTextButtonColors(),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("project.delete.confirm.cancel"))
                     }
 
                     Spacer(modifier = Modifier.width(8.dp))
 
-                    Button(
+                    dangerButton(
                         onClick = onConfirm,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error,
-                        ),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("project.delete.confirm.button"))
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Error
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -33,7 +32,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -55,6 +53,8 @@ import io.askimo.core.chat.domain.Project
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ProjectReIndexEvent
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import kotlinx.coroutines.Dispatchers
@@ -132,7 +132,7 @@ fun editProjectDialog(
                             text = loadError!!,
                             style = MaterialTheme.typography.bodyMedium,
                         )
-                        Button(
+                        primaryButton(
                             onClick = onDismiss,
                             modifier = Modifier.align(Alignment.End),
                         ) {
@@ -348,20 +348,17 @@ private fun editProjectForm(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        colors = ComponentColors.primaryTextButtonColors(),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.cancel"))
                     }
 
                     Spacer(modifier = Modifier.width(8.dp))
 
-                    Button(
+                    primaryButton(
                         onClick = ::performSave,
                         enabled = projectName.trim().isNotEmpty(),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.save"))
                     }
@@ -418,7 +415,7 @@ fun knowledgeSourceRow(
                 Icon(
                     Icons.Default.CheckCircle,
                     contentDescription = "Valid",
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(16.dp).padding(start = 4.dp),
                 )
             } else {

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/NewProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/NewProjectDialog.kt
@@ -20,9 +20,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -30,7 +27,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -50,6 +46,8 @@ import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ProjectIndexingRequestedEvent
 import io.askimo.core.logging.logger
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.ui.util.FileDialogUtils
@@ -216,7 +214,7 @@ fun newProjectDialog(
                     Icon(
                         imageVector = Icons.Default.CheckCircle,
                         contentDescription = "Success",
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(64.dp),
                     )
 
@@ -244,12 +242,8 @@ fun newProjectDialog(
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    Button(
+                    primaryButton(
                         onClick = onDismiss,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                        ),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("project.new.dialog.success.close"))
                     }
@@ -259,19 +253,17 @@ fun newProjectDialog(
                     modifier = Modifier.padding(24.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
-                    // Title
                     Text(
                         text = stringResource("project.new.dialog.title"),
                         style = MaterialTheme.typography.headlineSmall,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
 
-                    // Project Name Field
                     OutlinedTextField(
                         value = projectName,
                         onValueChange = {
                             projectName = it
-                            nameError = null // Clear error on change
+                            nameError = null
                         },
                         label = { Text(stringResource("project.new.dialog.name.label")) },
                         placeholder = { Text(stringResource("project.new.dialog.name.placeholder")) },
@@ -327,7 +319,7 @@ fun newProjectDialog(
                                 Icon(Icons.Default.ArrowDropDown, contentDescription = null)
                             }
 
-                            DropdownMenu(
+                            ComponentColors.themedDropdownMenu(
                                 expanded = showAddSourceMenu,
                                 onDismissRequest = { showAddSourceMenu = false },
                             ) {
@@ -338,6 +330,7 @@ fun newProjectDialog(
                                                 Icon(
                                                     typeInfo.icon,
                                                     contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.onSurface,
                                                     modifier = Modifier.padding(end = 8.dp).size(20.dp),
                                                 )
                                                 Text(stringResource(typeInfo.typeLabelKey))
@@ -347,6 +340,7 @@ fun newProjectDialog(
                                             showAddSourceMenu = false
                                             handleAddSource(typeInfo)
                                         },
+                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                     )
                                 }
                             }
@@ -358,25 +352,17 @@ fun newProjectDialog(
                     // Action buttons
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        TextButton(
+                        secondaryButton(
                             onClick = onDismiss,
-                            colors = ComponentColors.primaryTextButtonColors(),
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             Text(stringResource("project.new.dialog.button.cancel"))
                         }
 
-                        Spacer(modifier = Modifier.width(8.dp))
-
-                        Button(
+                        primaryButton(
                             onClick = { handleCreate() },
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
-                            ),
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             Text(stringResource("project.new.dialog.button.create"))
                         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
@@ -37,7 +37,6 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Cable
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -78,6 +77,7 @@ import io.askimo.core.mcp.ProjectMcpInstance
 import io.askimo.core.mcp.ProjectMcpInstanceService
 import io.askimo.core.util.TimeUtil
 import io.askimo.desktop.chat.chatInputField
+import io.askimo.desktop.common.components.primaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.ui.themedTooltip
@@ -158,7 +158,7 @@ fun projectView(
                             Icon(
                                 imageVector = Icons.Default.MoreVert,
                                 contentDescription = stringResource("project.menu.tooltip"),
-                                tint = MaterialTheme.colorScheme.primary,
+                                tint = MaterialTheme.colorScheme.onSurface,
                             )
                         }
                     }
@@ -239,7 +239,7 @@ fun projectView(
                                 Icon(
                                     imageVector = Icons.AutoMirrored.Outlined.LibraryBooks,
                                     contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                     modifier = Modifier.size(20.dp),
                                 )
 
@@ -247,7 +247,7 @@ fun projectView(
                                     text = stringResource("projects.sources.count", currentProject.knowledgeSources.size),
                                     style = MaterialTheme.typography.bodyMedium,
                                     fontWeight = FontWeight.SemiBold,
-                                    color = MaterialTheme.colorScheme.primary,
+                                    color = MaterialTheme.colorScheme.onSurface,
                                 )
 
                                 val rotation by animateFloatAsState(
@@ -262,7 +262,7 @@ fun projectView(
                                     } else {
                                         stringResource("projects.sources.expand")
                                     },
-                                    tint = MaterialTheme.colorScheme.primary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                     modifier = Modifier.rotate(rotation),
                                 )
 
@@ -272,7 +272,7 @@ fun projectView(
                                     Icon(
                                         imageVector = Icons.Default.Info,
                                         contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                         modifier = Modifier
                                             .size(20.dp)
                                             .pointerHoverIcon(PointerIcon.Hand),
@@ -289,7 +289,7 @@ fun projectView(
                                 Icon(
                                     imageVector = Icons.AutoMirrored.Outlined.LibraryBooks,
                                     contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                     modifier = Modifier.size(20.dp),
                                 )
 
@@ -300,7 +300,7 @@ fun projectView(
                                         text = stringResource("projects.sources.empty.title"),
                                         style = MaterialTheme.typography.bodyMedium,
                                         fontWeight = FontWeight.SemiBold,
-                                        color = MaterialTheme.colorScheme.primary,
+                                        color = MaterialTheme.colorScheme.onSurface,
                                     )
                                     Text(
                                         text = stringResource("projects.sources.empty.description"),
@@ -316,7 +316,7 @@ fun projectView(
                                     Icon(
                                         imageVector = Icons.Default.Info,
                                         contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                         modifier = Modifier
                                             .size(20.dp)
                                             .pointerHoverIcon(PointerIcon.Hand),
@@ -336,7 +336,7 @@ fun projectView(
                                 Icon(
                                     imageVector = Icons.Default.Add,
                                     contentDescription = stringResource("projects.sources.add.tooltip"),
-                                    tint = MaterialTheme.colorScheme.primary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                 )
                             }
                         }
@@ -376,7 +376,7 @@ fun projectView(
                                         text = groupName,
                                         style = MaterialTheme.typography.labelMedium,
                                         fontWeight = FontWeight.SemiBold,
-                                        color = MaterialTheme.colorScheme.primary,
+                                        color = MaterialTheme.colorScheme.onSurface,
                                         modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
                                     )
 
@@ -763,7 +763,7 @@ private fun mcpIntegrationsPanel(
                         Icon(
                             imageVector = Icons.Outlined.Cable,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.size(20.dp),
                         )
 
@@ -771,7 +771,7 @@ private fun mcpIntegrationsPanel(
                             text = stringResource("mcp.integrations.count", mcpInstances.size),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = MaterialTheme.colorScheme.onSurface,
                         )
 
                         val rotation by animateFloatAsState(
@@ -786,7 +786,7 @@ private fun mcpIntegrationsPanel(
                             } else {
                                 stringResource("mcp.integrations.expand")
                             },
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.rotate(rotation),
                         )
 
@@ -796,7 +796,7 @@ private fun mcpIntegrationsPanel(
                             Icon(
                                 imageVector = Icons.Default.Info,
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                 modifier = Modifier
                                     .size(20.dp)
                                     .pointerHoverIcon(PointerIcon.Hand),
@@ -813,7 +813,7 @@ private fun mcpIntegrationsPanel(
                         Icon(
                             imageVector = Icons.Outlined.Cable,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.size(20.dp),
                         )
 
@@ -824,7 +824,7 @@ private fun mcpIntegrationsPanel(
                                 text = stringResource("mcp.integrations.empty.title"),
                                 style = MaterialTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.primary,
+                                color = MaterialTheme.colorScheme.onSurface,
                             )
                             Text(
                                 text = stringResource("mcp.integrations.empty.description"),
@@ -840,7 +840,7 @@ private fun mcpIntegrationsPanel(
                             Icon(
                                 imageVector = Icons.Default.Info,
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                 modifier = Modifier
                                     .size(20.dp)
                                     .pointerHoverIcon(PointerIcon.Hand),
@@ -860,7 +860,7 @@ private fun mcpIntegrationsPanel(
                         Icon(
                             imageVector = Icons.Default.Add,
                             contentDescription = stringResource("mcp.integrations.add.tooltip"),
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 }
@@ -933,7 +933,7 @@ private fun mcpIntegrationsPanel(
             title = { Text(stringResource("mcp.integrations.error.title")) },
             text = { Text(message) },
             confirmButton = {
-                Button(onClick = { errorMessage = null }) {
+                primaryButton(onClick = { errorMessage = null }) {
                     Text(stringResource("dialog.close"))
                 }
             },
@@ -1012,7 +1012,7 @@ private fun mcpInstanceCard(
                         Icon(
                             imageVector = Icons.Default.Build,
                             contentDescription = stringResource("mcp.integrations.view.tools.tooltip"),
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier.size(18.dp),
                         )
                     }
@@ -1109,7 +1109,7 @@ private fun mcpToolsDialog(
                             ) {
                                 CircularProgressIndicator(
                                     modifier = Modifier.size(24.dp),
-                                    color = MaterialTheme.colorScheme.primary,
+                                    color = MaterialTheme.colorScheme.onSurface,
                                 )
                                 Text(
                                     text = stringResource("mcp.tools.dialog.loading"),
@@ -1210,9 +1210,8 @@ private fun mcpToolsDialog(
             }
         },
         confirmButton = {
-            Button(
+            primaryButton(
                 onClick = onDismiss,
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             ) {
                 Text(stringResource("dialog.close"))
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsView.kt
@@ -93,7 +93,7 @@ fun projectsView(
                 Icon(
                     Icons.Default.Refresh,
                     contentDescription = "Refresh projects",
-                    tint = MaterialTheme.colorScheme.onBackground,
+                    tint = MaterialTheme.colorScheme.onSurface,
                 )
             }
         }
@@ -122,7 +122,7 @@ fun projectsView(
                         Icon(
                             imageVector = Icons.Default.CheckCircle,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                         Text(
                             text = message,
@@ -312,7 +312,7 @@ private fun projectCard(
                         Icon(
                             Icons.Default.MoreVert,
                             contentDescription = "More options",
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
 
@@ -330,7 +330,7 @@ private fun projectCard(
                                 Icon(
                                     Icons.Default.Edit,
                                     contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                 )
                             },
                             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
@@ -382,7 +382,7 @@ private fun projectCard(
                         text = stringResource("projects.sources.count", project.knowledgeSources.size),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
 
                     val rotation by animateFloatAsState(
@@ -397,7 +397,7 @@ private fun projectCard(
                         } else {
                             stringResource("projects.sources.expand")
                         },
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.rotate(rotation),
                     )
                 }
@@ -487,14 +487,14 @@ private fun paginationControls(
             Icon(
                 Icons.Default.ChevronLeft,
                 contentDescription = stringResource("projects.page.previous"),
-                tint = if (hasPrevious) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                tint = if (hasPrevious) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             )
         }
 
         Text(
             text = stringResource("projects.page", currentPage, totalPages),
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onBackground,
+            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = 16.dp),
         )
 
@@ -506,7 +506,7 @@ private fun paginationControls(
             Icon(
                 Icons.Default.ChevronRight,
                 contentDescription = stringResource("projects.page.next"),
-                tint = if (hasNext) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                tint = if (hasNext) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             )
         }
     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/UrlInputDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/UrlInputDialog.kt
@@ -13,14 +13,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -32,12 +29,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.askimo.core.logging.logger
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import kotlinx.coroutines.Dispatchers
@@ -191,24 +188,18 @@ fun urlInputDialog(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
                         enabled = !isValidating,
-                        colors = ComponentColors.primaryTextButtonColors(),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("project.dialog.url.button.cancel"))
                     }
 
                     Spacer(modifier = Modifier.width(8.dp))
 
-                    Button(
+                    primaryButton(
                         onClick = { handleAdd() },
                         enabled = !isValidating,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                        ),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         if (isValidating) {
                             CircularProgressIndicator(

--- a/desktop/src/main/kotlin/io/askimo/desktop/session/ExportSessionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/session/ExportSessionDialog.kt
@@ -25,8 +25,6 @@ import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Language
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -35,7 +33,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -54,6 +51,8 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.export.ExportFormat
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
@@ -218,7 +217,7 @@ fun exportSessionDialog(
                         Icon(
                             imageVector = Icons.Default.FolderOpen,
                             contentDescription = stringResource("session.export.browse"),
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 }
@@ -228,29 +227,22 @@ fun exportSessionDialog(
                 // Action buttons
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.cancel"))
                     }
 
-                    Spacer(modifier = Modifier.width(8.dp))
-
-                    Button(
+                    primaryButton(
                         onClick = {
                             if (filePath.isNotBlank()) {
                                 onExport(filePath)
                             }
                         },
                         enabled = filePath.isNotBlank(),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                        ),
                     ) {
                         Text(stringResource("session.export.button.export"))
                     }
@@ -319,7 +311,7 @@ private fun formatCard(
                 imageVector = icon,
                 contentDescription = null,
                 tint = if (isSelected) {
-                    MaterialTheme.colorScheme.primary
+                    MaterialTheme.colorScheme.onSurface
                 } else {
                     MaterialTheme.colorScheme.onSurfaceVariant
                 },
@@ -375,7 +367,7 @@ private fun formatCard(
                 Icon(
                     imageVector = Icons.Default.CheckCircle,
                     contentDescription = "Selected",
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.size(24.dp),
                 )
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/session/ManageDirectivesDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/session/ManageDirectivesDialog.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +45,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.askimo.core.chat.domain.ChatDirective
 import io.askimo.core.util.TimeUtil
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 
@@ -141,7 +142,7 @@ fun manageDirectivesDialog(
                                         Text(
                                             text = directive.name,
                                             style = MaterialTheme.typography.titleMedium,
-                                            color = MaterialTheme.colorScheme.primary,
+                                            color = MaterialTheme.colorScheme.onSurface,
                                         )
 
                                         if (editingDirective != directive.id) {
@@ -160,7 +161,7 @@ fun manageDirectivesDialog(
                                                     Icon(
                                                         Icons.Default.Edit,
                                                         contentDescription = stringResource("action.edit"),
-                                                        tint = MaterialTheme.colorScheme.primary,
+                                                        tint = MaterialTheme.colorScheme.onSurface,
                                                     )
                                                 }
                                                 IconButton(
@@ -217,14 +218,13 @@ fun manageDirectivesDialog(
                                                 horizontalArrangement = Arrangement.End,
                                                 verticalAlignment = Alignment.CenterVertically,
                                             ) {
-                                                TextButton(
+                                                secondaryButton(
                                                     onClick = {
                                                         editingDirective = null
                                                         editName = ""
                                                         editContent = ""
                                                         editError = null
                                                     },
-                                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                                 ) {
                                                     Icon(
                                                         Icons.Default.Close,
@@ -234,7 +234,7 @@ fun manageDirectivesDialog(
                                                     Text(stringResource("settings.cancel"))
                                                 }
 
-                                                TextButton(
+                                                primaryButton(
                                                     onClick = {
                                                         if (editName.isBlank()) {
                                                             editError = nameRequiredError
@@ -248,8 +248,6 @@ fun manageDirectivesDialog(
                                                             editError = null
                                                         }
                                                     },
-                                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                                    colors = ComponentColors.primaryTextButtonColors(),
                                                 ) {
                                                     Icon(
                                                         Icons.Default.Check,
@@ -281,7 +279,7 @@ fun manageDirectivesDialog(
                                                         Text(
                                                             text = stringResource("directive.tooltip.full.content"),
                                                             style = MaterialTheme.typography.labelMedium,
-                                                            color = MaterialTheme.colorScheme.primary,
+                                                            color = MaterialTheme.colorScheme.onSurface,
                                                         )
                                                         Text(
                                                             text = directive.content,
@@ -320,9 +318,8 @@ fun manageDirectivesDialog(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.close"))
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/session/MoveToProjectMenu.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/session/MoveToProjectMenu.kt
@@ -69,14 +69,14 @@ fun moveToProjectMenuItem(
                 Icon(
                     Icons.AutoMirrored.Filled.DriveFileMove,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = MaterialTheme.colorScheme.onSurface,
                 )
             },
             trailingIcon = {
                 Icon(
                     Icons.Default.ChevronRight,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = MaterialTheme.colorScheme.onSurface,
                 )
             },
             modifier = Modifier
@@ -108,7 +108,7 @@ fun moveToProjectMenuItem(
                                 Icon(
                                     Icons.Default.Add,
                                     contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                 )
                             },
                             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
@@ -134,7 +134,7 @@ fun moveToProjectMenuItem(
                                     Icon(
                                         Icons.Default.Folder,
                                         contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        tint = MaterialTheme.colorScheme.onSurface,
                                     )
                                 },
                                 modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),

--- a/desktop/src/main/kotlin/io/askimo/desktop/session/NewDirectiveDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/session/NewDirectiveDialog.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,6 +27,8 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 
@@ -129,14 +130,13 @@ fun newDirectiveDialog(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("settings.cancel"))
                     }
 
-                    TextButton(
+                    primaryButton(
                         onClick = {
                             // Validate inputs
                             var hasError = false
@@ -155,8 +155,6 @@ fun newDirectiveDialog(
                                 onConfirm(name.trim(), content.trim(), applyToCurrent)
                             }
                         },
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        colors = ComponentColors.primaryTextButtonColors(),
                     ) {
                         Text(stringResource("directive.new.create"))
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/session/RenameSessionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/session/RenameSessionDialog.kt
@@ -7,19 +7,15 @@ package io.askimo.desktop.session
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -30,11 +26,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 
@@ -112,27 +108,18 @@ fun renameSessionDialog(
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        colors = ComponentColors.primaryTextButtonColors(),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.cancel"))
                     }
 
-                    Spacer(modifier = Modifier.width(8.dp))
-
-                    Button(
+                    primaryButton(
                         onClick = performRename,
                         enabled = newTitle.trim().isNotEmpty(),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                        ),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.rename"))
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -23,9 +22,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -74,10 +72,8 @@ fun aiProviderSettingsSection(viewModel: SettingsViewModel) {
                             color = MaterialTheme.colorScheme.onSecondaryContainer,
                         )
                     }
-                    Button(
+                    secondaryButton(
                         onClick = { viewModel.onChangeProvider() },
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        colors = ComponentColors.subtleButtonColors(),
                     ) {
                         Icon(Icons.Default.Edit, contentDescription = null)
                         Text(
@@ -107,10 +103,8 @@ fun aiProviderSettingsSection(viewModel: SettingsViewModel) {
                             color = MaterialTheme.colorScheme.onSecondaryContainer,
                         )
                     }
-                    Button(
+                    secondaryButton(
                         onClick = { viewModel.onChangeModel() },
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        colors = ComponentColors.subtleButtonColors(),
                     ) {
                         Icon(Icons.Default.Edit, contentDescription = null)
                         Text(
@@ -145,10 +139,8 @@ fun aiProviderSettingsSection(viewModel: SettingsViewModel) {
                                 )
                             }
                         }
-                        Button(
+                        secondaryButton(
                             onClick = { viewModel.onChangeSettings() },
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                            colors = ComponentColors.subtleButtonColors(),
                         ) {
                             Icon(Icons.Default.Edit, contentDescription = null)
                             Text(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
@@ -26,16 +26,14 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import io.askimo.core.VersionInfo
+import io.askimo.desktop.common.components.linkButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -77,7 +75,7 @@ fun aboutSettingsSection() {
                         imageVector = Icons.Default.Info,
                         contentDescription = null,
                         modifier = Modifier.size(32.dp),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = MaterialTheme.colorScheme.onSurface,
                     )
                     Column {
                         Text(
@@ -109,11 +107,10 @@ fun aboutSettingsSection() {
                 )
 
                 // Website Link
-                TextButton(
+                linkButton(
                     onClick = {
                         openUrl("https://askimo.chat")
                     },
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Icon(
                         imageVector = Icons.Default.Language,
@@ -234,23 +231,20 @@ fun aboutSettingsSection() {
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
 
-                TextButton(
+                linkButton(
                     onClick = { openUrl("https://github.com/haiphucnguyen/askimo") },
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text("GitHub Repository")
                 }
 
-                TextButton(
+                linkButton(
                     onClick = { openUrl("https://github.com/haiphucnguyen/askimo/issues") },
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text("Report Issues")
                 }
 
-                TextButton(
+                linkButton(
                     onClick = { openUrl("https://github.com/haiphucnguyen/askimo/blob/main/LICENSE") },
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text("View License")
                 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutView.kt
@@ -14,13 +14,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import io.askimo.core.VersionInfo
+import io.askimo.desktop.common.components.linkButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -71,7 +70,7 @@ fun aboutDialog(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSecondaryContainer,
                         )
-                        TextButton(
+                        linkButton(
                             onClick = {
                                 try {
                                     Desktop.getDesktop().browse(URI("https://askimo.chat"))
@@ -79,12 +78,10 @@ fun aboutDialog(
                                     // Silently fail if browser cannot be opened
                                 }
                             },
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             Text(
                                 text = "https://askimo.chat",
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.primary,
                             )
                         }
                     }
@@ -141,10 +138,8 @@ fun aboutDialog(
             }
         },
         confirmButton = {
-            TextButton(
+            secondaryButton(
                 onClick = onDismiss,
-                colors = ComponentColors.primaryTextButtonColors(),
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             ) {
                 Text(stringResource("action.close"))
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -44,8 +43,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
@@ -54,6 +51,8 @@ import io.askimo.core.logging.LogLevel
 import io.askimo.core.logging.LoggingService
 import io.askimo.core.logging.currentFileLogger
 import io.askimo.core.providers.ModelProvider
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -201,7 +200,7 @@ private fun logLevelCard() {
                                     Icon(
                                         Icons.Default.Check,
                                         contentDescription = "Selected",
-                                        tint = MaterialTheme.colorScheme.primary,
+                                        tint = MaterialTheme.colorScheme.onSurface,
                                     )
                                 }
                             } else {
@@ -247,10 +246,8 @@ private fun logViewerCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 // View Logs Button
-                OutlinedButton(
+                primaryButton(
                     onClick = onViewLogs,
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.subtleButtonColors(),
                 ) {
                     Icon(
                         imageVector = Icons.Default.Visibility,
@@ -262,13 +259,11 @@ private fun logViewerCard(
                 }
 
                 // Open Log Folder Button
-                OutlinedButton(
+                secondaryButton(
                     onClick = {
                         val logDir = LoggingService.getLogDirectory()
                         openInFileManager(logDir.toFile())
                     },
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.subtleButtonColors(),
                 ) {
                     Icon(
                         imageVector = Icons.Default.Folder,
@@ -978,7 +973,7 @@ private fun ragEmbeddingModelSelector() {
                                     Icon(
                                         Icons.Default.Check,
                                         contentDescription = "Selected",
-                                        tint = MaterialTheme.colorScheme.primary,
+                                        tint = MaterialTheme.colorScheme.onSurface,
                                     )
                                 }
                             } else {
@@ -1188,7 +1183,7 @@ private fun visionModelSelector() {
                                     Icon(
                                         Icons.Default.Check,
                                         contentDescription = "Selected",
-                                        tint = MaterialTheme.colorScheme.primary,
+                                        tint = MaterialTheme.colorScheme.onSurface,
                                     )
                                 }
                             } else {

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AppearanceSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AppearanceSettingsSection.kt
@@ -27,12 +27,10 @@ import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.SmartToy
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -42,9 +40,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
+import io.askimo.desktop.common.components.dangerButton
+import io.askimo.desktop.common.components.primaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.AccentColor
 import io.askimo.desktop.common.theme.ComponentColors
@@ -313,8 +311,7 @@ private fun avatarSetting(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                // Select button
-                TextButton(
+                primaryButton(
                     onClick = {
                         val fileDialog = FileDialog(
                             null as Frame?,
@@ -335,19 +332,13 @@ private fun avatarSetting(
                             onSelectAvatar(File(selectedDir, selectedFile).absolutePath)
                         }
                     },
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text(stringResource("settings.appearance.avatar.select"))
                 }
 
-                // Remove button (only show if avatar exists)
                 if (currentAvatar != null) {
-                    TextButton(
+                    dangerButton(
                         onClick = onRemoveAvatar,
-                        colors = ButtonDefaults.textButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error,
-                        ),
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.remove"))
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
@@ -4,7 +4,9 @@
  */
 package io.askimo.desktop.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -68,7 +70,7 @@ fun groupedModelListAsCards(
             Text(
                 text = category.uppercase(),
                 style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.primary,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(
                     horizontal = 0.dp,
@@ -105,7 +107,7 @@ fun groupedModelListAsCards(
                         Icon(
                             Icons.Default.CheckCircle,
                             contentDescription = "Selected model",
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 }
@@ -136,16 +138,22 @@ fun groupedModelListAsMenuItems(
     groupedModels.forEach { (category, categoryModels) ->
         // Category header
         if (shouldShowHeaders && categoryModels.isNotEmpty()) {
-            Text(
-                text = category.uppercase(),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.padding(
-                    horizontal = 16.dp,
-                    vertical = 8.dp,
-                ),
-            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .padding(
+                        horizontal = 16.dp,
+                        vertical = 8.dp,
+                    ),
+            ) {
+                Text(
+                    text = category.uppercase(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
         }
 
         // Models in this category
@@ -163,7 +171,7 @@ fun groupedModelListAsMenuItems(
                         Icon(
                             Icons.Default.Check,
                             contentDescription = "Current model",
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 } else {

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
@@ -20,15 +20,12 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AssistChip
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,6 +36,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import io.askimo.core.mcp.McpServerDefinition
 import io.askimo.core.mcp.config.McpServersConfig
+import io.askimo.desktop.common.components.dangerButton
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -79,7 +79,7 @@ fun mcpServerTemplatesSection() {
         Row(
             horizontalArrangement = Arrangement.spacedBy(Spacing.small),
         ) {
-            OutlinedButton(
+            primaryButton(
                 onClick = { showAddDialog = true },
             ) {
                 Icon(Icons.Default.Add, contentDescription = null)
@@ -87,7 +87,7 @@ fun mcpServerTemplatesSection() {
                 Text(stringResource("mcp.servers.add"))
             }
 
-            OutlinedButton(
+            secondaryButton(
                 onClick = { showResetConfirm = true },
             ) {
                 Icon(Icons.Default.RestartAlt, contentDescription = null)
@@ -162,7 +162,7 @@ fun mcpServerTemplatesSection() {
             title = { Text(stringResource("mcp.servers.delete.confirm.title")) },
             text = { Text(stringResource("mcp.servers.delete.confirm.message", server.name)) },
             confirmButton = {
-                Button(
+                dangerButton(
                     onClick = {
                         McpServersConfig.remove(server.id)
                         servers = McpServersConfig.getAll()
@@ -173,7 +173,7 @@ fun mcpServerTemplatesSection() {
                 }
             },
             dismissButton = {
-                TextButton(onClick = { deletingServer = null }) {
+                secondaryButton(onClick = { deletingServer = null }) {
                     Text(stringResource("dialog.cancel"))
                 }
             },
@@ -187,7 +187,7 @@ fun mcpServerTemplatesSection() {
             title = { Text(stringResource("mcp.servers.reset.confirm.title")) },
             text = { Text(stringResource("mcp.servers.reset.confirm.message")) },
             confirmButton = {
-                Button(
+                dangerButton(
                     onClick = {
                         McpServersConfig.resetToDefaults()
                         servers = McpServersConfig.getAll()
@@ -198,7 +198,7 @@ fun mcpServerTemplatesSection() {
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showResetConfirm = false }) {
+                secondaryButton(onClick = { showResetConfirm = false }) {
                     Text(stringResource("dialog.cancel"))
                 }
             },
@@ -248,7 +248,7 @@ private fun mcpServerTemplateCard(
                         Icon(
                             Icons.Filled.CheckCircle,
                             contentDescription = "Valid",
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     } else {
                         Icon(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ModelSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ModelSelectionDialog.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,6 +28,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -164,7 +165,7 @@ fun modelSelectionDialog(
                                     Icon(
                                         Icons.Default.CheckCircle,
                                         contentDescription = "New model selected",
-                                        tint = MaterialTheme.colorScheme.primary,
+                                        tint = MaterialTheme.colorScheme.onSurface,
                                     )
                                 }
                             }
@@ -221,7 +222,7 @@ fun modelSelectionDialog(
             }
         },
         confirmButton = {
-            TextButton(
+            primaryButton(
                 onClick = {
                     selectedModel?.let { onSelect(it) }
                 },
@@ -231,7 +232,7 @@ fun modelSelectionDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            secondaryButton(onClick = onDismiss) {
                 Text(stringResource("action.cancel"))
             }
         },

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
@@ -148,7 +148,9 @@ private fun proxyConfigurationCard() {
                         ProxyType.entries.forEach { type ->
                             DropdownMenuItem(
                                 text = {
-                                    Column {
+                                    Column(
+                                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                                    ) {
                                         Text(
                                             text = stringResource("settings.proxy.type.${type.name.lowercase()}"),
                                             style = MaterialTheme.typography.bodyMedium,
@@ -170,7 +172,7 @@ private fun proxyConfigurationCard() {
                                         Icon(
                                             Icons.Default.Check,
                                             contentDescription = "Selected",
-                                            tint = MaterialTheme.colorScheme.primary,
+                                            tint = MaterialTheme.colorScheme.onSurface,
                                         )
                                     }
                                 } else {

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
@@ -7,7 +7,6 @@ package io.askimo.desktop.settings
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,7 +24,6 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -33,10 +31,8 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,12 +40,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ProviderConfigField
+import io.askimo.desktop.common.components.linkButton
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 import io.askimo.desktop.common.theme.ComponentColors
 import io.askimo.desktop.common.theme.Spacing
@@ -288,7 +285,7 @@ fun providerSelectionDialog(
                                                     Icon(
                                                         Icons.Default.CheckCircle,
                                                         contentDescription = "Selected",
-                                                        tint = MaterialTheme.colorScheme.primary,
+                                                        tint = MaterialTheme.colorScheme.onSurface,
                                                     )
                                                 }
                                             } else {
@@ -302,10 +299,10 @@ fun providerSelectionDialog(
 
                         // Help link for provider setup instructions
                         if (viewModel.selectedProvider != null) {
-                            TextButton(
+                            linkButton(
                                 onClick = {
                                     try {
-                                        val providerName = viewModel.selectedProvider?.name?.lowercase() ?: return@TextButton
+                                        val providerName = viewModel.selectedProvider?.name?.lowercase() ?: return@linkButton
                                         Desktop.getDesktop().browse(
                                             URI("https://askimo.chat/docs/desktop/providers/$providerName/"),
                                         )
@@ -313,8 +310,7 @@ fun providerSelectionDialog(
                                         // Silently fail if browser cannot be opened
                                     }
                                 },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                contentPadding = PaddingValues(0.dp),
+                                modifier = Modifier.padding(0.dp),
                             ) {
                                 Icon(
                                     Icons.AutoMirrored.Filled.Help,
@@ -325,7 +321,6 @@ fun providerSelectionDialog(
                                 Text(
                                     text = stringResource("provider.setup.guide", viewModel.selectedProvider?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: ""),
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.primary,
                                 )
                             }
                         }
@@ -377,7 +372,7 @@ fun providerSelectionDialog(
                                                             Icon(
                                                                 Icons.Default.CheckCircle,
                                                                 contentDescription = stringResource("provider.apikey.already.stored"),
-                                                                tint = MaterialTheme.colorScheme.primary,
+                                                                tint = MaterialTheme.colorScheme.onSurface,
                                                             )
                                                         }
                                                         Spacer(modifier = Modifier.width(8.dp))
@@ -407,7 +402,7 @@ fun providerSelectionDialog(
                                                         style = MaterialTheme.typography.bodySmall,
                                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                                     )
-                                                    TextButton(
+                                                    linkButton(
                                                         onClick = {
                                                             try {
                                                                 Desktop.getDesktop().browse(
@@ -417,13 +412,11 @@ fun providerSelectionDialog(
                                                                 // Silently fail if browser cannot be opened
                                                             }
                                                         },
-                                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                                        contentPadding = PaddingValues(0.dp),
+                                                        modifier = Modifier.padding(0.dp),
                                                     ) {
                                                         Text(
                                                             text = stringResource("provider.apikey.security.link"),
                                                             style = MaterialTheme.typography.bodySmall,
-                                                            color = MaterialTheme.colorScheme.primary,
                                                         )
                                                     }
                                                 }
@@ -526,7 +519,7 @@ fun providerSelectionDialog(
 
                                         // Show download button for Ollama if model can be pulled
                                         if (viewModel.canPullEmbeddingModel && viewModel.embeddingModelProvider == "OLLAMA") {
-                                            Button(
+                                            primaryButton(
                                                 onClick = {
                                                     val baseUrl = viewModel.providerFieldValues["baseUrl"] ?: ""
                                                     if (baseUrl.isNotBlank()) {
@@ -534,7 +527,6 @@ fun providerSelectionDialog(
                                                     }
                                                 },
                                                 enabled = !viewModel.isCheckingEmbeddingModel,
-                                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                             ) {
                                                 if (viewModel.isCheckingEmbeddingModel) {
                                                     CircularProgressIndicator(
@@ -559,18 +551,16 @@ fun providerSelectionDialog(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.small),
             ) {
                 if (viewModel.showModelSelectionInProviderDialog) {
-                    OutlinedButton(
+                    secondaryButton(
                         onClick = { viewModel.backToProviderConfiguration() },
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("action.back"))
                     }
                 } else {
                     if (viewModel.selectedProvider != null && viewModel.providerConfigFields.isNotEmpty()) {
-                        OutlinedButton(
+                        secondaryButton(
                             onClick = { viewModel.testConnection() },
                             enabled = !viewModel.isTestingConnection,
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             if (viewModel.isTestingConnection) {
                                 CircularProgressIndicator(
@@ -587,25 +577,21 @@ fun providerSelectionDialog(
                 }
 
                 // Save button
-                Button(
+                primaryButton(
                     onClick = onSave,
                     enabled = if (viewModel.showModelSelectionInProviderDialog) {
                         viewModel.pendingModelForNewProvider != null
                     } else {
                         false
                     },
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.subtleButtonColors(),
                 ) {
                     Text(stringResource("settings.save"))
                 }
             }
         },
         dismissButton = {
-            TextButton(
+            secondaryButton(
                 onClick = onDismiss,
-                colors = ComponentColors.primaryTextButtonColors(),
-                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             ) {
                 Text(stringResource("settings.cancel"))
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsConfigDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsConfigDialog.kt
@@ -9,21 +9,25 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -122,14 +126,24 @@ fun settingsConfigDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = {
-                viewModel.closeSettingsDialog()
-            }) {
+            Button(
+                onClick = {
+                    viewModel.closeSettingsDialog()
+                },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ),
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) {
                 Text(stringResource("action.done"))
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            OutlinedButton(
+                onClick = onDismiss,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) {
                 Text(stringResource("action.cancel"))
             }
         },

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/EventLogWindow.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/EventLogWindow.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import androidx.compose.ui.window.rememberWindowState
 import io.askimo.core.event.Event
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.util.TimeUtil
+import io.askimo.desktop.common.components.linkButton
 
 /**
  * Developer Event Log Window - Shows ONLY developer events (isDeveloperEvent = true).
@@ -83,7 +83,7 @@ fun eventLogWindow(
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(onClick = onReattach) {
+                    linkButton(onClick = onReattach) {
                         Text(LocalizationManager.getString("eventlog.window.attach"))
                     }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
@@ -174,7 +174,7 @@ private fun providerButton(
                     imageVector = Icons.Default.AutoAwesome,
                     contentDescription = null,
                     modifier = Modifier.size(14.dp),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
                     text = currentProvider.name.lowercase().replaceFirstChar { it.uppercase() },
@@ -495,7 +495,7 @@ fun footerBar(
                                 stringResource("telemetry.show")
                             },
                             modifier = Modifier.size(18.dp),
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 }
@@ -513,7 +513,7 @@ fun footerBar(
                     Text(
                         text = stringResource("system.share.feedback"),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
                 }
 
@@ -691,6 +691,7 @@ private fun eventPopupContent(
                 text = "Notifications (${events.size})",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
             )
 
             if (events.isNotEmpty()) {
@@ -702,7 +703,7 @@ private fun eventPopupContent(
                     Text(
                         text = stringResource("event.notification.clear.all"),
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
                 }
             }
@@ -714,7 +715,7 @@ private fun eventPopupContent(
             Text(
                 text = stringResource("event.notification.empty"),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.padding(16.dp),
             )
         } else {
@@ -800,11 +801,7 @@ private fun eventItem(
                     fontWeight = FontWeight.Bold,
                     color = when {
                         isIndexingFailure -> MaterialTheme.colorScheme.error
-                        isIndexingSuccess -> MaterialTheme.colorScheme.primary
-                        isIndexingInProgress -> MaterialTheme.colorScheme.tertiary
-                        isIndexingStarted -> MaterialTheme.colorScheme.onSurfaceVariant
-                        isSystemEvent -> MaterialTheme.colorScheme.primary
-                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                        else -> MaterialTheme.colorScheme.onSurface
                     },
                 )
 
@@ -816,7 +813,7 @@ private fun eventItem(
                     Text(
                         text = stringResource("event.notification.clear"),
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.error,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
                 }
             }
@@ -824,7 +821,7 @@ private fun eventItem(
             Text(
                 text = formatInstantDisplay(event.timestamp),
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                color = MaterialTheme.colorScheme.onSurface,
             )
 
             Text(
@@ -833,7 +830,7 @@ private fun eventItem(
                 color = if (isIndexingFailure) {
                     MaterialTheme.colorScheme.error
                 } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
+                    MaterialTheme.colorScheme.onSurface
                 },
             )
 
@@ -855,7 +852,7 @@ private fun eventItem(
                         Text(
                             text = stringResource("event.details.action"),
                             style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                 }
@@ -900,7 +897,7 @@ private fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
                     Text(
                         text = stringResource("telemetry.title"),
                         style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = MaterialTheme.colorScheme.onSurface,
                         fontWeight = FontWeight.SemiBold,
                     )
 
@@ -1059,7 +1056,7 @@ private fun telemetryMetricCard(
                     Text(
                         text = value,
                         style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = MaterialTheme.colorScheme.onSurface,
                         fontWeight = FontWeight.Bold,
                     )
                 }
@@ -1067,7 +1064,7 @@ private fun telemetryMetricCard(
                 Text(
                     text = value,
                     style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = MaterialTheme.colorScheme.onSurface,
                     fontWeight = FontWeight.Bold,
                 )
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/GlobalSearchDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/GlobalSearchDialog.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SmartToy
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -34,7 +33,6 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -70,7 +68,10 @@ import io.askimo.core.search.DateFilter
 import io.askimo.core.search.SearchResult
 import io.askimo.core.search.SessionSearchService
 import io.askimo.core.search.SortBy
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
+import io.askimo.desktop.common.theme.ComponentColors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -267,6 +268,7 @@ fun globalSearchDialog(
                             }
                         },
                     singleLine = true,
+                    colors = ComponentColors.outlinedTextFieldColors(),
                 )
 
                 // Filters Row
@@ -290,6 +292,7 @@ fun globalSearchDialog(
                                 .fillMaxWidth()
                                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                                 .pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))),
+                            colors = ComponentColors.outlinedTextFieldColors(),
                         )
                         ExposedDropdownMenu(
                             expanded = dateFilterExpanded,
@@ -324,6 +327,7 @@ fun globalSearchDialog(
                                 .fillMaxWidth()
                                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                                 .pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))),
+                            colors = ComponentColors.outlinedTextFieldColors(),
                         )
                         ExposedDropdownMenu(
                             expanded = sortByExpanded,
@@ -396,7 +400,6 @@ fun globalSearchDialog(
                             }
                         }
                         searchResults.isNotEmpty() -> {
-                            // Results list
                             Column(modifier = Modifier.fillMaxSize()) {
                                 Text(
                                     text = if (searchResults.size == 1) {
@@ -426,7 +429,6 @@ fun globalSearchDialog(
                             }
                         }
                         else -> {
-                            // Initial state - no search yet
                             Box(
                                 modifier = Modifier.fillMaxSize(),
                                 contentAlignment = Alignment.Center,
@@ -436,7 +438,7 @@ fun globalSearchDialog(
                                         imageVector = Icons.Default.Search,
                                         contentDescription = null,
                                         modifier = Modifier.size(64.dp),
-                                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                                     )
                                     Spacer(modifier = Modifier.height(16.dp))
                                     Text(
@@ -453,22 +455,18 @@ fun globalSearchDialog(
                 // Action Buttons
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    OutlinedButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))),
                     ) {
                         Text(stringResource("dialog.cancel"))
                     }
 
-                    Spacer(modifier = Modifier.width(12.dp))
-
-                    Button(
+                    primaryButton(
                         onClick = { performSearch() },
                         enabled = searchQuery.isNotBlank() && !isSearching,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))),
                     ) {
                         Icon(
                             imageVector = Icons.Default.Search,
@@ -530,7 +528,7 @@ private fun searchResultItem(
                     text = result.sessionTitle,
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -530,6 +530,22 @@ private fun projectsList(
             bottom = (4 * fontScale).dp,
         ),
     ) {
+        NavigationDrawerItem(
+            icon = { Icon(Icons.Default.Add, contentDescription = null) },
+            label = {
+                Text(
+                    stringResource("project.new"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            selected = false,
+            onClick = onNewProject,
+            modifier = Modifier
+                .padding(vertical = (2 * fontScale).dp)
+                .pointerHoverIcon(PointerIcon.Hand),
+            colors = ComponentColors.navigationDrawerItemColors(),
+        )
+
         if (projectsViewModel.projects.isEmpty()) {
             // No projects yet
             Text(
@@ -551,23 +567,6 @@ private fun projectsList(
                 )
             }
         }
-
-        // New Project button
-        NavigationDrawerItem(
-            icon = { Icon(Icons.Default.Add, contentDescription = null) },
-            label = {
-                Text(
-                    stringResource("project.new"),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            },
-            selected = false,
-            onClick = onNewProject,
-            modifier = Modifier
-                .padding(vertical = (2 * fontScale).dp)
-                .pointerHoverIcon(PointerIcon.Hand),
-            colors = ComponentColors.navigationDrawerItemColors(),
-        )
     }
 
     // Delete confirmation dialog
@@ -737,7 +736,7 @@ private fun sessionsList(
                         Icon(
                             Icons.Default.Star,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     },
                     label = {
@@ -825,7 +824,7 @@ private fun sessionsList(
                             text = "More...",
                             style = MaterialTheme.typography.bodySmall,
                             fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = MaterialTheme.colorScheme.onSurface,
                         )
                     },
                     selected = false,


### PR DESCRIPTION
- Introduce shared primary/secondary/link/danger button composables
- Replace ad-hoc Material3 buttons across dialogs and views for consistency
- Use onSurface for icon/text tint to improve contrast across themes
- Add Modern Gray accent option and refine light/dark color schemes
- Adjust markdown link color to tertiary to keep links distinct from accents
- Add JSON render fallback in session memory view to handle invalid payloads