### PR TITLE
feat(rag-sources): add RAG sources tree and side panel

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -75,9 +75,6 @@
     "name": "[Lio.askimo.core.mcp.McpServerDefinition;"
   },
   {
-    "name": "[Lio.askimo.core.mcp.Parameter;"
-  },
-  {
     "name": "[Ljava.lang.Object;"
   },
   {
@@ -555,6 +552,7 @@
     "queryAllDeclaredConstructors": true,
     "methods": [
       { "name": "<init>", "parameterTypes": [] },
+      { "name": "getAnnotations", "parameterTypes": [] },
       { "name": "getAutoRemove", "parameterTypes": [] },
       { "name": "getBlkioDeviceReadBps", "parameterTypes": [] },
       { "name": "getBlkioDeviceReadIOps", "parameterTypes": [] },
@@ -3907,7 +3905,6 @@
           "java.lang.String",
           "io.askimo.core.mcp.TransportType",
           "io.askimo.core.mcp.StdioConfig",
-          "java.util.List",
           "java.lang.String",
           "java.lang.String",
           "java.util.List",
@@ -3922,7 +3919,6 @@
           "java.lang.String",
           "io.askimo.core.mcp.TransportType",
           "io.askimo.core.mcp.StdioConfig",
-          "java.util.List",
           "java.lang.String",
           "java.lang.String",
           "java.util.List"
@@ -3932,7 +3928,6 @@
       { "name": "getDescription", "parameterTypes": [] },
       { "name": "getId", "parameterTypes": [] },
       { "name": "getName", "parameterTypes": [] },
-      { "name": "getParameters", "parameterTypes": [] },
       { "name": "getStdioConfig", "parameterTypes": [] },
       { "name": "getTags", "parameterTypes": [] },
       { "name": "getTransportType", "parameterTypes": [] },
@@ -3944,78 +3939,6 @@
   },
   {
     "name": "io.askimo.core.mcp.McpServerDefinition$Companion"
-  },
-  {
-    "name": "io.askimo.core.mcp.Parameter",
-    "allDeclaredFields": true,
-    "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "int",
-          "java.lang.String",
-          "java.lang.String",
-          "io.askimo.core.mcp.ParameterType",
-          "boolean",
-          "java.lang.String",
-          "java.lang.String",
-          "java.lang.String",
-          "java.lang.String",
-          "io.askimo.core.mcp.ParameterLocation",
-          "boolean",
-          "kotlinx.serialization.internal.SerializationConstructorMarker"
-        ]
-      },
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "java.lang.String",
-          "java.lang.String",
-          "io.askimo.core.mcp.ParameterType",
-          "boolean",
-          "java.lang.String",
-          "java.lang.String",
-          "java.lang.String",
-          "java.lang.String",
-          "io.askimo.core.mcp.ParameterLocation",
-          "boolean"
-        ]
-      },
-      { "name": "getAllowMultiple", "parameterTypes": [] },
-      { "name": "getDefaultValue", "parameterTypes": [] },
-      { "name": "getDescription", "parameterTypes": [] },
-      { "name": "getKey", "parameterTypes": [] },
-      { "name": "getLabel", "parameterTypes": [] },
-      { "name": "getLocation", "parameterTypes": [] },
-      { "name": "getPlaceholder", "parameterTypes": [] },
-      { "name": "getRequired", "parameterTypes": [] },
-      { "name": "getType", "parameterTypes": [] },
-      { "name": "getValidationPattern", "parameterTypes": [] }
-    ]
-  },
-  {
-    "name": "io.askimo.core.mcp.Parameter$$serializer"
-  },
-  {
-    "name": "io.askimo.core.mcp.Parameter$Companion"
-  },
-  {
-    "name": "io.askimo.core.mcp.ParameterLocation",
-    "allDeclaredFields": true,
-    "queryAllDeclaredMethods": true
-  },
-  {
-    "name": "io.askimo.core.mcp.ParameterLocation$Companion"
-  },
-  {
-    "name": "io.askimo.core.mcp.ParameterType",
-    "allDeclaredFields": true,
-    "queryAllDeclaredMethods": true
-  },
-  {
-    "name": "io.askimo.core.mcp.ParameterType$Companion"
   },
   {
     "name": "io.askimo.core.mcp.ProjectMcpInstance"
@@ -4121,12 +4044,346 @@
     "name": "io.askimo.core.mcp.StdioConfig$Companion"
   },
   {
+    "name": "io.askimo.core.mcp.TemplateResolverTest",
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] },
+      {
+        "name": "extractParameters finds both simple and conditional",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractParameters finds conditional placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractParameters finds simple placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractParameters from complex template",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractParameters handles duplicate parameters",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractParameters returns empty for empty string",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractParameters returns empty for plain text",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve Docker command with all options",
+        "parameterTypes": []
+      },
+      { "name": "resolve MongoDB connection string", "parameterTypes": [] },
+      {
+        "name": "resolve command line arguments with optional flags",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve complex command with multiple placeholder types",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder when false",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder when missing",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder when true",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder with True capitalized",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder with case insensitive true",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder with complex value",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder with equals sign in value",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional placeholder with spaces in value",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional with empty string treats as false",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve conditional with non-boolean value treats as false",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve empty template returns empty string",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve environment variables for deployment",
+        "parameterTypes": []
+      },
+      { "name": "resolve handles adjacent placeholders", "parameterTypes": [] },
+      { "name": "resolve handles empty string value", "parameterTypes": [] },
+      {
+        "name": "resolve handles placeholder with numbers",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve handles placeholder with underscore",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve mix of simple and conditional placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve multiple conditional placeholders",
+        "parameterTypes": []
+      },
+      { "name": "resolve multiple simple placeholders", "parameterTypes": [] },
+      { "name": "resolve placeholder at end of string", "parameterTypes": [] },
+      {
+        "name": "resolve placeholder at start of string",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve placeholder with numeric value",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve placeholder with special characters in value",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve preserves whitespace around placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve same placeholder multiple times",
+        "parameterTypes": []
+      },
+      { "name": "resolve simple placeholder with value", "parameterTypes": [] },
+      {
+        "name": "resolve simple placeholder without value returns empty",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve template with no placeholders returns original",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolveList filters out empty results from false conditionals",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolveList filters out empty results from missing values",
+        "parameterTypes": []
+      },
+      { "name": "resolveList with all valid templates", "parameterTypes": [] },
+      {
+        "name": "resolveList with empty list returns empty",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolveList with mixed placeholder types",
+        "parameterTypes": []
+      },
+      { "name": "resolveMap filters out blank values", "parameterTypes": [] },
+      {
+        "name": "resolveMap handles comma-separated with spaces",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolveMap splits comma-separated KEY=value pairs",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolveMap with conditional placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolveMap with empty template map returns empty",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolveMap with simple key-value pairs",
+        "parameterTypes": []
+      },
+      { "name": "validate detects empty placeholder", "parameterTypes": [] },
+      {
+        "name": "validate detects unmatched closing braces",
+        "parameterTypes": []
+      },
+      {
+        "name": "validate detects unmatched opening braces",
+        "parameterTypes": []
+      },
+      {
+        "name": "validate returns valid for correct conditional placeholder",
+        "parameterTypes": []
+      },
+      {
+        "name": "validate returns valid for correct simple placeholder",
+        "parameterTypes": []
+      },
+      {
+        "name": "validate returns valid for empty string",
+        "parameterTypes": []
+      },
+      {
+        "name": "validate returns valid for multiple placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "validate returns valid for nested braces in value",
+        "parameterTypes": []
+      },
+      { "name": "validate returns valid for plain text", "parameterTypes": [] }
+    ]
+  },
+  {
     "name": "io.askimo.core.mcp.TransportType",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true
   },
   {
     "name": "io.askimo.core.mcp.TransportType$Companion"
+  },
+  {
+    "name": "io.askimo.core.mcp.VariableExtractorTest",
+    "allDeclaredFields": true,
+    "allDeclaredClasses": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] },
+      {
+        "name": "extract Filesystem MCP server variables",
+        "parameterTypes": []
+      },
+      { "name": "extract MongoDB MCP server variables", "parameterTypes": [] },
+      {
+        "name": "extract complex server with multiple variable types",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should find variables from command template only",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should find variables from environment template only",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should find variables from working directory",
+        "parameterTypes": []
+      },
+      { "name": "extract should handle empty config", "parameterTypes": [] },
+      {
+        "name": "extract should handle malformed placeholders gracefully",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should handle nested braces in conditional value",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should handle very long variable names",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should identify conditional variables",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should return sorted results by key",
+        "parameterTypes": []
+      },
+      {
+        "name": "extract should track variable in multiple locations",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should find both simple and conditional placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should find conditional placeholder",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should find multiple placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should find simple placeholder",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should handle adjacent placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should handle complex conditional with value containing special chars",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should handle conditional with spaces in value",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should handle unicode characters",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should remove duplicates",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should return empty for empty string",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should return empty for no placeholders",
+        "parameterTypes": []
+      },
+      {
+        "name": "extractFromString should trim whitespace in variable keys",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve extension should filter out blank working directory",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve extension should handle missing optional variables",
+        "parameterTypes": []
+      },
+      {
+        "name": "resolve extension should produce resolved config",
+        "parameterTypes": []
+      }
+    ]
   },
   {
     "name": "io.askimo.core.mcp.config.InstancesWrapper",
@@ -4292,7 +4549,7 @@
     ]
   },
   {
-    "name": "io.askimo.core.providers.ChatClient$MockitoMock$aLg5i2V2",
+    "name": "io.askimo.core.providers.ChatClient$MockitoMock$sjF4lq7e",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
@@ -5709,12 +5966,6 @@
     "queryAllDeclaredMethods": true
   },
   {
-    "name": "java.util.Collections$SingletonList",
-    "allDeclaredFields": true,
-    "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true
-  },
-  {
     "name": "java.util.Collections$SingletonMap",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,
@@ -6192,20 +6443,6 @@
     "name": "kotlinx.serialization.internal.SerializationConstructorMarker"
   },
   {
-    "name": "org.apache.commons.logging.LogFactory"
-  },
-  {
-    "name": "org.apache.commons.logging.impl.Log4jApiLogFactory",
-    "methods": [{ "name": "<init>", "parameterTypes": [] }]
-  },
-  {
-    "name": "org.apache.commons.logging.impl.WeakHashtable",
-    "methods": [{ "name": "<init>", "parameterTypes": [] }]
-  },
-  {
-    "name": "org.apache.logging.slf4j.SLF4JProvider"
-  },
-  {
     "name": "org.apache.tika.detect.microsoft.POIFSContainerDetector",
     "methods": [
       { "name": "<init>", "parameterTypes": [] },
@@ -6591,7 +6828,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$gljnWaoY",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$uwUPkgUn",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/cli/src/main/resources/META-INF/native-image/resource-config.json
+++ b/cli/src/main/resources/META-INF/native-image/resource-config.json
@@ -101,9 +101,6 @@
         "pattern": "\\QMETA-INF/services/kotlin.test.AsserterContributor\\E"
       },
       {
-        "pattern": "\\QMETA-INF/services/org.apache.commons.logging.LogFactory\\E"
-      },
-      {
         "pattern": "\\QMETA-INF/services/org.apache.logging.log4j.spi.Provider\\E"
       },
       {
@@ -162,9 +159,6 @@
       },
       {
         "pattern": "\\Qcom/github/dockerjava/zerodep/shaded/org/apache/hc/client5/version.properties\\E"
-      },
-      {
-        "pattern": "\\Qcommons-logging.properties\\E"
       },
       {
         "pattern": "\\Qcustom-mimetypes.xml\\E"

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatView.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -158,6 +159,16 @@ fun chatView(
     var ragIndexingStatus by remember { mutableStateOf<String?>(null) }
     var ragIndexingPercentage by remember { mutableStateOf<Int?>(null) }
 
+    // Side panel state (RAG sources, MCP, etc.)
+    var sidePanelExpanded by remember { mutableStateOf(true) }
+
+    // Auto-expand panel when project has knowledge sources
+    LaunchedEffect(project?.id, project?.knowledgeSources?.size) {
+        if (project != null && project.knowledgeSources.isNotEmpty() && !sidePanelExpanded) {
+            sidePanelExpanded = true
+        }
+    }
+
     // Check initial RAG status when project changes and subscribe to indexing events
     LaunchedEffect(project?.id) {
         if (project?.id != null && project.knowledgeSources.isNotEmpty()) {
@@ -279,7 +290,7 @@ fun chatView(
         )
     }
 
-    Column(
+    Row(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)
@@ -325,704 +336,724 @@ fun chatView(
                 }
             },
     ) {
-        // Session header with title and directive selector
-        if (provider != null && model != null) {
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = ComponentColors.sidebarSurfaceColor(),
-                    contentColor = MaterialTheme.colorScheme.onSurface,
-                ),
-            ) {
-                Row(
+        // Main chat area (left side)
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        ) {
+            // Session header with title and directive selector
+            if (provider != null && model != null) {
+                Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(12.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = ComponentColors.sidebarSurfaceColor(),
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
                 ) {
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.weight(1f, fill = false),
                     ) {
-                        // Breadcrumb navigation for project
-                        if (project != null) {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                // Clickable project name as breadcrumb
-                                TooltipArea(
-                                    tooltip = {
-                                        Surface(
-                                            color = MaterialTheme.colorScheme.surfaceVariant,
-                                            shape = RoundedCornerShape(4.dp),
-                                            modifier = Modifier.width(350.dp),
-                                        ) {
-                                            Column(
-                                                modifier = Modifier.padding(12.dp),
-                                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.weight(1f, fill = false),
+                        ) {
+                            // Breadcrumb navigation for project
+                            if (project != null) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    // Clickable project name as breadcrumb
+                                    TooltipArea(
+                                        tooltip = {
+                                            Surface(
+                                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                                shape = RoundedCornerShape(4.dp),
+                                                modifier = Modifier.width(350.dp),
                                             ) {
-                                                Text(
-                                                    text = project.name,
-                                                    style = MaterialTheme.typography.titleSmall,
-                                                    fontWeight = FontWeight.Bold,
-                                                )
-
-                                                project.description?.let { description ->
-                                                    if (description.isNotBlank()) {
-                                                        Text(
-                                                            text = description,
-                                                            style = MaterialTheme.typography.bodySmall,
-                                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                        )
-                                                    }
-                                                }
-
-                                                if (project.knowledgeSources.isNotEmpty()) {
-                                                    Spacer(modifier = Modifier.height(4.dp))
+                                                Column(
+                                                    modifier = Modifier.padding(12.dp),
+                                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                                ) {
                                                     Text(
-                                                        text = stringResource("projects.sources.title"),
-                                                        style = MaterialTheme.typography.labelSmall,
+                                                        text = project.name,
+                                                        style = MaterialTheme.typography.titleSmall,
                                                         fontWeight = FontWeight.Bold,
                                                     )
-                                                    Column(
-                                                        modifier = Modifier.padding(start = 8.dp),
-                                                        verticalArrangement = Arrangement.spacedBy(2.dp),
-                                                    ) {
-                                                        project.knowledgeSources.forEach { source ->
-                                                            Row(
-                                                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                                                verticalAlignment = Alignment.CenterVertically,
-                                                            ) {
-                                                                Text(
-                                                                    text = "•",
-                                                                    style = MaterialTheme.typography.bodySmall,
-                                                                )
-                                                                Text(
-                                                                    text = source.resourceIdentifier,
-                                                                    style = MaterialTheme.typography.bodySmall,
-                                                                    maxLines = 1,
-                                                                    overflow = TextOverflow.Ellipsis,
-                                                                )
+
+                                                    project.description?.let { description ->
+                                                        if (description.isNotBlank()) {
+                                                            Text(
+                                                                text = description,
+                                                                style = MaterialTheme.typography.bodySmall,
+                                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                            )
+                                                        }
+                                                    }
+
+                                                    if (project.knowledgeSources.isNotEmpty()) {
+                                                        Spacer(modifier = Modifier.height(4.dp))
+                                                        Text(
+                                                            text = stringResource("projects.sources.title"),
+                                                            style = MaterialTheme.typography.labelSmall,
+                                                            fontWeight = FontWeight.Bold,
+                                                        )
+                                                        Column(
+                                                            modifier = Modifier.padding(start = 8.dp),
+                                                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                                                        ) {
+                                                            project.knowledgeSources.forEach { source ->
+                                                                Row(
+                                                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                                                    verticalAlignment = Alignment.CenterVertically,
+                                                                ) {
+                                                                    Text(
+                                                                        text = "•",
+                                                                        style = MaterialTheme.typography.bodySmall,
+                                                                    )
+                                                                    Text(
+                                                                        text = source.resourceIdentifier,
+                                                                        style = MaterialTheme.typography.bodySmall,
+                                                                        maxLines = 1,
+                                                                        overflow = TextOverflow.Ellipsis,
+                                                                    )
+                                                                }
                                                             }
                                                         }
                                                     }
+
+                                                    // Timestamps
+                                                    Spacer(modifier = Modifier.height(4.dp))
+                                                    Text(
+                                                        text = "Created: ${formatDisplay(project.createdAt)}",
+                                                        style = MaterialTheme.typography.labelSmall,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    )
+                                                    Text(
+                                                        text = "Updated: ${formatDisplay(project.updatedAt)}",
+                                                        style = MaterialTheme.typography.labelSmall,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    )
                                                 }
-
-                                                // Timestamps
-                                                Spacer(modifier = Modifier.height(4.dp))
-                                                Text(
-                                                    text = "Created: ${formatDisplay(project.createdAt)}",
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                )
-                                                Text(
-                                                    text = "Updated: ${formatDisplay(project.updatedAt)}",
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                )
                                             }
-                                        }
-                                    },
-                                ) {
-                                    TextButton(
-                                        onClick = {
-                                            onNavigateToProject?.invoke(project.id)
                                         },
-                                        colors = ButtonDefaults.textButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        ),
-                                        shape = RoundedCornerShape(4.dp),
-                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                     ) {
-                                        Text(
-                                            text = project.name.take(3).uppercase(),
-                                            style = MaterialTheme.typography.labelMedium,
-                                            fontWeight = FontWeight.Bold,
-                                        )
-                                    }
-                                }
-
-                                // Chevron separator
-                                Icon(
-                                    imageVector = Icons.Default.ChevronRight,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSurface,
-                                    modifier = Modifier.size(20.dp),
-                                )
-                            }
-                        }
-
-                        // RAG indexing status indicator
-                        if (project != null && project.knowledgeSources.isNotEmpty()) {
-                            val statusText = when (ragIndexingStatus) {
-                                "started" -> "RAG (Started)"
-                                "inprogress" -> ragIndexingPercentage?.let { "RAG (In Progress - $it%)" } ?: "RAG (In Progress)"
-                                "completed" -> "RAG"
-                                "failed" -> "RAG (Failed)"
-                                else -> null
-                            }
-
-                            val statusColor = when (ragIndexingStatus) {
-                                "failed" -> MaterialTheme.colorScheme.error
-                                "completed" -> MaterialTheme.colorScheme.onSurface
-                                "inprogress" -> MaterialTheme.colorScheme.tertiary
-                                "started" -> MaterialTheme.colorScheme.onSurfaceVariant
-                                else -> MaterialTheme.colorScheme.onSurfaceVariant
-                            }
-
-                            if (statusText != null) {
-                                TooltipArea(
-                                    tooltip = {
-                                        Surface(
-                                            color = MaterialTheme.colorScheme.surfaceVariant,
+                                        TextButton(
+                                            onClick = {
+                                                onNavigateToProject?.invoke(project.id)
+                                            },
+                                            colors = ButtonDefaults.textButtonColors(
+                                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            ),
                                             shape = RoundedCornerShape(4.dp),
+                                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                         ) {
                                             Text(
-                                                text = statusText,
-                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                                style = MaterialTheme.typography.bodySmall,
-                                            )
-                                        }
-                                    },
-                                ) {
-                                    Row(
-                                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.AutoAwesome,
-                                            contentDescription = "RAG Status",
-                                            tint = statusColor,
-                                            modifier = Modifier.size(18.dp),
-                                        )
-                                        if (ragIndexingStatus == "inprogress") {
-                                            CircularProgressIndicator(
-                                                modifier = Modifier.size(14.dp),
-                                                color = statusColor,
-                                                strokeWidth = 2.dp,
+                                                text = project.name.take(3).uppercase(),
+                                                style = MaterialTheme.typography.labelMedium,
+                                                fontWeight = FontWeight.Bold,
                                             )
                                         }
                                     }
-                                }
-                            }
-                        }
 
-                        // Session title
-                        Text(
-                            text = sessionTitle ?: "New Chat",
-                            style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier
-                                .weight(1f, fill = false)
-                                .padding(end = 8.dp),
-                        )
-                    }
-
-                    // Right side: Directive selector and session actions
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource("chat.directive"),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-
-                        var showManageDirectivesDialog by remember { mutableStateOf(false) }
-                        var directiveDropdownExpanded by remember { mutableStateOf(false) }
-
-                        // Get the selected directive details
-                        val selectedDirectiveObj = remember(selectedDirective, availableDirectives) {
-                            selectedDirective?.let { id ->
-                                availableDirectives.find { it.id == id }
-                            }
-                        }
-
-                        Box {
-                            TooltipArea(
-                                tooltip = {
-                                    if (selectedDirectiveObj != null) {
-                                        Surface(
-                                            modifier = Modifier.width(400.dp),
-                                            shadowElevation = 4.dp,
-                                            shape = MaterialTheme.shapes.small,
-                                        ) {
-                                            Column(
-                                                modifier = Modifier.padding(12.dp),
-                                            ) {
-                                                Text(
-                                                    text = selectedDirectiveObj.name,
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    color = MaterialTheme.colorScheme.onSurface,
-                                                    fontWeight = FontWeight.Bold,
-                                                )
-                                                Text(
-                                                    text = selectedDirectiveObj.content,
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                    modifier = Modifier.padding(top = 8.dp),
-                                                )
-                                            }
-                                        }
-                                    }
-                                },
-                            ) {
-                                TextButton(
-                                    onClick = { directiveDropdownExpanded = true },
-                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                    colors = ButtonDefaults.textButtonColors(
-                                        contentColor = MaterialTheme.colorScheme.onSurface,
-                                    ),
-                                ) {
-                                    Text(
-                                        text = selectedDirectiveObj?.name?.take(30)?.let {
-                                            if (selectedDirectiveObj.name.length > 30) "$it..." else it
-                                        } ?: stringResource("chat.directive.none"),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                    )
+                                    // Chevron separator
                                     Icon(
-                                        imageVector = Icons.Default.ArrowDropDown,
-                                        contentDescription = "Select directive",
+                                        imageVector = Icons.Default.ChevronRight,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSurface,
                                         modifier = Modifier.size(20.dp),
                                     )
                                 }
                             }
 
-                            ComponentColors.themedDropdownMenu(
-                                expanded = directiveDropdownExpanded,
-                                onDismissRequest = { directiveDropdownExpanded = false },
-                                modifier = Modifier.fillMaxWidth(0.3f),
-                            ) {
-                                // "None" option to clear directive
-                                DropdownMenuItem(
-                                    text = {
-                                        Text(
-                                            text = stringResource("chat.directive.none"),
-                                            style = MaterialTheme.typography.bodyMedium,
-                                        )
-                                    },
-                                    onClick = {
-                                        actions.setDirective(null)
-                                        directiveDropdownExpanded = false
-                                    },
-                                    leadingIcon = if (selectedDirective == null) {
-                                        {
-                                            Icon(
-                                                Icons.Default.Check,
-                                                contentDescription = "Selected",
-                                                tint = MaterialTheme.colorScheme.onSurface,
-                                            )
-                                        }
-                                    } else {
-                                        null
-                                    },
-                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                )
+                            // RAG indexing status indicator
+                            if (project != null && project.knowledgeSources.isNotEmpty()) {
+                                val statusText = when (ragIndexingStatus) {
+                                    "started" -> "RAG (Started)"
+                                    "inprogress" -> ragIndexingPercentage?.let { "RAG (In Progress - $it%)" } ?: "RAG (In Progress)"
+                                    "completed" -> "RAG"
+                                    "failed" -> "RAG (Failed)"
+                                    else -> null
+                                }
 
-                                // Show available directives
-                                if (availableDirectives.isNotEmpty()) {
-                                    HorizontalDivider()
+                                val statusColor = when (ragIndexingStatus) {
+                                    "failed" -> MaterialTheme.colorScheme.error
+                                    "completed" -> MaterialTheme.colorScheme.onSurface
+                                    "inprogress" -> MaterialTheme.colorScheme.tertiary
+                                    "started" -> MaterialTheme.colorScheme.onSurfaceVariant
+                                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                                }
 
-                                    availableDirectives.forEach { directive ->
-                                        TooltipArea(
-                                            tooltip = {
-                                                Surface(
-                                                    modifier = Modifier.width(400.dp),
-                                                    shadowElevation = 4.dp,
-                                                    shape = MaterialTheme.shapes.small,
-                                                ) {
-                                                    Column(
-                                                        modifier = Modifier.padding(12.dp),
-                                                    ) {
-                                                        Text(
-                                                            text = directive.name,
-                                                            style = MaterialTheme.typography.labelMedium,
-                                                            color = MaterialTheme.colorScheme.onSurface,
-                                                            fontWeight = FontWeight.Bold,
-                                                        )
-                                                        Text(
-                                                            text = directive.content,
-                                                            style = MaterialTheme.typography.bodySmall,
-                                                            modifier = Modifier.padding(top = 8.dp),
-                                                        )
-                                                    }
-                                                }
-                                            },
+                                if (statusText != null) {
+                                    TooltipArea(
+                                        tooltip = {
+                                            Surface(
+                                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                                shape = RoundedCornerShape(4.dp),
+                                            ) {
+                                                Text(
+                                                    text = statusText,
+                                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                )
+                                            }
+                                        },
+                                    ) {
+                                        Row(
+                                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                            verticalAlignment = Alignment.CenterVertically,
                                         ) {
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Text(
-                                                        text = directive.name,
-                                                        style = MaterialTheme.typography.bodyMedium,
-                                                    )
-                                                },
-                                                onClick = {
-                                                    actions.setDirective(directive.id)
-                                                    directiveDropdownExpanded = false
-                                                },
-                                                leadingIcon = if (selectedDirective == directive.id) {
-                                                    {
-                                                        Icon(
-                                                            Icons.Default.Check,
-                                                            contentDescription = "Selected",
-                                                            tint = MaterialTheme.colorScheme.onSurface,
-                                                        )
-                                                    }
-                                                } else {
-                                                    null
-                                                },
-                                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                            Icon(
+                                                imageVector = Icons.Default.AutoAwesome,
+                                                contentDescription = "RAG Status",
+                                                tint = statusColor,
+                                                modifier = Modifier.size(18.dp),
                                             )
+                                            if (ragIndexingStatus == "inprogress") {
+                                                CircularProgressIndicator(
+                                                    modifier = Modifier.size(14.dp),
+                                                    color = statusColor,
+                                                    strokeWidth = 2.dp,
+                                                )
+                                            }
                                         }
                                     }
                                 }
-
-                                // Action items section
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = 4.dp),
-                                )
-
-                                // New Directive action
-                                DropdownMenuItem(
-                                    text = {
-                                        Row(
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                        ) {
-                                            Icon(
-                                                Icons.Default.Add,
-                                                contentDescription = "New directive",
-                                                tint = MaterialTheme.colorScheme.onSurface,
-                                                modifier = Modifier.size(20.dp),
-                                            )
-                                            Text(
-                                                text = stringResource("chat.directive.new"),
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.onSurface,
-                                            )
-                                        }
-                                    },
-                                    onClick = {
-                                        showNewDirectiveDialog = true
-                                        directiveDropdownExpanded = false
-                                    },
-                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                )
-
-                                // Manage Directives action
-                                DropdownMenuItem(
-                                    text = {
-                                        Row(
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                        ) {
-                                            Icon(
-                                                Icons.Default.Edit,
-                                                contentDescription = "Manage directives",
-                                                tint = MaterialTheme.colorScheme.onSurface,
-                                                modifier = Modifier.size(20.dp),
-                                            )
-                                            Text(
-                                                text = stringResource("chat.directive.manage"),
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.onSurface,
-                                            )
-                                        }
-                                    },
-                                    onClick = {
-                                        showManageDirectivesDialog = true
-                                        directiveDropdownExpanded = false
-                                    },
-                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                )
                             }
 
-                            // Show manage directives dialog
-                            if (showManageDirectivesDialog) {
-                                manageDirectivesDialog(
-                                    directives = availableDirectives,
-                                    onDismiss = { showManageDirectivesDialog = false },
-                                    onUpdate = { id, newName, newContent ->
-                                        directiveService.updateDirective(id, newName, newContent)
-                                        availableDirectives = directiveService.listAllDirectives()
-                                    },
-                                    onDelete = { id ->
-                                        directiveService.deleteDirective(id)
-                                        if (selectedDirective == id) {
-                                            actions.setDirective(null)
+                            // Session title
+                            Text(
+                                text = sessionTitle ?: "New Chat",
+                                style = MaterialTheme.typography.titleLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier
+                                    .weight(1f, fill = false)
+                                    .padding(end = 8.dp),
+                            )
+                        }
+
+                        // Right side: Directive selector and session actions
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = stringResource("chat.directive"),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+
+                            var showManageDirectivesDialog by remember { mutableStateOf(false) }
+                            var directiveDropdownExpanded by remember { mutableStateOf(false) }
+
+                            // Get the selected directive details
+                            val selectedDirectiveObj = remember(selectedDirective, availableDirectives) {
+                                selectedDirective?.let { id ->
+                                    availableDirectives.find { it.id == id }
+                                }
+                            }
+
+                            Box {
+                                TooltipArea(
+                                    tooltip = {
+                                        if (selectedDirectiveObj != null) {
+                                            Surface(
+                                                modifier = Modifier.width(400.dp),
+                                                shadowElevation = 4.dp,
+                                                shape = MaterialTheme.shapes.small,
+                                            ) {
+                                                Column(
+                                                    modifier = Modifier.padding(12.dp),
+                                                ) {
+                                                    Text(
+                                                        text = selectedDirectiveObj.name,
+                                                        style = MaterialTheme.typography.labelMedium,
+                                                        color = MaterialTheme.colorScheme.onSurface,
+                                                        fontWeight = FontWeight.Bold,
+                                                    )
+                                                    Text(
+                                                        text = selectedDirectiveObj.content,
+                                                        style = MaterialTheme.typography.bodySmall,
+                                                        modifier = Modifier.padding(top = 8.dp),
+                                                    )
+                                                }
+                                            }
                                         }
-                                        availableDirectives = directiveService.listAllDirectives()
+                                    },
+                                ) {
+                                    TextButton(
+                                        onClick = { directiveDropdownExpanded = true },
+                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                        colors = ButtonDefaults.textButtonColors(
+                                            contentColor = MaterialTheme.colorScheme.onSurface,
+                                        ),
+                                    ) {
+                                        Text(
+                                            text = selectedDirectiveObj?.name?.take(30)?.let {
+                                                if (selectedDirectiveObj.name.length > 30) "$it..." else it
+                                            } ?: stringResource("chat.directive.none"),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                        )
+                                        Icon(
+                                            imageVector = Icons.Default.ArrowDropDown,
+                                            contentDescription = "Select directive",
+                                            modifier = Modifier.size(20.dp),
+                                        )
+                                    }
+                                }
+
+                                ComponentColors.themedDropdownMenu(
+                                    expanded = directiveDropdownExpanded,
+                                    onDismissRequest = { directiveDropdownExpanded = false },
+                                    modifier = Modifier.fillMaxWidth(0.3f),
+                                ) {
+                                    // "None" option to clear directive
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                text = stringResource("chat.directive.none"),
+                                                style = MaterialTheme.typography.bodyMedium,
+                                            )
+                                        },
+                                        onClick = {
+                                            actions.setDirective(null)
+                                            directiveDropdownExpanded = false
+                                        },
+                                        leadingIcon = if (selectedDirective == null) {
+                                            {
+                                                Icon(
+                                                    Icons.Default.Check,
+                                                    contentDescription = "Selected",
+                                                    tint = MaterialTheme.colorScheme.onSurface,
+                                                )
+                                            }
+                                        } else {
+                                            null
+                                        },
+                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                    )
+
+                                    // Show available directives
+                                    if (availableDirectives.isNotEmpty()) {
+                                        HorizontalDivider()
+
+                                        availableDirectives.forEach { directive ->
+                                            TooltipArea(
+                                                tooltip = {
+                                                    Surface(
+                                                        modifier = Modifier.width(400.dp),
+                                                        shadowElevation = 4.dp,
+                                                        shape = MaterialTheme.shapes.small,
+                                                    ) {
+                                                        Column(
+                                                            modifier = Modifier.padding(12.dp),
+                                                        ) {
+                                                            Text(
+                                                                text = directive.name,
+                                                                style = MaterialTheme.typography.labelMedium,
+                                                                color = MaterialTheme.colorScheme.onSurface,
+                                                                fontWeight = FontWeight.Bold,
+                                                            )
+                                                            Text(
+                                                                text = directive.content,
+                                                                style = MaterialTheme.typography.bodySmall,
+                                                                modifier = Modifier.padding(top = 8.dp),
+                                                            )
+                                                        }
+                                                    }
+                                                },
+                                            ) {
+                                                DropdownMenuItem(
+                                                    text = {
+                                                        Text(
+                                                            text = directive.name,
+                                                            style = MaterialTheme.typography.bodyMedium,
+                                                        )
+                                                    },
+                                                    onClick = {
+                                                        actions.setDirective(directive.id)
+                                                        directiveDropdownExpanded = false
+                                                    },
+                                                    leadingIcon = if (selectedDirective == directive.id) {
+                                                        {
+                                                            Icon(
+                                                                Icons.Default.Check,
+                                                                contentDescription = "Selected",
+                                                                tint = MaterialTheme.colorScheme.onSurface,
+                                                            )
+                                                        }
+                                                    } else {
+                                                        null
+                                                    },
+                                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                                )
+                                            }
+                                        }
+                                    }
+
+                                    // Action items section
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(vertical = 4.dp),
+                                    )
+
+                                    // New Directive action
+                                    DropdownMenuItem(
+                                        text = {
+                                            Row(
+                                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                            ) {
+                                                Icon(
+                                                    Icons.Default.Add,
+                                                    contentDescription = "New directive",
+                                                    tint = MaterialTheme.colorScheme.onSurface,
+                                                    modifier = Modifier.size(20.dp),
+                                                )
+                                                Text(
+                                                    text = stringResource("chat.directive.new"),
+                                                    style = MaterialTheme.typography.bodyMedium,
+                                                    color = MaterialTheme.colorScheme.onSurface,
+                                                )
+                                            }
+                                        },
+                                        onClick = {
+                                            showNewDirectiveDialog = true
+                                            directiveDropdownExpanded = false
+                                        },
+                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                    )
+
+                                    // Manage Directives action
+                                    DropdownMenuItem(
+                                        text = {
+                                            Row(
+                                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                            ) {
+                                                Icon(
+                                                    Icons.Default.Edit,
+                                                    contentDescription = "Manage directives",
+                                                    tint = MaterialTheme.colorScheme.onSurface,
+                                                    modifier = Modifier.size(20.dp),
+                                                )
+                                                Text(
+                                                    text = stringResource("chat.directive.manage"),
+                                                    style = MaterialTheme.typography.bodyMedium,
+                                                    color = MaterialTheme.colorScheme.onSurface,
+                                                )
+                                            }
+                                        },
+                                        onClick = {
+                                            showManageDirectivesDialog = true
+                                            directiveDropdownExpanded = false
+                                        },
+                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                    )
+                                }
+
+                                // Show manage directives dialog
+                                if (showManageDirectivesDialog) {
+                                    manageDirectivesDialog(
+                                        directives = availableDirectives,
+                                        onDismiss = { showManageDirectivesDialog = false },
+                                        onUpdate = { id, newName, newContent ->
+                                            directiveService.updateDirective(id, newName, newContent)
+                                            availableDirectives = directiveService.listAllDirectives()
+                                        },
+                                        onDelete = { id ->
+                                            directiveService.deleteDirective(id)
+                                            if (selectedDirective == id) {
+                                                actions.setDirective(null)
+                                            }
+                                            availableDirectives = directiveService.listAllDirectives()
+                                        },
+                                    )
+                                }
+                            }
+
+                            if (sessionId != null) {
+                                sessionActionsMenu(
+                                    sessionId = sessionId,
+                                    onRenameSession = onRenameSession,
+                                    onExportSession = onExportSession,
+                                    onDeleteSession = onDeleteSession,
+                                    onShowSessionSummary = { sid ->
+                                        sessionMemorySessionId = sid
+                                        showSessionMemoryDialog = true
                                     },
                                 )
                             }
                         }
+                    }
+                }
+            }
 
-                        if (sessionId != null) {
-                            sessionActionsMenu(
-                                sessionId = sessionId,
-                                onRenameSession = onRenameSession,
-                                onExportSession = onExportSession,
-                                onDeleteSession = onDeleteSession,
-                                onShowSessionSummary = { sid ->
-                                    sessionMemorySessionId = sid
-                                    showSessionMemoryDialog = true
+            // Search bar - fixed at top, always visible when search mode is active
+            if (isSearchMode) {
+                HorizontalDivider()
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    colors = ComponentColors.bannerCardColors(),
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        // Search icon
+                        Icon(
+                            Icons.Default.Search,
+                            contentDescription = "Search",
+                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+
+                        // Search input field
+                        OutlinedTextField(
+                            value = searchQuery,
+                            onValueChange = actions::searchMessages,
+                            modifier = Modifier
+                                .weight(1f)
+                                .focusRequester(searchFocusRequester),
+                            placeholder = { Text(stringResource("chat.search.placeholder")) },
+                            singleLine = true,
+                            colors = ComponentColors.outlinedTextFieldColors(),
+                        )
+
+                        // Result count
+                        if (!isSearching && searchQuery.isNotEmpty()) {
+                            Text(
+                                text = if (searchResults.isEmpty()) {
+                                    stringResource("chat.search.no.results")
+                                } else {
+                                    "${currentSearchResultIndex + 1}/${searchResults.size}"
                                 },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.padding(horizontal = 8.dp),
+                            )
+                        }
+
+                        // Navigation buttons (Previous)
+                        IconButton(
+                            onClick = actions::previousSearchResult,
+                            enabled = searchResults.isNotEmpty(),
+                            modifier = Modifier
+                                .size(36.dp)
+                                .pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowUp,
+                                contentDescription = "Previous result (${AppShortcut.PREVIOUS_SEARCH_RESULT.getDisplayString()})",
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+
+                        // Navigation buttons (Next)
+                        IconButton(
+                            onClick = actions::nextSearchResult,
+                            enabled = searchResults.isNotEmpty(),
+                            modifier = Modifier
+                                .size(36.dp)
+                                .pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowDown,
+                                contentDescription = "Next result (${AppShortcut.NEXT_SEARCH_RESULT.getDisplayString()})",
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+
+                        // Close button
+                        IconButton(
+                            onClick = actions::clearSearch,
+                            modifier = Modifier
+                                .size(36.dp)
+                                .pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = "Close search",
+                                modifier = Modifier.size(20.dp),
                             )
                         }
                     }
                 }
             }
-        }
 
-        // Search bar - fixed at top, always visible when search mode is active
-        if (isSearchMode) {
-            HorizontalDivider()
-
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                colors = ComponentColors.bannerCardColors(),
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    // Search icon
-                    Icon(
-                        Icons.Default.Search,
-                        contentDescription = "Search",
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
-
-                    // Search input field
-                    OutlinedTextField(
-                        value = searchQuery,
-                        onValueChange = actions::searchMessages,
-                        modifier = Modifier
-                            .weight(1f)
-                            .focusRequester(searchFocusRequester),
-                        placeholder = { Text(stringResource("chat.search.placeholder")) },
-                        singleLine = true,
-                        colors = ComponentColors.outlinedTextFieldColors(),
-                    )
-
-                    // Result count
-                    if (!isSearching && searchQuery.isNotEmpty()) {
-                        Text(
-                            text = if (searchResults.isEmpty()) {
-                                stringResource("chat.search.no.results")
-                            } else {
-                                "${currentSearchResultIndex + 1}/${searchResults.size}"
-                            },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier = Modifier.padding(horizontal = 8.dp),
-                        )
-                    }
-
-                    // Navigation buttons (Previous)
-                    IconButton(
-                        onClick = actions::previousSearchResult,
-                        enabled = searchResults.isNotEmpty(),
-                        modifier = Modifier
-                            .size(36.dp)
-                            .pointerHoverIcon(PointerIcon.Hand),
-                    ) {
-                        Icon(
-                            Icons.Default.KeyboardArrowUp,
-                            contentDescription = "Previous result (${AppShortcut.PREVIOUS_SEARCH_RESULT.getDisplayString()})",
-                            modifier = Modifier.size(20.dp),
-                        )
-                    }
-
-                    // Navigation buttons (Next)
-                    IconButton(
-                        onClick = actions::nextSearchResult,
-                        enabled = searchResults.isNotEmpty(),
-                        modifier = Modifier
-                            .size(36.dp)
-                            .pointerHoverIcon(PointerIcon.Hand),
-                    ) {
-                        Icon(
-                            Icons.Default.KeyboardArrowDown,
-                            contentDescription = "Next result (${AppShortcut.NEXT_SEARCH_RESULT.getDisplayString()})",
-                            modifier = Modifier.size(20.dp),
-                        )
-                    }
-
-                    // Close button
-                    IconButton(
-                        onClick = actions::clearSearch,
-                        modifier = Modifier
-                            .size(36.dp)
-                            .pointerHoverIcon(PointerIcon.Hand),
-                    ) {
-                        Icon(
-                            Icons.Default.Close,
-                            contentDescription = "Close search",
-                            modifier = Modifier.size(20.dp),
-                        )
-                    }
-                }
-            }
-        }
-
-        // Download attachment handler
-        val saveDialogTitle = stringResource("attachment.save.file")
-        val downloadAttachment: (FileAttachmentDTO) -> Unit = { attachment ->
-            val fileChooser = FileDialog(null as Frame?, saveDialogTitle, FileDialog.SAVE)
-            fileChooser.file = attachment.fileName
-            fileChooser.isVisible = true
-            val selectedFile = fileChooser.file
-            val selectedDir = fileChooser.directory
-            if (selectedFile != null && selectedDir != null) {
-                val targetFile = File(selectedDir, selectedFile)
-                // Copy the attachment file to the selected location
-                attachment.filePath?.let { filePath ->
-                    val sourceFile = File(filePath)
-                    if (sourceFile.exists()) {
-                        try {
-                            sourceFile.copyTo(targetFile, overwrite = true)
-                            log.debug("Downloaded attachment: ${attachment.fileName} to ${targetFile.absolutePath}")
-                        } catch (e: Exception) {
-                            log.error("Error copying attachment file: ${e.message}", e)
+            // Download attachment handler
+            val saveDialogTitle = stringResource("attachment.save.file")
+            val downloadAttachment: (FileAttachmentDTO) -> Unit = { attachment ->
+                val fileChooser = FileDialog(null as Frame?, saveDialogTitle, FileDialog.SAVE)
+                fileChooser.file = attachment.fileName
+                fileChooser.isVisible = true
+                val selectedFile = fileChooser.file
+                val selectedDir = fileChooser.directory
+                if (selectedFile != null && selectedDir != null) {
+                    val targetFile = File(selectedDir, selectedFile)
+                    // Copy the attachment file to the selected location
+                    attachment.filePath?.let { filePath ->
+                        val sourceFile = File(filePath)
+                        if (sourceFile.exists()) {
+                            try {
+                                sourceFile.copyTo(targetFile, overwrite = true)
+                                log.debug("Downloaded attachment: ${attachment.fileName} to ${targetFile.absolutePath}")
+                            } catch (e: Exception) {
+                                log.error("Error copying attachment file: ${e.message}", e)
+                            }
+                        } else {
+                            log.error("Source file not found: $filePath")
                         }
-                    } else {
-                        log.error("Source file not found: $filePath")
+                    } ?: log.error("Attachment file path is null: ${attachment.fileName}")
+                }
+            }
+
+            // Messages area
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            ) {
+                when {
+                    isSearchMode && searchResults.isEmpty() && !isSearching -> {
+                        Text(
+                            stringResource("chat.search.not.found", searchQuery),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.align(Alignment.Center),
+                        )
                     }
-                } ?: log.error("Attachment file path is null: ${attachment.fileName}")
-            }
-        }
-
-        // Messages area
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(16.dp),
-        ) {
-            when {
-                isSearchMode && searchResults.isEmpty() && !isSearching -> {
-                    Text(
-                        stringResource("chat.search.not.found", searchQuery),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.align(Alignment.Center),
-                    )
-                }
-                isSearchMode -> {
-                    messageList(
-                        messages = searchResults,
-                        isThinking = false,
-                        thinkingElapsedSeconds = 0,
-                        spinnerFrame = spinnerFrame.toString(),
-                        hasMoreMessages = false,
-                        isLoadingPrevious = false,
-                        onLoadPrevious = {},
-                        searchQuery = searchQuery,
-                        currentSearchResultIndex = currentSearchResultIndex,
-                        onMessageClick = onJumpToMessage,
-                        onEditMessage = { message ->
-                            if (message.isUser) {
-                                // User message - set editing mode
-                                editingMessage = message
-                                inputText = TextFieldValue(
-                                    text = message.content,
-                                    selection = TextRange(0),
-                                )
-                                attachments = message.attachments
-                            } else {
-                                // AI message - show edit dialog
-                                editingAIMessage = message
-                            }
-                        },
-                        onDownloadAttachment = downloadAttachment,
-                        aiAvatarPath = aiAvatarPath,
-                        onRetryMessage = actions::retryMessage,
-                    )
-                }
-                messages.isEmpty() -> {
-                    Text(
-                        stringResource("chat.welcome"),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.align(Alignment.Center),
-                    )
-                }
-                else -> {
-                    messageList(
-                        messages = messages,
-                        isThinking = isThinking,
-                        thinkingElapsedSeconds = thinkingElapsedSeconds,
-                        spinnerFrame = spinnerFrame.toString(),
-                        hasMoreMessages = hasMoreMessages,
-                        isLoadingPrevious = isLoadingPrevious,
-                        onLoadPrevious = actions::loadPrevious,
-                        onEditMessage = { message ->
-                            if (message.isUser) {
-                                // User message - set editing mode
-                                editingMessage = message
-                                inputText = TextFieldValue(
-                                    text = message.content,
-                                    selection = TextRange(0),
-                                )
-                                attachments = message.attachments
-                            } else {
-                                // AI message - show edit dialog
-                                editingAIMessage = message
-                            }
-                        },
-                        onDownloadAttachment = downloadAttachment,
-                        aiAvatarPath = aiAvatarPath,
-                        onRetryMessage = actions::retryMessage,
-                    )
+                    isSearchMode -> {
+                        messageList(
+                            messages = searchResults,
+                            isThinking = false,
+                            thinkingElapsedSeconds = 0,
+                            spinnerFrame = spinnerFrame.toString(),
+                            hasMoreMessages = false,
+                            isLoadingPrevious = false,
+                            onLoadPrevious = {},
+                            searchQuery = searchQuery,
+                            currentSearchResultIndex = currentSearchResultIndex,
+                            onMessageClick = onJumpToMessage,
+                            onEditMessage = { message ->
+                                if (message.isUser) {
+                                    // User message - set editing mode
+                                    editingMessage = message
+                                    inputText = TextFieldValue(
+                                        text = message.content,
+                                        selection = TextRange(0),
+                                    )
+                                    attachments = message.attachments
+                                } else {
+                                    // AI message - show edit dialog
+                                    editingAIMessage = message
+                                }
+                            },
+                            onDownloadAttachment = downloadAttachment,
+                            aiAvatarPath = aiAvatarPath,
+                            onRetryMessage = actions::retryMessage,
+                        )
+                    }
+                    messages.isEmpty() -> {
+                        Text(
+                            stringResource("chat.welcome"),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
+                    else -> {
+                        messageList(
+                            messages = messages,
+                            isThinking = isThinking,
+                            thinkingElapsedSeconds = thinkingElapsedSeconds,
+                            spinnerFrame = spinnerFrame.toString(),
+                            hasMoreMessages = hasMoreMessages,
+                            isLoadingPrevious = isLoadingPrevious,
+                            onLoadPrevious = actions::loadPrevious,
+                            onEditMessage = { message ->
+                                if (message.isUser) {
+                                    // User message - set editing mode
+                                    editingMessage = message
+                                    inputText = TextFieldValue(
+                                        text = message.content,
+                                        selection = TextRange(0),
+                                    )
+                                    attachments = message.attachments
+                                } else {
+                                    // AI message - show edit dialog
+                                    editingAIMessage = message
+                                }
+                            },
+                            onDownloadAttachment = downloadAttachment,
+                            aiAvatarPath = aiAvatarPath,
+                            onRetryMessage = actions::retryMessage,
+                        )
+                    }
                 }
             }
-        }
 
-        // Input area
-        chatInputField(
-            inputText = inputText,
-            onInputTextChange = { inputText = it },
-            attachments = attachments,
-            onAttachmentsChange = { attachments = it },
-            onSendMessage = {
-                if (inputText.text.isNotBlank() && !isLoading && !isThinking) {
-                    actions.sendOrEditMessage(inputText.text, attachments, editingMessage)
+            // Input area
+            chatInputField(
+                inputText = inputText,
+                onInputTextChange = { inputText = it },
+                attachments = attachments,
+                onAttachmentsChange = { attachments = it },
+                onSendMessage = {
+                    if (inputText.text.isNotBlank() && !isLoading && !isThinking) {
+                        actions.sendOrEditMessage(inputText.text, attachments, editingMessage)
+                        inputText = TextFieldValue("")
+                        attachments = emptyList()
+                        editingMessage = null
+                    }
+                },
+                isLoading = isLoading,
+                isThinking = isThinking,
+                onStopResponse = actions::cancelResponse,
+                errorMessage = errorMessage,
+                editingMessage = editingMessage,
+                onCancelEdit = {
+                    editingMessage = null
                     inputText = TextFieldValue("")
                     attachments = emptyList()
-                    editingMessage = null
-                }
-            },
-            isLoading = isLoading,
-            isThinking = isThinking,
-            onStopResponse = actions::cancelResponse,
-            errorMessage = errorMessage,
-            editingMessage = editingMessage,
-            onCancelEdit = {
-                editingMessage = null
-                inputText = TextFieldValue("")
-                attachments = emptyList()
-            },
-            sessionId = sessionId,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-        )
-    }
+                },
+                sessionId = sessionId,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            )
+        } // End of main chat Column
 
+        // Project Side Panel (right side) - Tabbed panel with RAG sources, MCP, etc.
+        if (project != null) {
+            projectSidePanel(
+                project = project,
+                ragIndexingStatus = ragIndexingStatus,
+                ragIndexingPercentage = ragIndexingPercentage,
+                isExpanded = sidePanelExpanded,
+                onExpandedChange = { sidePanelExpanded = it },
+                modifier = Modifier.fillMaxHeight(),
+            )
+        }
+    } // End of Row
+
+    // AI Message Edit Dialog
     editingAIMessage?.let { message ->
         aiMessageEditDialog(
             message = message,

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/McpTabContent.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/McpTabContent.kt
@@ -1,0 +1,551 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.chat
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.ExtensionOff
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.langchain4j.agent.tool.ToolSpecification
+import io.askimo.core.chat.domain.Project
+import io.askimo.core.mcp.ProjectMcpInstance
+import io.askimo.core.mcp.ProjectMcpInstanceService
+import io.askimo.desktop.common.i18n.stringResource
+import io.askimo.desktop.common.theme.ComponentColors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.core.context.GlobalContext as KoinGlobalContext
+
+/**
+ * Shows list of MCP instances and their available tools.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun mcpTabContent(project: Project?) {
+    if (project == null) {
+        mcpEmptyState()
+        return
+    }
+
+    val mcpService = remember { KoinGlobalContext.get().get<ProjectMcpInstanceService>() }
+    var instances by remember(project.id) { mutableStateOf<List<ProjectMcpInstance>>(emptyList()) }
+    var selectedInstanceId by remember { mutableStateOf<String?>(null) }
+    var instanceTools by remember { mutableStateOf<Map<String, List<ToolSpecification>>>(emptyMap()) }
+    var loadingTools by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var failedInstances by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var selectedTool by remember { mutableStateOf<Pair<String, String>?>(null) } // instanceId to toolName
+    val coroutineScope = rememberCoroutineScope()
+
+    // Load instances when project changes
+    LaunchedEffect(project.id) {
+        instances = withContext(Dispatchers.IO) {
+            mcpService.getInstances(project.id)
+        }
+    }
+
+    if (instances.isEmpty()) {
+        // No MCP instances configured
+        mcpNoInstancesState()
+        return
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        // MCP Instances list
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(instances) { instance ->
+                mcpInstanceItem(
+                    instance = instance,
+                    isSelected = selectedInstanceId == instance.id,
+                    isExpanded = selectedInstanceId == instance.id,
+                    isLoadingTools = loadingTools.contains(instance.id),
+                    hasFailed = failedInstances.contains(instance.id),
+                    tools = instanceTools[instance.id] ?: emptyList(),
+                    selectedTool = selectedTool,
+                    onToolSelected = { toolName ->
+                        selectedTool = instance.id to toolName
+                    },
+                    onClick = {
+                        if (selectedInstanceId == instance.id) {
+                            // Collapse
+                            selectedInstanceId = null
+                        } else {
+                            // Expand and load tools
+                            selectedInstanceId = instance.id
+
+                            // If failed before, allow retry by clearing failed state
+                            if (failedInstances.contains(instance.id)) {
+                                failedInstances = failedInstances - instance.id
+                            }
+
+                            if (instanceTools[instance.id] == null &&
+                                !loadingTools.contains(instance.id) &&
+                                !failedInstances.contains(instance.id)
+                            ) {
+                                // Load tools for this instance
+                                loadingTools = loadingTools + instance.id
+                                coroutineScope.launch(Dispatchers.IO) {
+                                    try {
+                                        // Add timeout to prevent hanging
+                                        kotlinx.coroutines.withTimeout(15000L) {
+                                            // 15 second timeout
+                                            val client = mcpService.createMcpClient(instance, "ui_${instance.id}")
+                                            if (client != null) {
+                                                val tools = client.listTools()
+                                                // Update UI state - no need for withContext since we're already in a coroutine
+                                                instanceTools = instanceTools + (instance.id to tools)
+                                                loadingTools = loadingTools - instance.id
+                                            } else {
+                                                loadingTools = loadingTools - instance.id
+                                                failedInstances = failedInstances + instance.id
+                                            }
+                                        }
+                                    } catch (e: TimeoutCancellationException) {
+                                        // Connection timeout
+                                        loadingTools = loadingTools - instance.id
+                                        failedInstances = failedInstances + instance.id
+                                    } catch (e: Exception) {
+                                        // Other errors (connection failed, etc.)
+                                        loadingTools = loadingTools - instance.id
+                                        failedInstances = failedInstances + instance.id
+                                    }
+                                }
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * MCP instance item with expandable tools list
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun mcpInstanceItem(
+    instance: ProjectMcpInstance,
+    isSelected: Boolean,
+    isExpanded: Boolean,
+    isLoadingTools: Boolean,
+    hasFailed: Boolean,
+    tools: List<ToolSpecification>,
+    selectedTool: Pair<String, String>?,
+    onToolSelected: (String) -> Unit,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        // Instance header
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                    } else {
+                        Color.Transparent
+                    },
+                    shape = RoundedCornerShape(4.dp),
+                )
+                .clickable(
+                    onClick = onClick,
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                )
+                .padding(8.dp)
+                .pointerHoverIcon(PointerIcon.Hand),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Expand/collapse icon
+            Icon(
+                imageVector = if (isExpanded) {
+                    Icons.Default.KeyboardArrowDown
+                } else {
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight
+                },
+                contentDescription = if (isExpanded) {
+                    stringResource("rag.tree.collapse")
+                } else {
+                    stringResource("rag.tree.expand")
+                },
+                tint = ComponentColors.secondaryIconColor(),
+                modifier = Modifier.size(20.dp),
+            )
+
+            // Instance icon
+            Icon(
+                imageVector = Icons.Default.Extension,
+                contentDescription = null,
+                tint = if (instance.enabled) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    ComponentColors.secondaryIconColor()
+                },
+                modifier = Modifier.size(20.dp),
+            )
+
+            // Instance name and status
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = instance.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                if (!instance.enabled) {
+                    Text(
+                        text = stringResource("mcp.instance.disabled"),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = ComponentColors.secondaryTextColor(),
+                    )
+                }
+            }
+
+            // Tool count badge (when tools loaded)
+            if (tools.isNotEmpty()) {
+                Surface(
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Text(
+                        text = "${tools.size}",
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
+            }
+        }
+
+        // Tools list (when expanded)
+        if (isExpanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 36.dp, top = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                when {
+                    isLoadingTools -> {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(8.dp),
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Text(
+                                text = stringResource("mcp.tools.loading"),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = ComponentColors.secondaryTextColor(),
+                            )
+                        }
+                    }
+                    hasFailed -> {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(8.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.ErrorOutline,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(16.dp),
+                            )
+                            Text(
+                                text = stringResource("mcp.tools.failed"),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                    tools.isEmpty() -> {
+                        Text(
+                            text = stringResource("mcp.tools.none"),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = ComponentColors.secondaryTextColor(),
+                            modifier = Modifier.padding(8.dp),
+                        )
+                    }
+                    else -> {
+                        tools.forEach { tool ->
+                            toolItem(
+                                tool = tool,
+                                instanceId = instance.id,
+                                isSelected = selectedTool?.first == instance.id && selectedTool.second == tool.name(),
+                                onSelected = { onToolSelected(tool.name()) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Individual tool item with selection support and detailed tooltip
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun toolItem(
+    tool: ToolSpecification,
+    instanceId: String,
+    isSelected: Boolean,
+    onSelected: () -> Unit,
+) {
+    TooltipArea(
+        tooltip = {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(4.dp),
+                modifier = Modifier.widthIn(max = 500.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    // Tool name
+                    Text(
+                        text = tool.name(),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+
+                    // Tool description
+                    tool.description()?.let { desc ->
+                        Text(
+                            text = desc,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    // Parameters section
+                    if (tool.parameters() != null) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(vertical = 4.dp),
+                            color = MaterialTheme.colorScheme.outlineVariant,
+                        )
+
+                        Text(
+                            text = stringResource("mcp.tool.parameters"),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+
+                        // Show parameter structure (simplified)
+                        val params = tool.parameters()
+                        if (params != null) {
+                            val properties = params.properties()
+                            if (properties != null && properties.isNotEmpty()) {
+                                Column(
+                                    modifier = Modifier.padding(start = 8.dp),
+                                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                                ) {
+                                    properties.entries.take(5).forEach { (paramName, _) ->
+                                        Text(
+                                            text = "• $paramName",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = ComponentColors.secondaryTextColor(),
+                                        )
+                                    }
+                                    if (properties.size > 5) {
+                                        Text(
+                                            text = "... and ${properties.size - 5} more",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = ComponentColors.tertiaryTextColor(),
+                                            fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                    } else {
+                        Color.Transparent
+                    },
+                    shape = RoundedCornerShape(4.dp),
+                )
+                .clickable(
+                    onClick = onSelected,
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                )
+                .padding(vertical = 4.dp, horizontal = 8.dp)
+                .pointerHoverIcon(PointerIcon.Hand),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Build,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.size(16.dp),
+            )
+
+            Text(
+                text = tool.name(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = if (isSelected) {
+                    FontWeight.Medium
+                } else {
+                    FontWeight.Normal
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+/**
+ * Empty state when no project is selected
+ */
+@Composable
+private fun mcpEmptyState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Extension,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = ComponentColors.tertiaryIconColor(),
+            )
+
+            Text(
+                text = stringResource("mcp.title"),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+            )
+
+            Text(
+                text = stringResource("mcp.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = ComponentColors.secondaryTextColor(),
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+/**
+ * Empty state when no MCP instances configured
+ */
+@Composable
+private fun mcpNoInstancesState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.ExtensionOff,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = ComponentColors.tertiaryIconColor(),
+            )
+
+            Text(
+                text = stringResource("mcp.no.instances.title"),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Medium,
+            )
+
+            Text(
+                text = stringResource("mcp.no.instances.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = ComponentColors.secondaryTextColor(),
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ProjectSidePanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ProjectSidePanel.kt
@@ -1,0 +1,418 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.chat
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import io.askimo.core.chat.domain.Project
+import io.askimo.desktop.common.i18n.stringResource
+import io.askimo.desktop.common.theme.ComponentColors
+import java.awt.Cursor
+
+/**
+ * Tab types for the side panel
+ */
+enum class PanelTab(
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val labelKey: String, // Localization key instead of label
+) {
+    RAG_SOURCES(Icons.Default.AutoAwesome, "panel.tab.rag.sources"),
+    MCP(Icons.Default.Extension, "panel.tab.mcp"),
+    // Add more tabs here in the future
+}
+
+/**
+ * Side panel with tabs for RAG sources, MCP, and more.
+ * Shows as icon bar when collapsed, full panel when expanded.
+ * Supports drag-to-resize when expanded.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun projectSidePanel(
+    project: Project?,
+    ragIndexingStatus: String?,
+    ragIndexingPercentage: Int?,
+    isExpanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Currently selected tab
+    var selectedTab by remember { mutableStateOf(PanelTab.RAG_SOURCES) }
+
+    // Panel width state (default 350dp, min 250dp, max 600dp)
+    var panelWidth by remember { mutableStateOf(350.dp) }
+
+    // Unified card containing both content panel and icon bar
+    Card(
+        modifier = modifier
+            .width(if (isExpanded) panelWidth else 56.dp)
+            .fillMaxHeight(),
+        colors = CardDefaults.cardColors(
+            containerColor = ComponentColors.sidebarSurfaceColor(),
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        shape = RoundedCornerShape(0.dp), // No rounded corners
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(0.dp),
+        ) {
+            // Draggable resize handle (left edge) - only when expanded
+            if (isExpanded) {
+                Box(
+                    modifier = Modifier
+                        .width(4.dp)
+                        .fillMaxHeight()
+                        .background(MaterialTheme.colorScheme.outlineVariant)
+                        .pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.W_RESIZE_CURSOR)))
+                        .pointerInput(Unit) {
+                            detectDragGestures(
+                                onDrag = { change, dragAmount ->
+                                    change.consume()
+                                    val newWidth = panelWidth - dragAmount.x.toDp()
+                                    // Constrain width between 250dp and 600dp
+                                    panelWidth = newWidth.coerceIn(250.dp, 600.dp)
+                                },
+                            )
+                        },
+                )
+            }
+
+            // Content panel (left side) - only visible when expanded
+            if (isExpanded) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f) // Take remaining space after resize handle and icon bar
+                        .fillMaxHeight()
+                        .padding(16.dp),
+                ) {
+                    // Header with title and collapse button
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(selectedTab.labelKey),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                        )
+
+                        IconButton(
+                            onClick = { onExpandedChange(false) },
+                            modifier = Modifier
+                                .size(32.dp)
+                                .pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.ChevronRight,
+                                contentDescription = stringResource("panel.collapse"),
+                                tint = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+                    HorizontalDivider()
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // Tab content
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                    ) {
+                        when (selectedTab) {
+                            PanelTab.RAG_SOURCES -> {
+                                ragSourcesTabContent(
+                                    project = project,
+                                    ragIndexingStatus = ragIndexingStatus,
+                                    ragIndexingPercentage = ragIndexingPercentage,
+                                )
+                            }
+                            PanelTab.MCP -> {
+                                mcpTabContent(project = project)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Icon bar (right side) - always visible
+            Column(
+                modifier = Modifier
+                    .width(56.dp)
+                    .fillMaxHeight()
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                    .padding(vertical = 16.dp, horizontal = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // Tab icons
+                PanelTab.entries.forEach { tab ->
+                    tabIcon(
+                        tab = tab,
+                        isSelected = selectedTab == tab,
+                        onClick = {
+                            selectedTab = tab
+                            if (!isExpanded) {
+                                onExpandedChange(true)
+                            }
+                        },
+                        ragIndexingStatus = if (tab == PanelTab.RAG_SOURCES) ragIndexingStatus else null,
+                        ragIndexingPercentage = if (tab == PanelTab.RAG_SOURCES) ragIndexingPercentage else null,
+                        project = project,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Tab icon with tooltip and selection state
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun tabIcon(
+    tab: PanelTab,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    ragIndexingStatus: String?,
+    ragIndexingPercentage: Int?,
+    project: Project?,
+) {
+    val tooltipText = when (tab) {
+        PanelTab.RAG_SOURCES -> stringResource("panel.tab.rag.sources")
+        PanelTab.MCP -> stringResource("panel.tab.mcp")
+    }
+
+    TooltipArea(
+        tooltip = {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(4.dp),
+            ) {
+                Text(
+                    text = tooltipText,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        },
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(40.dp)
+                .background(
+                    color = if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                    } else {
+                        Color.Transparent
+                    },
+                    shape = RoundedCornerShape(0.dp), // No rounded shape
+                )
+                .clickable(
+                    onClick = onClick,
+                    indication = null, // Remove ripple/focus effect
+                    interactionSource = remember { MutableInteractionSource() },
+                )
+                .pointerHoverIcon(PointerIcon.Hand),
+        ) {
+            Icon(
+                imageVector = tab.icon,
+                contentDescription = stringResource(tab.labelKey),
+                tint = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+/**
+ * RAG Sources tab content
+ */
+@Composable
+private fun ragSourcesTabContent(
+    project: Project?,
+    ragIndexingStatus: String?,
+    ragIndexingPercentage: Int?,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        // RAG Status indicator (only show if sources exist)
+        if (project != null && project.knowledgeSources.isNotEmpty()) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(vertical = 8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.AutoAwesome,
+                    contentDescription = stringResource("rag.status.icon"),
+                    tint = when (ragIndexingStatus) {
+                        "completed" -> MaterialTheme.colorScheme.onSurface
+                        "failed" -> MaterialTheme.colorScheme.error
+                        "inprogress" -> MaterialTheme.colorScheme.tertiary
+                        else -> MaterialTheme.colorScheme.onSurface
+                    },
+                    modifier = Modifier.size(20.dp),
+                )
+
+                Text(
+                    text = when (ragIndexingStatus) {
+                        "started" -> stringResource("rag.status.started")
+                        "inprogress" -> ragIndexingPercentage?.let {
+                            stringResource("rag.status.inprogress", it)
+                        } ?: stringResource("rag.status.inprogress.unknown")
+                        "completed" -> stringResource("rag.status.ready")
+                        "failed" -> stringResource("rag.status.failed")
+                        else -> stringResource("rag.status.not.indexed")
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = when (ragIndexingStatus) {
+                        "completed" -> MaterialTheme.colorScheme.onSurface
+                        "failed" -> MaterialTheme.colorScheme.error
+                        "inprogress" -> MaterialTheme.colorScheme.tertiary
+                        else -> MaterialTheme.colorScheme.onSurface
+                    },
+                )
+
+                if (ragIndexingStatus == "inprogress") {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        }
+
+        // Content area
+        if (project == null || project.knowledgeSources.isEmpty()) {
+            // Empty state
+            ragSourcesEmptyState()
+        } else {
+            // RAG sources tree
+            ragSourcesTree(
+                sources = project.knowledgeSources,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            )
+        }
+    }
+}
+
+/**
+ * Empty state for RAG sources
+ */
+@Composable
+private fun ragSourcesEmptyState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.FolderOpen,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = ComponentColors.tertiaryIconColor(),
+            )
+
+            Text(
+                text = stringResource("rag.empty.title"),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+            )
+
+            Text(
+                text = stringResource("rag.empty.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = ComponentColors.secondaryTextColor(),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            )
+
+            // Placeholder for future "Add Sources" button
+            Button(
+                onClick = { /* TODO: Implement add sources dialog */ },
+                enabled = false,
+                colors = ButtonDefaults.buttonColors(
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource("rag.empty.button.add"))
+            }
+
+            Text(
+                text = stringResource("rag.empty.coming.soon"),
+                style = MaterialTheme.typography.labelSmall,
+                color = ComponentColors.tertiaryTextColor(),
+            )
+        }
+    }
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/RagSourcesTree.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/RagSourcesTree.kt
@@ -1,0 +1,640 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.chat
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.PointerMatcher
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.onClick
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
+import io.askimo.core.chat.domain.LocalFilesKnowledgeSourceConfig
+import io.askimo.core.chat.domain.LocalFoldersKnowledgeSourceConfig
+import io.askimo.core.chat.domain.UrlKnowledgeSourceConfig
+import io.askimo.desktop.common.i18n.stringResource
+import io.askimo.desktop.common.theme.ComponentColors
+import java.awt.Desktop
+import java.io.File
+import java.net.URI
+
+/**
+ * Tree view component for displaying RAG knowledge sources.
+ * Shows files and folders with expandable/collapsible functionality.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ragSourcesTree(
+    sources: List<KnowledgeSourceConfig>,
+    modifier: Modifier = Modifier,
+) {
+    // Selection state
+    var selectedNode by remember { mutableStateOf<TreeNode?>(null) }
+
+    // Convert sources to tree nodes
+    val treeNodes = remember(sources) {
+        sources.map { source ->
+            when (source) {
+                is LocalFoldersKnowledgeSourceConfig -> {
+                    FolderTreeNode(
+                        path = source.resourceIdentifier,
+                        source = source,
+                    )
+                }
+                is LocalFilesKnowledgeSourceConfig -> {
+                    FileTreeNode(
+                        path = source.resourceIdentifier,
+                        source = source,
+                    )
+                }
+                is UrlKnowledgeSourceConfig -> {
+                    UrlTreeNode(
+                        url = source.resourceIdentifier,
+                        source = source,
+                    )
+                }
+            }
+        }
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        items(treeNodes) { node ->
+            treeNodeItem(
+                node = node,
+                level = 0,
+                selectedNode = selectedNode,
+                onNodeSelected = { selectedNode = it },
+            )
+        }
+    }
+}
+
+/**
+ * Sealed class representing different types of tree nodes
+ */
+sealed class TreeNode {
+    abstract val displayName: String
+    abstract val fullPath: String
+}
+
+data class FolderTreeNode(
+    val path: String,
+    val source: LocalFoldersKnowledgeSourceConfig,
+    val children: List<TreeNode> = emptyList(),
+) : TreeNode() {
+    override val displayName: String = File(path).name.ifEmpty { path }
+    override val fullPath: String = path
+}
+
+data class FileTreeNode(
+    val path: String,
+    val source: LocalFilesKnowledgeSourceConfig,
+) : TreeNode() {
+    override val displayName: String = File(path).name.ifEmpty { path }
+    override val fullPath: String = path
+}
+
+data class UrlTreeNode(
+    val url: String,
+    val source: UrlKnowledgeSourceConfig,
+) : TreeNode() {
+    override val displayName: String = url
+    override val fullPath: String = url
+}
+
+/**
+ * Renders a single tree node (file, folder, or URL)
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun treeNodeItem(
+    node: TreeNode,
+    level: Int,
+    selectedNode: TreeNode?,
+    onNodeSelected: (TreeNode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (node) {
+        is FolderTreeNode -> folderNodeItem(node, level, selectedNode, onNodeSelected, modifier)
+        is FileTreeNode -> fileNodeItem(node, level, selectedNode, onNodeSelected, modifier)
+        is UrlTreeNode -> urlNodeItem(node, level, selectedNode, onNodeSelected, modifier)
+    }
+}
+
+/**
+ * Renders a folder node with expand/collapse functionality
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun folderNodeItem(
+    node: FolderTreeNode,
+    level: Int,
+    selectedNode: TreeNode?,
+    onNodeSelected: (TreeNode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+    var showContextMenu by remember { mutableStateOf(false) }
+
+    val children = remember(node.path, isExpanded) {
+        if (isExpanded) {
+            loadFolderChildren(node.path)
+        } else {
+            emptyList()
+        }
+    }
+
+    val isSelected = selectedNode == node
+    val backgroundColor = if (isSelected) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+
+    Column(modifier = modifier) {
+        // Folder row
+        TooltipArea(
+            tooltip = {
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = RoundedCornerShape(4.dp),
+                ) {
+                    Text(
+                        text = node.fullPath,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            },
+        ) {
+            Box {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(backgroundColor, RoundedCornerShape(4.dp))
+                        .onClick(
+                            matcher = PointerMatcher.mouse(PointerButton.Primary),
+                            onClick = {
+                                isExpanded = !isExpanded
+                                onNodeSelected(node)
+                            },
+                        )
+                        .onClick(
+                            matcher = PointerMatcher.mouse(PointerButton.Secondary),
+                            onClick = { showContextMenu = true },
+                        )
+                        .padding(start = (level * 16).dp, top = 4.dp, bottom = 4.dp, end = 4.dp)
+                        .pointerHoverIcon(PointerIcon.Hand),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // Expand/collapse arrow
+                    Icon(
+                        imageVector = if (isExpanded) {
+                            Icons.Default.KeyboardArrowDown
+                        } else {
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight
+                        },
+                        contentDescription = if (isExpanded) {
+                            stringResource("rag.tree.collapse")
+                        } else {
+                            stringResource("rag.tree.expand")
+                        },
+                        tint = ComponentColors.secondaryIconColor(),
+                        modifier = Modifier.size(16.dp),
+                    )
+
+                    // Folder icon
+                    Icon(
+                        imageVector = if (isExpanded) {
+                            Icons.Default.FolderOpen
+                        } else {
+                            Icons.Default.Folder
+                        },
+                        contentDescription = null,
+                        tint = ComponentColors.secondaryIconColor(),
+                        modifier = Modifier.size(18.dp),
+                    )
+
+                    // Folder name
+                    Text(
+                        text = node.displayName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                // Context menu
+                DropdownMenu(
+                    expanded = showContextMenu,
+                    onDismissRequest = { showContextMenu = false },
+                    offset = DpOffset(x = 0.dp, y = 0.dp),
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource("rag.tree.folder.open")) },
+                        onClick = {
+                            openInFileBrowser(node.path)
+                            showContextMenu = false
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Default.FolderOpen, contentDescription = null)
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource("rag.tree.folder.copy.path")) },
+                        onClick = {
+                            copyToClipboard(node.path)
+                            showContextMenu = false
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Default.ContentCopy, contentDescription = null)
+                        },
+                    )
+                }
+            }
+        }
+
+        // Show children when expanded
+        if (isExpanded && children.isNotEmpty()) {
+            Column {
+                children.forEach { child ->
+                    treeNodeItem(
+                        node = child,
+                        level = level + 1,
+                        selectedNode = selectedNode,
+                        onNodeSelected = onNodeSelected,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Renders a file node
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun fileNodeItem(
+    node: FileTreeNode,
+    level: Int,
+    selectedNode: TreeNode?,
+    onNodeSelected: (TreeNode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showContextMenu by remember { mutableStateOf(false) }
+    val isSelected = selectedNode == node
+    val backgroundColor = if (isSelected) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+
+    TooltipArea(
+        tooltip = {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(4.dp),
+            ) {
+                Text(
+                    text = node.fullPath,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+    ) {
+        Box {
+            Row(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .background(backgroundColor, RoundedCornerShape(4.dp))
+                    .onClick(
+                        matcher = PointerMatcher.mouse(PointerButton.Primary),
+                        onClick = { onNodeSelected(node) },
+                    )
+                    .onClick(
+                        matcher = PointerMatcher.mouse(PointerButton.Secondary),
+                        onClick = { showContextMenu = true },
+                    )
+                    .padding(start = (level * 16 + 16).dp, top = 4.dp, bottom = 4.dp, end = 4.dp)
+                    .pointerHoverIcon(PointerIcon.Hand),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // File icon
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.InsertDriveFile,
+                    contentDescription = null,
+                    tint = ComponentColors.secondaryIconColor(),
+                    modifier = Modifier.size(18.dp),
+                )
+
+                // File name
+                Text(
+                    text = node.displayName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            // Context menu
+            DropdownMenu(
+                expanded = showContextMenu,
+                onDismissRequest = { showContextMenu = false },
+                offset = DpOffset(x = 0.dp, y = 0.dp),
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource("rag.tree.file.open")) },
+                    onClick = {
+                        openInFileBrowser(node.path)
+                        showContextMenu = false
+                    },
+                    leadingIcon = {
+                        Icon(Icons.AutoMirrored.Filled.InsertDriveFile, contentDescription = null)
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource("rag.tree.file.open.folder")) },
+                    onClick = {
+                        openContainingFolder(node.path)
+                        showContextMenu = false
+                    },
+                    leadingIcon = {
+                        Icon(Icons.Default.Folder, contentDescription = null)
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource("rag.tree.file.copy.path")) },
+                    onClick = {
+                        copyToClipboard(node.path)
+                        showContextMenu = false
+                    },
+                    leadingIcon = {
+                        Icon(Icons.Default.ContentCopy, contentDescription = null)
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Renders a URL node
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun urlNodeItem(
+    node: UrlTreeNode,
+    level: Int,
+    selectedNode: TreeNode?,
+    onNodeSelected: (TreeNode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showContextMenu by remember { mutableStateOf(false) }
+    val isSelected = selectedNode == node
+    val backgroundColor = if (isSelected) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+
+    TooltipArea(
+        tooltip = {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = RoundedCornerShape(4.dp),
+            ) {
+                Text(
+                    text = node.fullPath,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+    ) {
+        Box {
+            Row(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .background(backgroundColor, RoundedCornerShape(4.dp))
+                    .onClick(
+                        matcher = PointerMatcher.mouse(PointerButton.Primary),
+                        onClick = { onNodeSelected(node) },
+                    )
+                    .onClick(
+                        matcher = PointerMatcher.mouse(PointerButton.Secondary),
+                        onClick = { showContextMenu = true },
+                    )
+                    .padding(start = (level * 16).dp, top = 4.dp, bottom = 4.dp, end = 4.dp)
+                    .pointerHoverIcon(PointerIcon.Hand),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // URL icon
+                Icon(
+                    imageVector = Icons.Default.Language,
+                    contentDescription = null,
+                    tint = ComponentColors.secondaryIconColor(),
+                    modifier = Modifier.size(18.dp),
+                )
+
+                // URL text
+                Text(
+                    text = node.displayName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            // Context menu
+            DropdownMenu(
+                expanded = showContextMenu,
+                onDismissRequest = { showContextMenu = false },
+                offset = DpOffset(x = 0.dp, y = 0.dp),
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource("rag.tree.url.open")) },
+                    onClick = {
+                        openInBrowser(node.url)
+                        showContextMenu = false
+                    },
+                    leadingIcon = {
+                        Icon(Icons.Default.Language, contentDescription = null)
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource("rag.tree.url.copy")) },
+                    onClick = {
+                        copyToClipboard(node.url)
+                        showContextMenu = false
+                    },
+                    leadingIcon = {
+                        Icon(Icons.Default.ContentCopy, contentDescription = null)
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Loads children files and folders for a given directory path
+ */
+private fun loadFolderChildren(folderPath: String): List<TreeNode> {
+    val folder = File(folderPath)
+    if (!folder.exists() || !folder.isDirectory) {
+        return emptyList()
+    }
+
+    val children = mutableListOf<TreeNode>()
+    val files = folder.listFiles() ?: return emptyList()
+
+    // Sort: folders first, then files, both alphabetically
+    val sortedFiles = files.sortedWith(
+        compareBy<File> { !it.isDirectory }
+            .thenBy { it.name.lowercase() },
+    )
+
+    sortedFiles.forEach { file ->
+        when {
+            file.isDirectory -> {
+                children.add(
+                    FolderTreeNode(
+                        path = file.absolutePath,
+                        source = LocalFoldersKnowledgeSourceConfig(
+                            resourceIdentifier = file.absolutePath,
+                        ),
+                    ),
+                )
+            }
+            file.isFile -> {
+                children.add(
+                    FileTreeNode(
+                        path = file.absolutePath,
+                        source = LocalFilesKnowledgeSourceConfig(
+                            resourceIdentifier = file.absolutePath,
+                        ),
+                    ),
+                )
+            }
+        }
+    }
+
+    return children
+}
+
+/**
+ * Opens a file or folder in the OS file browser
+ */
+private fun openInFileBrowser(path: String) {
+    try {
+        val file = File(path)
+        if (file.exists()) {
+            if (Desktop.isDesktopSupported()) {
+                Desktop.getDesktop().open(file)
+            }
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}
+
+/**
+ * Opens the containing folder of a file in the OS file browser
+ */
+private fun openContainingFolder(filePath: String) {
+    try {
+        val file = File(filePath)
+        val parentFolder = file.parentFile
+        if (parentFolder?.exists() == true) {
+            if (Desktop.isDesktopSupported()) {
+                Desktop.getDesktop().open(parentFolder)
+            }
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}
+
+/**
+ * Opens a URL in the default web browser
+ */
+private fun openInBrowser(url: String) {
+    try {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            Desktop.getDesktop().browse(URI(url))
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}
+
+/**
+ * Copies text to system clipboard
+ */
+private fun copyToClipboard(text: String) {
+    try {
+        val clipboard = java.awt.Toolkit.getDefaultToolkit().systemClipboard
+        val stringSelection = java.awt.datatransfer.StringSelection(text)
+        clipboard.setContents(stringSelection, null)
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/theme/ComponentColors.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/theme/ComponentColors.kt
@@ -194,6 +194,51 @@ object ComponentColors {
     fun sidebarHeaderColor(): Color = MaterialTheme.colorScheme.secondaryContainer
 
     /**
+     * Icon tint for secondary/muted icons
+     * - Used for icons that need less emphasis than primary content
+     * - Examples: collapsed sidebar icons, secondary actions, metadata icons
+     * - Provides good contrast while being visually subdued
+     */
+    @Composable
+    fun secondaryIconColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+
+    /**
+     * Icon tint for disabled or very subtle icons
+     * - Used for disabled state or very low emphasis elements
+     * - Examples: placeholder icons, disabled actions
+     * - Follows Material Design 3 guidelines (38% alpha)
+     */
+    @Composable
+    fun disabledIconColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+
+    /**
+     * Icon tint for tertiary/muted icons with very low emphasis
+     * - Used for background icons or decorative elements
+     * - Examples: empty state icons, watermarks
+     * - More subdued than secondaryIconColor
+     */
+    @Composable
+    fun tertiaryIconColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+
+    /**
+     * Text color for secondary text
+     * - Used for supporting text that needs less emphasis
+     * - Examples: descriptions, metadata, helper text
+     * - Better readability than tertiary text
+     */
+    @Composable
+    fun secondaryTextColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+
+    /**
+     * Text color for tertiary text with minimal emphasis
+     * - Used for very subtle text elements
+     * - Examples: "(Coming soon)" labels, footnotes, timestamps
+     * - More subdued than secondary text
+     */
+    @Composable
+    fun tertiaryTextColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+
+    /**
      * Themed DropdownMenu that uses correct theme colors.
      *
      * DropdownMenu in Material3 uses surfaceContainer by default, which doesn't follow

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -1018,3 +1018,47 @@ tutorial.step4.description=Explore these resources to get the most out of Askimo
 tutorial.step4.link.docs=📚 Browse Documentation
 tutorial.step4.link.providers=🔧 Configure AI Providers
 tutorial.step4.link.github=⭐ Star us on GitHub
+
+# RAG Sources Tree
+rag.tree.expand=Expand
+rag.tree.collapse=Collapse
+rag.tree.folder.open=Open in File Browser
+rag.tree.folder.copy.path=Copy Path
+rag.tree.file.open=Open File
+rag.tree.file.open.folder=Open Containing Folder
+rag.tree.file.copy.path=Copy Path
+rag.tree.url.open=Open in Browser
+rag.tree.url.copy=Copy URL
+
+# Project Side Panel
+panel.tab.rag.sources=RAG Sources
+panel.tab.mcp=MCP
+panel.collapse=Collapse panel
+
+# RAG Status
+rag.status.icon=RAG Status
+rag.status.started=Indexing Started
+rag.status.inprogress=Indexing: {0}%
+rag.status.inprogress.unknown=Indexing...
+rag.status.ready=Ready
+rag.status.failed=Indexing Failed
+rag.status.not.indexed=Not Indexed
+
+# RAG Empty State
+rag.empty.title=No Knowledge Sources
+rag.empty.description=Add files or folders to enable RAG\nfor this project
+rag.empty.button.add=Add Sources
+rag.empty.coming.soon=(Coming soon)
+
+# MCP Tab
+mcp.title=MCP (Model Context Protocol)
+mcp.description=Connect to external tools and services\nvia Model Context Protocol
+mcp.coming.soon=(Coming soon)
+mcp.instance.disabled=Disabled
+mcp.tools.loading=Loading tools...
+mcp.tools.failed=Connection failed. Click to retry.
+mcp.tools.none=No tools available
+mcp.tool.parameters=Parameters:
+mcp.no.instances.title=No MCP Instances
+mcp.no.instances.description=Configure MCP server instances in project settings\nto connect external tools and services
+

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -1026,3 +1026,40 @@ tutorial.step4.description=Entdecken Sie diese Ressourcen, um das Beste aus Aski
 tutorial.step4.link.docs=📚 Dokumentation durchsuchen
 tutorial.step4.link.providers=🔧 KI-Anbieter konfigurieren
 tutorial.step4.link.github=⭐ Auf GitHub unterstützen
+
+# RAG Sources Tree
+rag.tree.expand=Erweitern
+rag.tree.collapse=Reduzieren
+rag.tree.folder.open=Im Dateimanager öffnen
+rag.tree.folder.copy.path=Pfad kopieren
+rag.tree.file.open=Datei öffnen
+rag.tree.file.open.folder=Übergeordneten Ordner öffnen
+rag.tree.file.copy.path=Pfad kopieren
+rag.tree.url.open=Im Browser öffnen
+rag.tree.url.copy=URL kopieren
+
+# Project Side Panel
+panel.tab.rag.sources=RAG-Quellen
+panel.tab.mcp=MCP
+panel.collapse=Panel reduzieren
+
+# RAG Status
+rag.status.icon=RAG-Status
+rag.status.started=Indizierung gestartet
+rag.status.inprogress=Indizierung: {0}%
+rag.status.inprogress.unknown=Indizierung...
+rag.status.ready=Bereit
+rag.status.failed=Indizierung fehlgeschlagen
+rag.status.not.indexed=Nicht indiziert
+
+# RAG Empty State
+rag.empty.title=Keine Wissensquellen
+rag.empty.description=Fügen Sie Dateien oder Ordner hinzu,\num RAG für dieses Projekt zu aktivieren
+rag.empty.button.add=Quellen hinzufügen
+rag.empty.coming.soon=(Demnächst verfügbar)
+
+# MCP Tab
+mcp.title=MCP (Model Context Protocol)
+mcp.description=Mit externen Tools und Diensten\nüber das Model Context Protocol verbinden
+mcp.coming.soon=(Demnächst verfügbar)
+

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -1025,3 +1025,38 @@ tutorial.step4.link.docs=📚 Ver documentación
 tutorial.step4.link.providers=🔧 Configurar proveedores de IA
 tutorial.step4.link.github=⭐ Danos una estrella en GitHub
 
+# RAG Sources Tree
+rag.tree.expand=Expandir
+rag.tree.collapse=Contraer
+rag.tree.folder.open=Abrir en el explorador de archivos
+rag.tree.folder.copy.path=Copiar ruta
+rag.tree.file.open=Abrir archivo
+rag.tree.file.open.folder=Abrir carpeta contenedora
+rag.tree.file.copy.path=Copiar ruta
+rag.tree.url.open=Abrir en el navegador
+rag.tree.url.copy=Copiar URL
+
+# Project Side Panel
+panel.tab.rag.sources=Fuentes RAG
+panel.tab.mcp=MCP
+panel.collapse=Contraer panel
+
+# RAG Status
+rag.status.icon=Estado de RAG
+rag.status.started=Indexación iniciada
+rag.status.inprogress=Indexando: {0}%
+rag.status.inprogress.unknown=Indexando...
+rag.status.ready=Listo
+rag.status.failed=Error de indexación
+rag.status.not.indexed=No indexado
+
+# RAG Empty State
+rag.empty.title=Sin fuentes de conocimiento
+rag.empty.description=Agregue archivos o carpetas para habilitar RAG\npara este proyecto
+rag.empty.button.add=Agregar fuentes
+rag.empty.coming.soon=(Próximamente)
+
+# MCP Tab
+mcp.title=MCP (Model Context Protocol)
+mcp.description=Conectarse a herramientas y servicios externos\na través del Model Context Protocol
+mcp.coming.soon=(Próximamente)

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -1024,3 +1024,39 @@ tutorial.step4.description=Explorez ces ressources pour tirer le meilleur parti 
 tutorial.step4.link.docs=📚 Parcourir la documentation
 tutorial.step4.link.providers=🔧 Configurer les fournisseurs d’IA
 tutorial.step4.link.github=⭐ Donnez-nous une étoile sur GitHub
+
+# RAG Sources Tree
+rag.tree.expand=Développer
+rag.tree.collapse=Réduire
+rag.tree.folder.open=Ouvrir dans l’explorateur de fichiers
+rag.tree.folder.copy.path=Copier le chemin
+rag.tree.file.open=Ouvrir le fichier
+rag.tree.file.open.folder=Ouvrir le dossier contenant
+rag.tree.file.copy.path=Copier le chemin
+rag.tree.url.open=Ouvrir dans le navigateur
+rag.tree.url.copy=Copier l’URL
+
+# Project Side Panel
+panel.tab.rag.sources=Sources RAG
+panel.tab.mcp=MCP
+panel.collapse=Réduire le panneau
+
+# RAG Status
+rag.status.icon=Statut RAG
+rag.status.started=Indexation démarrée
+rag.status.inprogress=Indexation : {0}%
+rag.status.inprogress.unknown=Indexation...
+rag.status.ready=Prêt
+rag.status.failed=Échec de l’indexation
+rag.status.not.indexed=Non indexé
+
+# RAG Empty State
+rag.empty.title=Aucune source de connaissances
+rag.empty.description=Ajoutez des fichiers ou dossiers pour activer RAG\npour ce projet
+rag.empty.button.add=Ajouter des sources
+rag.empty.coming.soon=(Bientôt disponible)
+
+# MCP Tab
+mcp.title=MCP (Model Context Protocol)
+mcp.description=Se connecter à des outils et services externes\nvia le Model Context Protocol
+mcp.coming.soon=(Bientôt disponible)

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -1025,3 +1025,38 @@ tutorial.step4.link.docs=📚 ドキュメントを見る
 tutorial.step4.link.providers=🔧 AI プロバイダーを設定
 tutorial.step4.link.github=⭐ GitHub でスターを付ける
 
+# RAG Sources Tree
+rag.tree.expand=展開
+rag.tree.collapse=折りたたむ
+rag.tree.folder.open=ファイルブラウザで開く
+rag.tree.folder.copy.path=パスをコピー
+rag.tree.file.open=ファイルを開く
+rag.tree.file.open.folder=含まれるフォルダを開く
+rag.tree.file.copy.path=パスをコピー
+rag.tree.url.open=ブラウザで開く
+rag.tree.url.copy=URLをコピー
+
+# Project Side Panel
+panel.tab.rag.sources=RAGソース
+panel.tab.mcp=MCP
+panel.collapse=パネルを折りたたむ
+
+# RAG Status
+rag.status.icon=RAGステータス
+rag.status.started=インデックス作成を開始しました
+rag.status.inprogress=インデックス作成中: {0}%
+rag.status.inprogress.unknown=インデックス作成中...
+rag.status.ready=準備完了
+rag.status.failed=インデックス作成に失敗しました
+rag.status.not.indexed=未インデックス
+
+# RAG Empty State
+rag.empty.title=ナレッジソースがありません
+rag.empty.description=このプロジェクトでRAGを有効にするには\nファイルまたはフォルダを追加してください
+rag.empty.button.add=ソースを追加
+rag.empty.coming.soon=（近日公開）
+
+# MCP Tab
+mcp.title=MCP（Model Context Protocol）
+mcp.description=Model Context Protocol を介して\n外部ツールやサービスに接続します
+mcp.coming.soon=（近日公開）

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -1026,3 +1026,38 @@ tutorial.step4.link.docs=📚 문서 보기
 tutorial.step4.link.providers=🔧 AI 제공자 구성
 tutorial.step4.link.github=⭐ GitHub에서 별표 주기
 
+# RAG Sources Tree
+rag.tree.expand=확장
+rag.tree.collapse=축소
+rag.tree.folder.open=파일 탐색기에서 열기
+rag.tree.folder.copy.path=경로 복사
+rag.tree.file.open=파일 열기
+rag.tree.file.open.folder=포함된 폴더 열기
+rag.tree.file.copy.path=경로 복사
+rag.tree.url.open=브라우저에서 열기
+rag.tree.url.copy=URL 복사
+
+# Project Side Panel
+panel.tab.rag.sources=RAG 소스
+panel.tab.mcp=MCP
+panel.collapse=패널 축소
+
+# RAG Status
+rag.status.icon=RAG 상태
+rag.status.started=인덱싱 시작됨
+rag.status.inprogress=인덱싱 중: {0}%
+rag.status.inprogress.unknown=인덱싱 중...
+rag.status.ready=준비 완료
+rag.status.failed=인덱싱 실패
+rag.status.not.indexed=인덱싱되지 않음
+
+# RAG Empty State
+rag.empty.title=지식 소스가 없습니다
+rag.empty.description=이 프로젝트에서 RAG를 활성화하려면\n파일 또는 폴더를 추가하세요
+rag.empty.button.add=소스 추가
+rag.empty.coming.soon=(곧 제공 예정)
+
+# MCP Tab
+mcp.title=MCP (Model Context Protocol)
+mcp.description=Model Context Protocol을 통해\n외부 도구 및 서비스에 연결
+mcp.coming.soon=(곧 제공 예정)

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -1025,3 +1025,39 @@ tutorial.step4.description=Explore estes recursos para aproveitar ao máximo o A
 tutorial.step4.link.docs=📚 Ver documentação
 tutorial.step4.link.providers=🔧 Configurar provedores de IA
 tutorial.step4.link.github=⭐ Dê uma estrela no GitHub
+
+# RAG Sources Tree
+rag.tree.expand=Expandir
+rag.tree.collapse=Recolher
+rag.tree.folder.open=Abrir no explorador de arquivos
+rag.tree.folder.copy.path=Copiar caminho
+rag.tree.file.open=Abrir arquivo
+rag.tree.file.open.folder=Abrir pasta contida
+rag.tree.file.copy.path=Copiar caminho
+rag.tree.url.open=Abrir no navegador
+rag.tree.url.copy=Copiar URL
+
+# Project Side Panel
+panel.tab.rag.sources=Fontes RAG
+panel.tab.mcp=MCP
+panel.collapse=Recolher painel
+
+# RAG Status
+rag.status.icon=Status do RAG
+rag.status.started=Indexação iniciada
+rag.status.inprogress=Indexando: {0}%
+rag.status.inprogress.unknown=Indexando...
+rag.status.ready=Pronto
+rag.status.failed=Falha na indexação
+rag.status.not.indexed=Não indexado
+
+# RAG Empty State
+rag.empty.title=Nenhuma fonte de conhecimento
+rag.empty.description=Adicione arquivos ou pastas para ativar o RAG\npara este projeto
+rag.empty.button.add=Adicionar fontes
+rag.empty.coming.soon=(Em breve)
+
+# MCP Tab
+mcp.title=MCP (Model Context Protocol)
+mcp.description=Conectar a ferramentas e serviços externos\npor meio do Model Context Protocol
+mcp.coming.soon=(Em breve)

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -1023,3 +1023,39 @@ tutorial.step4.description=Khám phá các tài nguyên dưới đây để tậ
 tutorial.step4.link.docs=📚 Xem tài liệu
 tutorial.step4.link.providers=🔧 Cấu hình nhà cung cấp AI
 tutorial.step4.link.github=⭐ Đánh dấu sao trên GitHub
+
+# RAG Sources Tree
+rag.tree.expand=Mở rộng
+rag.tree.collapse=Thu gọn
+rag.tree.folder.open=Mở trong trình quản lý tệp
+rag.tree.folder.copy.path=Sao chép đường dẫn
+rag.tree.file.open=Mở tệp
+rag.tree.file.open.folder=Mở thư mục chứa
+rag.tree.file.copy.path=Sao chép đường dẫn
+rag.tree.url.open=Mở trong trình duyệt
+rag.tree.url.copy=Sao chép URL
+
+# Project Side Panel
+panel.tab.rag.sources=Nguồn RAG
+panel.tab.mcp=MCP
+panel.collapse=Thu gọn bảng điều khiển
+
+# RAG Status
+rag.status.icon=Trạng thái RAG
+rag.status.started=Bắt đầu lập chỉ mục
+rag.status.inprogress=Đang lập chỉ mục: {0}%
+rag.status.inprogress.unknown=Đang lập chỉ mục...
+rag.status.ready=Sẵn sàng
+rag.status.failed=Lập chỉ mục thất bại
+rag.status.not.indexed=Chưa lập chỉ mục
+
+# RAG Empty State
+rag.empty.title=Không có nguồn tri thức
+rag.empty.description=Thêm tệp hoặc thư mục để bật RAG\ncho dự án này
+rag.empty.button.add=Thêm nguồn
+rag.empty.coming.soon=(Sắp ra mắt)
+
+# MCP Tab
+mcp.title=MCP (Model Context Protocol)
+mcp.description=Kết nối với công cụ và dịch vụ bên ngoài\nthông qua Model Context Protocol
+mcp.coming.soon=(Sắp ra mắt)

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -1026,3 +1026,38 @@ tutorial.step4.link.docs=📚 浏览文档
 tutorial.step4.link.providers=🔧 配置 AI 提供商
 tutorial.step4.link.github=⭐ 在 GitHub 上为我们加星
 
+# RAG Sources Tree
+rag.tree.expand=展开
+rag.tree.collapse=折叠
+rag.tree.folder.open=在文件浏览器中打开
+rag.tree.folder.copy.path=复制路径
+rag.tree.file.open=打开文件
+rag.tree.file.open.folder=打开所在文件夹
+rag.tree.file.copy.path=复制路径
+rag.tree.url.open=在浏览器中打开
+rag.tree.url.copy=复制 URL
+
+# Project Side Panel
+panel.tab.rag.sources=RAG 来源
+panel.tab.mcp=MCP
+panel.collapse=折叠面板
+
+# RAG Status
+rag.status.icon=RAG 状态
+rag.status.started=开始建立索引
+rag.status.inprogress=正在建立索引：{0}%
+rag.status.inprogress.unknown=正在建立索引...
+rag.status.ready=就绪
+rag.status.failed=索引失败
+rag.status.not.indexed=未建立索引
+
+# RAG Empty State
+rag.empty.title=暂无知识来源
+rag.empty.description=添加文件或文件夹以为此项目启用 RAG
+rag.empty.button.add=添加来源
+rag.empty.coming.soon=（即将推出）
+
+# MCP Tab
+mcp.title=MCP（Model Context Protocol）
+mcp.description=通过 Model Context Protocol 连接外部工具和服务
+mcp.coming.soon=（即将推出）

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -1026,3 +1026,39 @@ tutorial.step4.description=探索以下資源，充分發揮 Askimo 的功能
 tutorial.step4.link.docs=📚 瀏覽文件
 tutorial.step4.link.providers=🔧 設定 AI 供應商
 tutorial.step4.link.github=⭐ 在 GitHub 上為我們加星
+
+# RAG Sources Tree
+rag.tree.expand=展開
+rag.tree.collapse=收合
+rag.tree.folder.open=在檔案總管中開啟
+rag.tree.folder.copy.path=複製路徑
+rag.tree.file.open=開啟檔案
+rag.tree.file.open.folder=開啟所在資料夾
+rag.tree.file.copy.path=複製路徑
+rag.tree.url.open=在瀏覽器中開啟
+rag.tree.url.copy=複製 URL
+
+# Project Side Panel
+panel.tab.rag.sources=RAG 來源
+panel.tab.mcp=MCP
+panel.collapse=收合面板
+
+# RAG Status
+rag.status.icon=RAG 狀態
+rag.status.started=開始建立索引
+rag.status.inprogress=建立索引中：{0}%
+rag.status.inprogress.unknown=建立索引中...
+rag.status.ready=就緒
+rag.status.failed=索引失敗
+rag.status.not.indexed=尚未建立索引
+
+# RAG Empty State
+rag.empty.title=尚無知識來源
+rag.empty.description=新增檔案或資料夾以啟用此專案的 RAG
+rag.empty.button.add=新增來源
+rag.empty.coming.soon=（即將推出）
+
+# MCP Tab
+mcp.title=MCP（Model Context Protocol）
+mcp.description=透過 Model Context Protocol 連接外部工具與服務
+mcp.coming.soon=（即將推出）


### PR DESCRIPTION
- Add RagSourcesTree component to display project knowledge sources
- Expose side panel state in ChatView and integrate new components
- Add MCP Tab with Model Context Protocol content
- Extend ComponentColors with new tint and text colours for UI
- Update i18n bundles for RAG and MCP across all locales
- Adjust native‑image resource and reflect configs for new classes