### PR TITLE
feat(desktop): add image saving and project reindex actions

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/MessageComponents.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/MessageComponents.kt
@@ -422,7 +422,7 @@ fun messageBubble(
                                     if (isClickable) {
                                         Modifier
                                             .clickable {
-                                                onMessageClick?.invoke(message.id!!, message.timestamp!!)
+                                                onMessageClick.invoke(message.id!!, message.timestamp!!)
                                             }
                                             .pointerHoverIcon(PointerIcon.Hand)
                                     } else {

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/preferences/ApplicationPreferences.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/preferences/ApplicationPreferences.kt
@@ -174,13 +174,4 @@ object ApplicationPreferences {
     fun resetVersion() {
         prefs.remove(LAST_LAUNCHED_VERSION_KEY)
     }
-
-    /**
-     * Reset all preferences (for testing).
-     */
-    fun resetAll() {
-        resetTutorial()
-        resetStarPrompt()
-        resetVersion()
-    }
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
@@ -452,7 +452,6 @@ fun projectView(
             }
         }
 
-        // Fixed bottom: Chat Input
         chatInputField(
             inputText = inputText,
             onInputTextChange = { inputText = it },

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsViewModel.kt
@@ -12,6 +12,7 @@ import io.askimo.core.chat.domain.Project
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.db.Pageable
 import io.askimo.core.event.EventBus
+import io.askimo.core.event.internal.ProjectDeletedEvent
 import io.askimo.core.event.internal.ProjectsRefreshEvent
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.logging.logger
@@ -168,6 +169,11 @@ class ProjectsViewModel(
                 }
                 if (deleted) {
                     deleteProjectSuccessfulBannerMessage = LocalizationManager.getString("projects.delete.success")
+                    EventBus.post(
+                        ProjectDeletedEvent(
+                            projectId = projectId,
+                        ),
+                    )
                     refresh()
                 } else {
                     errorMessage = LocalizationManager.getString("projects.error.not.found")

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/StarPromptDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/StarPromptDialog.kt
@@ -14,20 +14,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import io.askimo.desktop.common.components.primaryButton
+import io.askimo.desktop.common.components.secondaryButton
 import io.askimo.desktop.common.i18n.stringResource
 
 /**
@@ -42,9 +39,9 @@ fun starPromptDialog(
     onDismiss: () -> Unit,
     onStar: () -> Unit,
 ) {
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = {}) {
         Surface(
-            modifier = Modifier.width(450.dp),
+            modifier = Modifier.width(600.dp),
             shape = MaterialTheme.shapes.large,
             tonalElevation = 8.dp,
         ) {
@@ -59,7 +56,7 @@ fun starPromptDialog(
                     Icon(
                         imageVector = Icons.Default.Star,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(32.dp),
                     )
                     Column(
@@ -84,21 +81,16 @@ fun starPromptDialog(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    TextButton(
+                    secondaryButton(
                         onClick = onDismiss,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(stringResource("star.prompt.maybe.later"))
                     }
 
                     Spacer(modifier = Modifier.width(8.dp))
 
-                    Button(
+                    primaryButton(
                         onClick = onStar,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                        ),
                     ) {
                         Icon(
                             imageVector = Icons.Default.Star,

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -335,10 +335,10 @@ action.retry=Try Again
 action.done=Done
 
 # Star Prompt
-star.prompt.title=Enjoying Askimo?
-star.prompt.message=You've had some great conversations! Help others discover Askimo by starring us on GitHub. It takes just a second and means a lot to us! ⭐
-star.prompt.star.button=⭐ Star on GitHub
-star.prompt.maybe.later=Maybe Later
+star.prompt.title=If Askimo has been helpful…
+star.prompt.message=Askimo is an open-source project built and maintained with community support.\n\nIf it has improved your workflow, consider supporting the project with a star on GitHub ⭐.\n\nYour support helps others discover it and encourages continued development.
+star.prompt.star.button=Join others supporting Askimo
+star.prompt.maybe.later=Not now
 
 # File operations
 file.overwrite.title=File Already Exists
@@ -1047,6 +1047,8 @@ rag.tree.url.copy=Copy URL
 # Project Side Panel
 panel.tab.rag.sources=RAG Sources
 panel.tab.mcp=MCP
+panel.context.menu=Context menu
+panel.context.reindex=Reindex project
 panel.collapse=Collapse panel
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -334,10 +334,10 @@ action.retry=Erneut versuchen
 action.done=Fertig
 
 # Star Prompt
-star.prompt.title=Gefällt dir Askimo?
-star.prompt.message=Du hattest schon einige tolle Gespräche! Hilf anderen, Askimo zu entdecken, indem du uns auf GitHub einen Stern gibst. Es dauert nur eine Sekunde und bedeutet uns viel! ⭐
-star.prompt.star.button=⭐ Auf GitHub mit einem Stern markieren
-star.prompt.maybe.later=Vielleicht später
+star.prompt.title=Wenn Askimo hilfreich für Sie war …
+star.prompt.message=Askimo ist ein Open-Source-Projekt, das mit Unterstützung der Community entwickelt und gepflegt wird.\n\nWenn es Ihren Arbeitsablauf verbessert hat, unterstützen Sie das Projekt gerne mit einem Stern auf GitHub ⭐.\n\nIhre Unterstützung hilft anderen, Askimo zu entdecken, und fördert die Weiterentwicklung.
+star.prompt.star.button=Gemeinsam Askimo unterstützen
+star.prompt.maybe.later=Jetzt nicht
 
 # File operations
 file.overwrite.title=Datei existiert bereits
@@ -434,6 +434,9 @@ chat.directive.new=Neue Direktive
 chat.directive.manage=Direktiven verwalten
 chat.attach.file=Datei anhängen ({0}+A)
 chat.attach.file.menu=Anhänge hinzufügen
+chat.create.image.menu=Bild erstellen
+chat.create.image.mode=Bild
+chat.create.image.mode.cancel=Bild-Erstellungsmodus beenden
 chat.input.placeholder=Nachricht eingeben... (Enter zum Senden, Shift+Enter für neue Zeile)
 chat.select.file=Datei(en) auswählen
 chat.attachment.remove=Anhang entfernen
@@ -760,6 +763,12 @@ settings.rag.embedding.not.supported={0} unterstützt keine Embedding-Modelle f�
 settings.vision.models.title=Vision-Modelle
 settings.vision.models.description=Vision-Modelle ermöglichen es der KI, Bilder, Screenshots, Diagramme und andere visuelle Inhalte zu analysieren und zu verstehen. Überschreiben Sie das Standard-Vision-Modell pro Anbieter, um unterschiedliche Fähigkeiten in der Bildverarbeitung, OCR und visuellen Schlussfolgerung zu nutzen.
 settings.vision.models.not.supported={0} unterstützt keine Vision-Modelle
+
+## Settings - Image Models
+settings.image.models.title=Bildgenerierungsmodelle
+settings.image.models.description=Bildgenerierungsmodelle erstellen visuelle Inhalte aus Textbeschreibungen. Konfigurieren Sie für jeden KI-Anbieter, welches Modell zur Erstellung von Diagrammen, Illustrationen und anderen visuellen Ausgaben verwendet werden soll.
+settings.image.models.not.supported={0} unterstützt keine Bildgenerierungsmodelle
+
 settings.model.placeholder.enter={0}-Modell eingeben
 settings.model.placeholder.not.supported=Nicht unterstützt
 
@@ -1046,6 +1055,8 @@ rag.tree.url.copy=URL kopieren
 # Project Side Panel
 panel.tab.rag.sources=RAG-Quellen
 panel.tab.mcp=MCP
+panel.context.menu=Kontextmenü
+panel.context.reindex=Projekt neu indizieren
 panel.collapse=Panel reduzieren
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -334,10 +334,10 @@ action.retry=Reintentar
 action.done=Listo
 
 # Star Prompt
-star.prompt.title=¿Disfrutando Askimo?
-star.prompt.message=¡Has tenido excelentes conversaciones! Ayuda a otros a descubrir Askimo dándonos una estrella en GitHub. ¡Solo toma un segundo y significa mucho para nosotros! ⭐
-star.prompt.star.button=⭐ Dar una estrella en GitHub
-star.prompt.maybe.later=Quizá más tarde
+star.prompt.title=Si Askimo te ha sido útil…
+star.prompt.message=Askimo es un proyecto de código abierto desarrollado y mantenido con el apoyo de la comunidad.\n\nSi ha mejorado tu flujo de trabajo, considera apoyar el proyecto con una estrella en GitHub ⭐.\n\nTu apoyo ayuda a que más personas descubran Askimo y fomenta su desarrollo continuo.
+star.prompt.star.button=Únete a quienes apoyan Askimo
+star.prompt.maybe.later=Ahora no
 
 # File operations
 file.overwrite.title=El archivo ya existe
@@ -433,6 +433,9 @@ chat.directive.new=Nueva directiva
 chat.directive.manage=Gestionar directivas
 chat.attach.file=Adjuntar archivo ({0}+A)
 chat.attach.file.menu=Agregar archivos adjuntos
+chat.create.image.menu=Crear imagen
+chat.create.image.mode=Imagen
+chat.create.image.mode.cancel=Cancelar modo de creación de imagen
 chat.input.placeholder=Escribe tu mensaje... (Enter para enviar, Shift+Enter para nueva línea)
 chat.select.file=Seleccionar archivo(s)
 chat.attachment.remove=Eliminar archivo adjunto
@@ -757,6 +760,12 @@ settings.rag.embedding.not.supported={0} no admite modelos de embedding para RAG
 settings.vision.models.title=Modelos de visión
 settings.vision.models.description=Los modelos de visión permiten a la IA analizar y comprender imágenes, capturas de pantalla, diagramas y otros contenidos visuales. Reemplaza el modelo de visión predeterminado por proveedor para utilizar distintas capacidades en comprensión de imágenes, OCR y razonamiento visual.
 settings.vision.models.not.supported={0} no admite modelos de visión
+
+## Settings - Image Models
+settings.image.models.title=Modelos de generación de imágenes
+settings.image.models.description=Los modelos de generación de imágenes crean contenido visual a partir de descripciones de texto. Configure qué modelo de generación de imágenes utilizar para cada proveedor de IA al crear diagramas, ilustraciones y otros contenidos visuales.
+settings.image.models.not.supported={0} no admite modelos de generación de imágenes
+
 settings.model.placeholder.enter=Introducir modelo {0}
 settings.model.placeholder.not.supported=No compatible
 
@@ -1044,6 +1053,8 @@ rag.tree.url.copy=Copiar URL
 # Project Side Panel
 panel.tab.rag.sources=Fuentes RAG
 panel.tab.mcp=MCP
+panel.context.menu=Menú contextual
+panel.context.reindex=Reindexar proyecto
 panel.collapse=Contraer panel
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -334,10 +334,10 @@ action.retry=Réessayer
 action.done=Terminé
 
 # Star Prompt
-star.prompt.title=Vous aimez Askimo ?
-star.prompt.message=Vous avez eu de super conversations ! Aidez d’autres personnes à découvrir Askimo en nous mettant une étoile sur GitHub. Cela ne prend qu’une seconde et compte beaucoup pour nous ! ⭐
-star.prompt.star.button=⭐ Mettre une étoile sur GitHub
-star.prompt.maybe.later=Peut-être plus tard
+star.prompt.title=Si Askimo vous a été utile…
+star.prompt.message=Askimo est un projet open source développé et maintenu grâce au soutien de la communauté.\n\nS’il a amélioré votre flux de travail, pensez à soutenir le projet en lui attribuant une étoile sur GitHub ⭐.\n\nVotre soutien aide d’autres personnes à découvrir Askimo et encourage son développement continu.
+star.prompt.star.button=Rejoignez ceux qui soutiennent Askimo
+star.prompt.maybe.later=Pas maintenant
 
 # File operations
 file.overwrite.title=Le fichier existe déjà
@@ -433,6 +433,9 @@ chat.directive.new=Nouvelle directive
 chat.directive.manage=Gérer les directives
 chat.attach.file=Joindre un fichier ({0}+A)
 chat.attach.file.menu=Ajouter des pièces jointes
+chat.create.image.menu=Créer une image
+chat.create.image.mode=Image
+chat.create.image.mode.cancel=Annuler le mode de création d’image
 chat.input.placeholder=Tapez votre message... (Entrée pour envoyer, Shift+Entrée pour une nouvelle ligne)
 chat.select.file=Sélectionner un ou plusieurs fichiers
 chat.attachment.remove=Supprimer la pièce jointe
@@ -758,6 +761,12 @@ settings.rag.embedding.not.supported={0} ne prend pas en charge les modèles d�
 settings.vision.models.title=Modèles de vision
 settings.vision.models.description=Les modèles de vision permettent à l’IA d’analyser et de comprendre des images, des captures d’écran, des diagrammes et d’autres contenus visuels. Remplacez le modèle de vision par défaut pour chaque fournisseur afin d’utiliser différentes capacités de compréhension d’images, d’OCR et de raisonnement visuel.
 settings.vision.models.not.supported={0} ne prend pas en charge les modèles de vision
+
+## Settings - Image Models
+settings.image.models.title=Modèles de génération d’images
+settings.image.models.description=Les modèles de génération d’images créent du contenu visuel à partir de descriptions textuelles. Configurez le modèle à utiliser pour chaque fournisseur d’IA afin de créer des diagrammes, illustrations et autres contenus visuels.
+settings.image.models.not.supported={0} ne prend pas en charge les modèles de génération d’images
+
 settings.model.placeholder.enter=Saisir le modèle {0}
 settings.model.placeholder.not.supported=Non pris en charge
 
@@ -1044,6 +1053,8 @@ rag.tree.url.copy=Copier l’URL
 # Project Side Panel
 panel.tab.rag.sources=Sources RAG
 panel.tab.mcp=MCP
+panel.context.menu=Menu contextuel
+panel.context.reindex=Réindexer le projet
 panel.collapse=Réduire le panneau
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -334,10 +334,10 @@ action.retry=再試行
 action.done=完了
 
 # Star Prompt
-star.prompt.title=Askimo を気に入っていただけましたか？
-star.prompt.message=素晴らしい会話ができていますね！GitHub でスターを付けて、Askimo を他の人にも広めるお手伝いをしてください。ほんの一瞬でできて、とても励みになります！ ⭐
-star.prompt.star.button=⭐ GitHubでスターを付ける
-star.prompt.maybe.later=後で
+star.prompt.title=Askimoがお役に立てたなら…
+star.prompt.message=Askimoはコミュニティの支援によって開発・維持されているオープンソースプロジェクトです。\n\nワークフローの改善に役立った場合は、GitHubで⭐を付けてプロジェクトを応援していただけると幸いです。\n\n皆さまのサポートは、より多くの方にAskimoを知ってもらい、継続的な開発を後押しします。
+star.prompt.star.button=Askimoを応援する
+star.prompt.maybe.later=今はしない
 
 # File operations
 file.overwrite.title=ファイルは既に存在します
@@ -433,6 +433,9 @@ chat.directive.new=新しいディレクティブ
 chat.directive.manage=ディレクティブ管理
 chat.attach.file=ファイル添付 ({0}+A)
 chat.attach.file.menu=添付ファイルを追加
+chat.create.image.menu=画像を作成
+chat.create.image.mode=画像
+chat.create.image.mode.cancel=画像作成モードをキャンセル
 chat.input.placeholder=メッセージを入力...（Enter 送信、Shift+Enter 改行）
 chat.select.file=ファイルを選択（複数可）
 chat.attachment.remove=添付ファイルを削除
@@ -759,6 +762,12 @@ settings.rag.embedding.not.supported={0} は RAG 用の埋め込みモデルを�
 settings.vision.models.title=ビジョンモデル
 settings.vision.models.description=ビジョンモデルは、画像、スクリーンショット、図、その他の視覚コンテンツを AI が分析・理解することを可能にします。プロバイダーごとにデフォルトのビジョンモデルを上書きし、画像理解、OCR、視覚的推論における異なる機能を利用できます。
 settings.vision.models.not.supported={0} はビジョンモデルをサポートしていません
+
+## Settings - Image Models
+settings.image.models.title=画像生成モデル
+settings.image.models.description=画像生成モデルはテキストの説明から視覚的なコンテンツを作成します。図、イラスト、その他のビジュアル出力を作成するために、各AIプロバイダーで使用する画像生成モデルを設定してください。
+settings.image.models.not.supported={0} は画像生成モデルをサポートしていません
+
 settings.model.placeholder.enter={0} モデルを入力
 settings.model.placeholder.not.supported=未対応
 
@@ -1044,6 +1053,8 @@ rag.tree.url.copy=URLをコピー
 # Project Side Panel
 panel.tab.rag.sources=RAGソース
 panel.tab.mcp=MCP
+panel.context.menu=コンテキストメニュー
+panel.context.reindex=プロジェクトを再インデックス
 panel.collapse=パネルを折りたたむ
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -335,10 +335,10 @@ action.retry=다시 시도
 action.done=완료
 
 # Star Prompt
-star.prompt.title=Askimo가 마음에 드시나요?
-star.prompt.message=멋진 대화를 많이 나누셨네요! GitHub에서 별표를 눌러 Askimo를 다른 사람들에게도 알려주세요. 단 몇 초면 되고, 저희에게 큰 힘이 됩니다! ⭐
-star.prompt.star.button=⭐ GitHub에서 별 주기
-star.prompt.maybe.later=나중에
+star.prompt.title=Askimo가 도움이 되셨다면…
+star.prompt.message=Askimo는 커뮤니티의 지원으로 개발되고 유지되는 오픈소스 프로젝트입니다.\n\n업무 흐름 개선에 도움이 되었다면 GitHub에서 ⭐를 눌러 프로젝트를 지원해 주세요.\n\n여러분의 지원은 더 많은 사람들이 Askimo를 발견하고 지속적인 개발을 이어가는 데 큰 힘이 됩니다.
+star.prompt.star.button=Askimo 지원하기
+star.prompt.maybe.later=지금은 아니요
 
 # File operations
 file.overwrite.title=파일이 이미 존재합니다
@@ -434,6 +434,9 @@ chat.directive.new=새 지시문
 chat.directive.manage=지시문 관리
 chat.attach.file=파일 첨부 ({0}+A)
 chat.attach.file.menu=첨부 파일 추가
+chat.create.image.menu=이미지 생성
+chat.create.image.mode=이미지
+chat.create.image.mode.cancel=이미지 생성 모드 취소
 chat.input.placeholder=메시지 입력... (Enter 전송, Shift+Enter 줄바꿈)
 chat.select.file=파일 선택 (여러 개 선택 가능)
 chat.attachment.remove=첨부 파일 삭제
@@ -760,6 +763,12 @@ settings.rag.embedding.not.supported={0}은(는) RAG용 임베딩 모델을 지�
 settings.vision.models.title=비전 모델
 settings.vision.models.description=비전 모델을 통해 AI는 이미지, 스크린샷, 다이어그램 및 기타 시각적 콘텐츠를 분석하고 이해할 수 있습니다. 공급자별로 기본 비전 모델을 재정의하여 이미지 이해, OCR 및 시각적 추론에서 다양한 기능을 사용할 수 있습니다.
 settings.vision.models.not.supported={0}은(는) 비전 모델을 지원하지 않습니다
+
+## Settings - Image Models
+settings.image.models.title=이미지 생성 모델
+settings.image.models.description=이미지 생성 모델은 텍스트 설명을 기반으로 시각적 콘텐츠를 생성합니다. 다이어그램, 일러스트 및 기타 시각적 결과물을 만들기 위해 각 AI 제공자에서 사용할 이미지 생성 모델을 구성하세요.
+settings.image.models.not.supported={0} 은(는) 이미지 생성 모델을 지원하지 않습니다
+
 settings.model.placeholder.enter={0} 모델 입력
 settings.model.placeholder.not.supported=지원되지 않음
 
@@ -1045,6 +1054,8 @@ rag.tree.url.copy=URL 복사
 # Project Side Panel
 panel.tab.rag.sources=RAG 소스
 panel.tab.mcp=MCP
+panel.context.menu=컨텍스트 메뉴
+panel.context.reindex=프로젝트 재인덱싱
 panel.collapse=패널 축소
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -334,10 +334,10 @@ action.retry=Tentar novamente
 action.done=Concluído
 
 # Star Prompt
-star.prompt.title=Gostando do Askimo?
-star.prompt.message=Você teve ótimas conversas! Ajude outras pessoas a descobrir o Askimo dando uma estrela no GitHub. Leva apenas um segundo e significa muito para nós! ⭐
-star.prompt.star.button=⭐ Dar uma estrela no GitHub
-star.prompt.maybe.later=Talvez depois
+star.prompt.title=Se o Askimo foi útil para você…
+star.prompt.message=Askimo é um projeto open-source desenvolvido e mantido com o apoio da comunidade.\n\nSe ele melhorou seu fluxo de trabalho, considere apoiar o projeto com uma estrela no GitHub ⭐.\n\nSeu apoio ajuda mais pessoas a descobrirem o Askimo e incentiva o desenvolvimento contínuo.
+star.prompt.star.button=Junte-se a quem apoia o Askimo
+star.prompt.maybe.later=Agora não
 
 # File operations
 file.overwrite.title=O arquivo já existe
@@ -434,6 +434,9 @@ chat.directive.new=Nova Diretiva
 chat.directive.manage=Gerenciar Diretivas
 chat.attach.file=Anexar Arquivo ({0}+A)
 chat.attach.file.menu=Adicionar Anexos
+chat.create.image.menu=Criar imagem
+chat.create.image.mode=Imagem
+chat.create.image.mode.cancel=Cancelar modo de criação de imagem
 chat.input.placeholder=Digite sua mensagem... (Enter para enviar, Shift+Enter para nova linha)
 chat.select.file=Selecionar Arquivo(s)
 chat.attachment.remove=Remover anexo
@@ -760,6 +763,12 @@ settings.rag.embedding.not.supported={0} não oferece suporte a modelos de embed
 settings.vision.models.title=Modelos de visão
 settings.vision.models.description=Os modelos de visão permitem que a IA analise e compreenda imagens, capturas de tela, diagramas e outros conteúdos visuais. Substitua o modelo de visão padrão por provedor para usar diferentes capacidades de compreensão de imagens, OCR e raciocínio visual.
 settings.vision.models.not.supported={0} não oferece suporte a modelos de visão
+
+## Settings - Image Models
+settings.image.models.title=Modelos de geração de imagens
+settings.image.models.description=Os modelos de geração de imagens criam conteúdo visual a partir de descrições em texto. Configure qual modelo de geração de imagens usar para cada provedor de IA ao criar diagramas, ilustrações e outros conteúdos visuais.
+settings.image.models.not.supported={0} não oferece suporte a modelos de geração de imagens
+
 settings.model.placeholder.enter=Inserir modelo {0}
 settings.model.placeholder.not.supported=Não suportado
 
@@ -1045,6 +1054,8 @@ rag.tree.url.copy=Copiar URL
 # Project Side Panel
 panel.tab.rag.sources=Fontes RAG
 panel.tab.mcp=MCP
+panel.context.menu=Menu de contexto
+panel.context.reindex=Reindexar projeto
 panel.collapse=Recolher painel
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -331,9 +331,9 @@ action.retry=Thử lại
 action.done=Hoàn thành
 
 # Star Prompt
-star.prompt.title=Bạn thích Askimo chứ?
-star.prompt.message=Bạn đã có những cuộc trò chuyện thật tuyệt! Hãy giúp nhiều người biết đến Askimo bằng cách gắn sao cho chúng tôi trên GitHub. Chỉ mất vài giây nhưng rất ý nghĩa đối với chúng tôi! ⭐
-star.prompt.star.button=⭐ Gắn sao trên GitHub
+star.prompt.title=Nếu Askimo hữu ích với bạn…
+star.prompt.message=Askimo là một dự án mã nguồn mở được xây dựng và duy trì với sự hỗ trợ từ cộng đồng.\n\nNếu nó đã cải thiện quy trình làm việc của bạn, hãy cân nhắc ủng hộ dự án bằng cách tặng một ngôi sao trên GitHub ⭐.\n\nSự ủng hộ của bạn giúp nhiều người khác biết đến Askimo và thúc đẩy sự phát triển lâu dài của dự án.
+star.prompt.star.button=Tham gia ủng hộ Askimo
 star.prompt.maybe.later=Để sau
 
 # File operations
@@ -430,6 +430,9 @@ chat.directive.new=Chỉ thị mới
 chat.directive.manage=Quản lý chỉ thị
 chat.attach.file=Đính kèm tệp ({0}+A)
 chat.attach.file.menu=Thêm tệp đính kèm
+chat.create.image.menu=Tạo hình ảnh
+chat.create.image.mode=Hình ảnh
+chat.create.image.mode.cancel=Hủy chế độ tạo hình ảnh
 chat.input.placeholder=Nhập tin nhắn... (Enter để gửi, Shift+Enter để xuống dòng)
 chat.select.file=Chọn tệp (nhiều tệp)
 chat.attachment.remove=Xóa tệp đính kèm
@@ -757,6 +760,12 @@ settings.rag.embedding.not.supported={0} không hỗ trợ mô hình embedding c
 settings.vision.models.title=Mô hình thị giác
 settings.vision.models.description=Các mô hình thị giác cho phép AI phân tích và hiểu hình ảnh, ảnh chụp màn hình, sơ đồ và các nội dung trực quan khác. Ghi đè mô hình thị giác mặc định cho từng nhà cung cấp để sử dụng các khả năng khác nhau trong hiểu hình ảnh, OCR và suy luận thị giác.
 settings.vision.models.not.supported={0} không hỗ trợ mô hình thị giác
+
+## Settings - Image Models
+settings.image.models.title=Mô hình tạo hình ảnh
+settings.image.models.description=Các mô hình tạo hình ảnh tạo nội dung trực quan từ mô tả văn bản. Hãy cấu hình mô hình tạo hình ảnh cho từng nhà cung cấp AI khi tạo sơ đồ, minh họa và các đầu ra trực quan khác.
+settings.image.models.not.supported={0} không hỗ trợ mô hình tạo hình ảnh
+
 settings.model.placeholder.enter=Nhập mô hình {0}
 settings.model.placeholder.not.supported=Không hỗ trợ
 
@@ -1043,6 +1052,8 @@ rag.tree.url.copy=Sao chép URL
 # Project Side Panel
 panel.tab.rag.sources=Nguồn RAG
 panel.tab.mcp=MCP
+panel.context.menu=Menu ngữ cảnh
+panel.context.reindex=Lập chỉ mục lại dự án
 panel.collapse=Thu gọn bảng điều khiển
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -334,10 +334,10 @@ action.retry=重试
 action.done=完成
 
 # Star Prompt
-star.prompt.title=喜欢 Askimo 吗？
-star.prompt.message=你已经进行了一些很棒的对话！在 GitHub 上为我们加颗星，帮助更多人发现 Askimo。这只需要一秒，但对我们意义重大！ ⭐
-star.prompt.star.button=⭐ 在 GitHub 上加星
-star.prompt.maybe.later=稍后再说
+star.prompt.title=如果 Askimo 对您有所帮助…
+star.prompt.message=Askimo 是一个由社区支持开发和维护的开源项目。\n\n如果它提升了您的工作效率，欢迎在 GitHub 上为项目点亮 ⭐ 以示支持。\n\n您的支持有助于让更多人了解 Askimo，并推动项目持续发展。
+star.prompt.star.button=加入支持 Askimo 的行列
+star.prompt.maybe.later=暂不
 
 # File operations
 file.overwrite.title=文件已存在
@@ -434,6 +434,9 @@ chat.directive.new=新指令
 chat.directive.manage=管理指令
 chat.attach.file=附加文件 ({0}+A)
 chat.attach.file.menu=添加附件
+chat.create.image.menu=创建图像
+chat.create.image.mode=图像
+chat.create.image.mode.cancel=取消图像创建模式
 chat.input.placeholder=输入消息...（Enter 发送，Shift+Enter 换行）
 chat.select.file=选择文件（可多选）
 chat.attachment.remove=移除附件
@@ -759,6 +762,12 @@ settings.rag.embedding.not.supported={0} 不支持用于 RAG 的嵌入模型
 settings.vision.models.title=视觉模型
 settings.vision.models.description=视觉模型使 AI 能够分析和理解图像、截图、图表以及其他视觉内容。可为每个提供商覆盖默认视觉模型，以使用不同的图像理解、OCR 和视觉推理能力。
 settings.vision.models.not.supported={0} 不支持视觉模型
+
+## Settings - Image Models
+settings.image.models.title=图像生成模型
+settings.image.models.description=图像生成模型可根据文本描述创建视觉内容。请为每个 AI 提供商配置用于生成图表、插图及其他视觉输出的图像生成模型。
+settings.image.models.not.supported={0} 不支持图像生成模型
+
 settings.model.placeholder.enter=输入 {0} 模型
 settings.model.placeholder.not.supported=不支持
 
@@ -1045,6 +1054,8 @@ rag.tree.url.copy=复制 URL
 # Project Side Panel
 panel.tab.rag.sources=RAG 来源
 panel.tab.mcp=MCP
+panel.context.menu=上下文菜单
+panel.context.reindex=重新索引项目
 panel.collapse=折叠面板
 
 # RAG Status

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -334,10 +334,10 @@ action.retry=重試
 action.done=完成
 
 # Star Prompt
-star.prompt.title=喜歡 Askimo 嗎？
-star.prompt.message=你已經有了一些很棒的對話！歡迎到 GitHub 替我們加個星，讓更多人發現 Askimo。只要一秒鐘，但對我們非常重要！ ⭐
-star.prompt.star.button=⭐ 在 GitHub 上加星標
-star.prompt.maybe.later=稍後再說
+star.prompt.title=如果 Askimo 對您有所幫助…
+star.prompt.message=Askimo 是一個由社群支持開發與維護的開源專案。\n\n如果它提升了您的工作流程，歡迎在 GitHub 上為專案點亮 ⭐ 以示支持。\n\n您的支持能幫助更多人認識 Askimo，並促進專案持續發展。
+star.prompt.star.button=加入支持 Askimo
+star.prompt.maybe.later=暫時不要
 
 # File operations
 file.overwrite.title=檔案已存在
@@ -433,6 +433,9 @@ chat.directive.new=新增指令
 chat.directive.manage=管理指令
 chat.attach.file=附加檔案 ({0}+A)
 chat.attach.file.menu=新增附件
+chat.create.image.menu=建立影像
+chat.create.image.mode=影像
+chat.create.image.mode.cancel=取消影像建立模式
 chat.input.placeholder=輸入訊息...（Enter 送出，Shift+Enter 換行）
 chat.select.file=選擇檔案（可多選）
 chat.attachment.remove=移除附件
@@ -760,6 +763,12 @@ settings.rag.embedding.not.supported={0} 不支援用於 RAG 的嵌入模型
 settings.vision.models.title=視覺模型
 settings.vision.models.description=視覺模型讓 AI 能夠分析並理解影像、螢幕截圖、圖表及其他視覺內容。您可以為每個提供者覆寫預設的視覺模型，以使用不同的影像理解、OCR 與視覺推論能力。
 settings.vision.models.not.supported={0} 不支援視覺模型
+
+## Settings - Image Models
+settings.image.models.title=影像生成模型
+settings.image.models.description=影像生成模型可根據文字描述建立視覺內容。請為每個 AI 供應商設定用於產生圖表、插圖及其他視覺輸出的影像生成模型。
+settings.image.models.not.supported={0} 不支援影像生成模型
+
 settings.model.placeholder.enter=輸入 {0} 模型
 settings.model.placeholder.not.supported=不支援
 
@@ -1046,6 +1055,8 @@ rag.tree.url.copy=複製 URL
 # Project Side Panel
 panel.tab.rag.sources=RAG 來源
 panel.tab.mcp=MCP
+panel.context.menu=內容選單
+panel.context.reindex=重新建立專案索引
 panel.collapse=收合面板
 
 # RAG Status

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -285,11 +285,11 @@ data class AnthropicModelConfig(
 )
 
 data class GeminiModelConfig(
-    val utilityModel: String = "gemini-2.0-flash",
+    val utilityModel: String = "gemini-2.5-flash-lite",
     val utilityModelTimeoutSeconds: Long = 45,
-    val embeddingModel: String = "text-embedding-004",
+    val embeddingModel: String = "gemini-embedding-001",
     val visionModel: String = "gemini-2.0-pro",
-    val imageModel: String = "grok-imagine-image",
+    val imageModel: String = "gemini-2.5-flash-image",
 )
 
 data class OpenAiModelConfig(

--- a/shared/src/main/kotlin/io/askimo/core/mcp/connectors/StdioMcpConnector.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/connectors/StdioMcpConnector.kt
@@ -28,7 +28,7 @@ class StdioMcpConnector(
 
         val builder = StdioMcpTransport.builder()
             .logger(log)
-            .logEvents(true)
+            .logEvents(log.isTraceEnabled)
             .command(command)
 
         // Add environment variables if any

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -60,7 +60,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
                 .modelName(model)
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
+                .logResponses(log.isTraceEnabled)
                 .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.ANTHROPIC.name.lowercase())))
                 .baseUrl(settings.baseUrl)
                 .build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -94,7 +94,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
                 .modelName(model)
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
+                .logResponses(log.isTraceEnabled)
                 .timeout(Duration.ofMinutes(5))
                 .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.DOCKER.name.lowercase())))
                 .build()
@@ -120,7 +120,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
         .modelName(AppConfig.models.docker.imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
-        .logResponses(log.isDebugEnabled)
+        .logResponses(log.isTraceEnabled)
         .build()
 
     private fun createSecondaryChatModel(settings: DockerAiSettings): ChatModel {

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -74,7 +74,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
                 .modelName(model)
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
+                .logResponses(log.isTraceEnabled)
                 .listeners(listOf(TelemetryChatModelListener(telemetry, GEMINI.name.lowercase())))
                 .build()
 
@@ -95,10 +95,11 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
         settings: GeminiSettings,
     ): ImageModel = GoogleAiGeminiImageModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
-        .modelName(AppConfig.models.openai.imageModel)
+        .baseUrl(settings.baseUrl)
+        .modelName(AppConfig.models.gemini.imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
-        .logResponses(log.isDebugEnabled)
+        .logResponses(log.isTraceEnabled)
         .build()
 
     private fun createSecondaryChatModel(settings: GeminiSettings): ChatModel {

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
@@ -75,7 +75,7 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
                 .modelName(model)
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
+                .logResponses(log.isTraceEnabled)
                 .timeout(Duration.ofMinutes(5))
                 .httpClientBuilder(jdkHttpClientBuilder)
                 .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.LMSTUDIO.name.lowercase())))
@@ -105,7 +105,7 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
             .modelName(AppConfig.models.lmstudio.imageModel)
             .logger(log)
             .logRequests(log.isDebugEnabled)
-            .logResponses(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
             .httpClientBuilder(jdkHttpClientBuilder)
             .build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
@@ -72,7 +72,7 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
                 .timeout(Duration.ofMinutes(5))
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
+                .logResponses(log.isTraceEnabled)
                 .listeners(listOf(TelemetryChatModelListener(telemetry, LOCALAI.name.lowercase()))).build()
 
         return AiServiceBuilder.buildChatClient(
@@ -96,7 +96,7 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
         .modelName(AppConfig.models.localai.imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
-        .logResponses(log.isDebugEnabled)
+        .logResponses(log.isTraceEnabled)
         .build()
 
     private fun createSecondaryChatModel(settings: LocalAiSettings): ChatModel {

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -102,7 +102,7 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
         .modelName(AppConfig.models.ollama.imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
-        .logResponses(log.isDebugEnabled)
+        .logResponses(log.isTraceEnabled)
         .build()
 
     private fun createSecondaryChatModel(settings: OllamaSettings): ChatModel {

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -80,7 +80,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
                 .modelName(model)
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
+                .logResponses(log.isTraceEnabled)
                 .listeners(listOf(TelemetryChatModelListener(telemetry, OPENAI.name.lowercase())))
                 .build()
 
@@ -104,7 +104,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
         .modelName(AppConfig.models.openai.imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
-        .logResponses(log.isDebugEnabled)
+        .logResponses(log.isTraceEnabled)
         .build()
 
     private fun createSecondaryChatModel(settings: OpenAiSettings): ChatModel {

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
@@ -72,7 +72,7 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
                 .modelName(model)
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
+                .logResponses(log.isTraceEnabled)
                 .listeners(listOf(TelemetryChatModelListener(telemetry, XAI.name.lowercase())))
                 .build()
 
@@ -97,7 +97,7 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
         .modelName(AppConfig.models.xai.imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
-        .logResponses(log.isDebugEnabled)
+        .logResponses(log.isTraceEnabled)
         .build()
 
     private fun createSecondaryChatModel(settings: XAiSettings): ChatModel {

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinator.kt
@@ -36,4 +36,10 @@ interface IndexingCoordinator : Closeable {
      * Stop watching for changes.
      */
     fun stopWatching()
+
+    /**
+     * Clear all indexed data for this knowledge source.
+     * This is used when the project is deleted or reset.
+     */
+    fun clearAll()
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFilesIndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFilesIndexingCoordinator.kt
@@ -343,4 +343,12 @@ class LocalFilesIndexingCoordinator(
     override fun close() {
         log.debug("Closed LocalFilesIndexingCoordinator for project $projectId")
     }
+
+    /**
+     * Clear all indexed data for this project.
+     */
+    override fun clearAll() {
+        stateManager.clearStates()
+        log.info("Cleared all index states for project $projectId (files)")
+    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFoldersIndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFoldersIndexingCoordinator.kt
@@ -427,6 +427,14 @@ class LocalFoldersIndexingCoordinator(
     }
 
     /**
+     * Clear all indexed data for this project.
+     */
+    override fun clearAll() {
+        stateManager.clearStates()
+        log.info("Cleared all index states for project $projectId (folders)")
+    }
+
+    /**
      * Close coordinator and cleanup resources.
      */
     override fun close() {

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/UrlIndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/UrlIndexingCoordinator.kt
@@ -229,6 +229,14 @@ class UrlIndexingCoordinator(
         // No-op
     }
 
+    /**
+     * Clear all indexed data for this project.
+     */
+    override fun clearAll() {
+        stateManager.clearStates()
+        log.info("Cleared all index states for project $projectId (urls)")
+    }
+
     override fun close() {
         stopWatching()
     }

--- a/shared/src/main/kotlin/io/askimo/core/rag/state/IndexStateManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/state/IndexStateManager.kt
@@ -73,7 +73,15 @@ class IndexStateManager(
     }
 
     /**
-     * Calculate hash for URL content (used by URL indexing coordinator)
+     * Clear all index states for this project.
+     * Deletes all records that have the projectId field equals to this projectId.
      */
-    fun calculateUrlHash(url: String): String = url.hashCode().toString()
+    fun clearStates() {
+        try {
+            repository.clearProjectState(projectId)
+            log.info("Cleared all index states for project $projectId")
+        } catch (e: Exception) {
+            log.error("Failed to clear index states for project $projectId", e)
+        }
+    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/state/IndexStateRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/state/IndexStateRepository.kt
@@ -13,7 +13,6 @@ import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.upsert
 import java.time.LocalDateTime
 
 /**
@@ -27,24 +26,6 @@ class IndexStateRepository(
 
     private val database: Database by lazy {
         Database.connect(databaseManager.dataSource)
-    }
-
-    /**
-     * Get the hash of a specific file for a project and source type.
-     */
-    fun getFileHash(
-        projectId: String,
-        filePath: String,
-        sourceType: String,
-    ): String? = transaction(database) {
-        IndexFileStateTable.selectAll()
-            .where {
-                (IndexFileStateTable.projectId eq projectId) and
-                    (IndexFileStateTable.filePath eq filePath) and
-                    (IndexFileStateTable.sourceType eq sourceType)
-            }
-            .singleOrNull()
-            ?.get(IndexFileStateTable.fileHash)
     }
 
     /**
@@ -63,24 +44,6 @@ class IndexStateRepository(
             .associate { row ->
                 row[IndexFileStateTable.filePath] to row[IndexFileStateTable.fileHash]
             }
-    }
-
-    /**
-     * Save or update the state for a single file.
-     */
-    fun saveFileState(
-        projectId: String,
-        filePath: String,
-        hash: String,
-        sourceType: String,
-    ) = transaction(database) {
-        IndexFileStateTable.upsert {
-            it[IndexFileStateTable.projectId] = projectId
-            it[IndexFileStateTable.filePath] = filePath
-            it[IndexFileStateTable.fileHash] = hash
-            it[IndexFileStateTable.sourceType] = sourceType
-            it[IndexFileStateTable.indexedAt] = LocalDateTime.now()
-        }
     }
 
     /**
@@ -111,70 +74,6 @@ class IndexStateRepository(
         }
 
         log.debug("Batch saved ${fileHashes.size} file states for project $projectId, source type $sourceType")
-    }
-
-    /**
-     * Remove file states for deleted files.
-     */
-    fun removeDeletedFiles(
-        projectId: String,
-        filePaths: List<String>,
-        sourceType: String,
-    ) = transaction(database) {
-        var deleted = 0
-        for (filePath in filePaths) {
-            deleted += IndexFileStateTable.deleteWhere {
-                (IndexFileStateTable.projectId eq projectId) and
-                    (IndexFileStateTable.sourceType eq sourceType) and
-                    (IndexFileStateTable.filePath eq filePath)
-            }
-        }
-        log.debug("Removed $deleted deleted file states for project $projectId, source type $sourceType")
-    }
-
-    /**
-     * Get the count of indexed files for a project and source type.
-     */
-    fun getFileCount(
-        projectId: String,
-        sourceType: String,
-    ): Int = transaction(database) {
-        IndexFileStateTable.selectAll()
-            .where {
-                (IndexFileStateTable.projectId eq projectId) and
-                    (IndexFileStateTable.sourceType eq sourceType)
-            }
-            .count()
-            .toInt()
-    }
-
-    /**
-     * Get all file paths for a project and source type.
-     */
-    fun getAllFilePaths(
-        projectId: String,
-        sourceType: String,
-    ): List<String> = transaction(database) {
-        IndexFileStateTable.selectAll()
-            .where {
-                (IndexFileStateTable.projectId eq projectId) and
-                    (IndexFileStateTable.sourceType eq sourceType)
-            }
-            .map { it[IndexFileStateTable.filePath] }
-    }
-
-    /**
-     * Delete all state for a specific project and source type.
-     */
-    fun clearProjectSourceState(
-        projectId: String,
-        sourceType: String,
-    ) = transaction(database) {
-        val deleted = IndexFileStateTable.deleteWhere {
-            (IndexFileStateTable.projectId eq projectId) and
-                (IndexFileStateTable.sourceType eq sourceType)
-        }
-        log.info("Cleared $deleted file states for project $projectId, source type $sourceType")
     }
 
     /**


### PR DESCRIPTION
- Add context menu to project side panel with a reindex option
- Allow saving rendered images from markdown to a chosen file location
- Post a project-deleted event so index state can be cleared reliably
- Add clearAll support to indexing coordinators to reset per-project state
- Update Gemini default model names and wire Gemini image base URL/model
- Reduce noisy provider/MCP logging by gating response/event logs to trace