### PR TITLE
refactor(indexing): track coordinators by knowledge source and support removal

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -701,7 +701,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
     val handleResumeSession: (String) -> Unit = { sessionId ->
         sessionManager.switchToSession(sessionId)
-
+        selectedProjectId = null
         currentView = View.CHAT
     }
 
@@ -866,6 +866,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                                 projectsViewModel = projectsViewModel,
                                                 sessionsViewModel = sessionsViewModel,
                                                 currentSessionId = activeSessionId,
+                                                currentProjectId = selectedProjectId,
                                                 userProfile = userProfile,
                                                 onToggleExpand = { isSidebarExpanded = !isSidebarExpanded },
                                                 onNewChat = {

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
@@ -509,6 +509,7 @@ fun projectView(
                 EventBus.post(
                     ProjectIndexingRequestedEvent(
                         projectId = currentProject.id,
+                        knowledgeSources = newConfigs,
                         watchForChanges = true,
                     ),
                 )

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectViewModel.kt
@@ -13,6 +13,7 @@ import io.askimo.core.chat.domain.Project
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ProjectDeletedEvent
+import io.askimo.core.event.internal.ProjectIndexRemovalEvent
 import io.askimo.core.event.internal.ProjectReIndexEvent
 import io.askimo.core.event.internal.ProjectRefreshEvent
 import io.askimo.core.event.internal.ProjectSessionsRefreshEvent
@@ -203,8 +204,9 @@ class ProjectViewModel(
                 }
 
                 EventBus.post(
-                    ProjectReIndexEvent(
-                        projectId = projectId,
+                    ProjectIndexRemovalEvent(
+                        projectId = project.id,
+                        knowledgeSource = source,
                         reason = "Knowledge source removed by user",
                     ),
                 )

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -100,6 +100,7 @@ fun navigationSidebar(
     projectsViewModel: ProjectsViewModel,
     sessionsViewModel: SessionsViewModel,
     currentSessionId: String?,
+    currentProjectId: String?,
     userProfile: UserProfile?,
     onToggleExpand: () -> Unit,
     onNewChat: () -> Unit,
@@ -134,6 +135,7 @@ fun navigationSidebar(
             projectsViewModel = projectsViewModel,
             sessionsViewModel = sessionsViewModel,
             currentSessionId = currentSessionId,
+            currentProjectId = currentProjectId,
             userProfile = userProfile,
             onToggleExpand = onToggleExpand,
             onNewChat = onNewChat,
@@ -175,7 +177,8 @@ private fun expandedNavigationSidebar(
     projectsViewModel: ProjectsViewModel,
     sessionsViewModel: SessionsViewModel,
     currentSessionId: String?,
-    userProfile: io.askimo.core.user.domain.UserProfile?, // Add this
+    currentProjectId: String?,
+    userProfile: UserProfile?,
     onToggleExpand: () -> Unit,
     onNewChat: () -> Unit,
     onToggleProjects: () -> Unit,
@@ -303,6 +306,7 @@ private fun expandedNavigationSidebar(
             if (isProjectsExpanded) {
                 projectsList(
                     projectsViewModel = projectsViewModel,
+                    currentProjectId = currentProjectId,
                     onNewProject = onNewProject,
                     onSelectProject = onSelectProject,
                 )
@@ -516,6 +520,7 @@ private fun collapsedNavigationSidebar(
 @Composable
 private fun projectsList(
     projectsViewModel: ProjectsViewModel,
+    currentProjectId: String?,
     onNewProject: () -> Unit,
     onSelectProject: (String) -> Unit,
 ) {
@@ -562,6 +567,7 @@ private fun projectsList(
             projectsViewModel.projects.forEach { project ->
                 projectItemWithMenu(
                     project = project,
+                    isSelected = project.id == currentProjectId,
                     onProjectClick = { onSelectProject(project.id) },
                     onDeleteProject = { projectToDelete = it },
                 )
@@ -628,6 +634,7 @@ private fun navigationItemLabelWithMenu(
 @Composable
 private fun projectItemWithMenu(
     project: Project,
+    isSelected: Boolean,
     onProjectClick: () -> Unit,
     onDeleteProject: (Project) -> Unit,
 ) {
@@ -655,7 +662,7 @@ private fun projectItemWithMenu(
                         onMenuClick = { showMenu = true },
                     )
                 },
-                selected = false,
+                selected = isSelected,
                 onClick = onProjectClick,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/shared/src/main/kotlin/io/askimo/core/event/internal/ProjectIndexRemovalEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/event/internal/ProjectIndexRemovalEvent.kt
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.event.internal
+
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
+import io.askimo.core.event.Event
+import io.askimo.core.event.EventSource
+import io.askimo.core.event.EventType
+import java.time.Instant
+
+/**
+ * Event emitted when a specific knowledge source should be removed from the index.
+ * This is an internal event that triggers ProjectIndexer to delete the embeddings
+ * and index state associated with the given knowledge source.
+ */
+data class ProjectIndexRemovalEvent(
+    val projectId: String,
+    val knowledgeSource: KnowledgeSourceConfig,
+    val reason: String = "Knowledge source removed",
+    override val timestamp: Instant = Instant.now(),
+    override val source: EventSource = EventSource.SYSTEM,
+) : Event {
+    override val type = EventType.INTERNAL
+
+    override fun getDetails(): String = "Removal requested for project $projectId, source: ${knowledgeSource.resourceIdentifier} — $reason"
+}

--- a/shared/src/main/kotlin/io/askimo/core/event/internal/ProjectIndexingRequestedEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/event/internal/ProjectIndexingRequestedEvent.kt
@@ -7,6 +7,7 @@ package io.askimo.core.event.internal
 import dev.langchain4j.data.segment.TextSegment
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.store.embedding.EmbeddingStore
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
 import io.askimo.core.event.Event
 import io.askimo.core.event.EventSource
 import io.askimo.core.event.EventType
@@ -16,16 +17,27 @@ import java.time.Instant
  * Event emitted when a project needs to be indexed.
  * This is an internal event that triggers ProjectIndexer to index the project files
  * using the provided embedding store and model.
+ *
+ * @param knowledgeSources Optional list of specific sources to index.
+ *   If null, all project sources will be indexed.
  */
 data class ProjectIndexingRequestedEvent(
     val projectId: String,
     val embeddingStore: EmbeddingStore<TextSegment>? = null,
     val embeddingModel: EmbeddingModel? = null,
     val watchForChanges: Boolean = true,
+    val knowledgeSources: List<KnowledgeSourceConfig>? = null,
     override val timestamp: Instant = Instant.now(),
     override val source: EventSource = EventSource.SYSTEM,
 ) : Event {
     override val type = EventType.INTERNAL
 
-    override fun getDetails(): String = "Indexing requested for project $projectId"
+    override fun getDetails(): String {
+        val sourcesInfo = if (knowledgeSources != null) {
+            ", sources: [${knowledgeSources.joinToString { it.resourceIdentifier }}]"
+        } else {
+            ""
+        }
+        return "Indexing requested for project $projectId$sourcesInfo"
+    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinator.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.core.rag.indexing
 
+import io.askimo.core.chat.domain.KnowledgeSourceConfig
 import io.askimo.core.rag.state.IndexProgress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -13,8 +14,17 @@ import java.io.Closeable
  * Coordinator for indexing knowledge sources.
  * Each knowledge source type (files, web pages, databases) implements this interface
  * to handle indexing and watching for changes in its own way.
+ *
+ * The type parameter [T] represents the specific [KnowledgeSourceConfig] subtype
+ * used by this coordinator. The `out` variance allows coordinators with specific
+ * config types to be used where the base type is expected.
  */
-interface IndexingCoordinator : Closeable {
+interface IndexingCoordinator<out T : KnowledgeSourceConfig> : Closeable {
+    /**
+     * The knowledge source configuration this coordinator is responsible for.
+     */
+    val knowledgeSourceConfig: T
+
     /**
      * Progress of the indexing operation.
      */

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorFactory.kt
@@ -35,7 +35,7 @@ object IndexingCoordinatorFactory {
         embeddingStore: EmbeddingStore<TextSegment>,
         embeddingModel: EmbeddingModel,
         appContext: AppContext,
-    ): IndexingCoordinator {
+    ): IndexingCoordinator<KnowledgeSourceConfig> {
         val provider = IndexingCoordinatorProviderRegistry.getProvider(knowledgeSource)
             ?: throw IllegalArgumentException(
                 "No provider registered for knowledge source type: ${knowledgeSource::class.simpleName}. " +

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProvider.kt
@@ -46,5 +46,5 @@ interface IndexingCoordinatorProvider {
         embeddingStore: EmbeddingStore<TextSegment>,
         embeddingModel: EmbeddingModel,
         appContext: AppContext,
-    ): IndexingCoordinator
+    ): IndexingCoordinator<KnowledgeSourceConfig>
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProviderRegistry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProviderRegistry.kt
@@ -108,17 +108,6 @@ object IndexingCoordinatorProviderRegistry {
     }
 
     /**
-     * Check if a provider is registered for a specific knowledge source type.
-     *
-     * @param type The knowledge source type to check
-     * @return true if a provider is registered, false otherwise
-     */
-    fun hasProvider(type: Class<out KnowledgeSourceConfig>): Boolean {
-        ensureInitialized()
-        return providers.containsKey(type)
-    }
-
-    /**
      * Remove all registered providers and reset initialization.
      * Primarily useful for testing.
      */

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFilesIndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFilesIndexingCoordinator.kt
@@ -7,6 +7,7 @@ package io.askimo.core.rag.indexing
 import dev.langchain4j.data.segment.TextSegment
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.store.embedding.EmbeddingStore
+import io.askimo.core.chat.domain.LocalFilesKnowledgeSourceConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.user.IndexingInProgressEvent
@@ -19,6 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.io.path.isRegularFile
@@ -31,12 +33,14 @@ import kotlin.io.path.isRegularFile
 class LocalFilesIndexingCoordinator(
     private val projectId: String,
     private val projectName: String,
-    private val filePaths: List<Path>,
+    override val knowledgeSourceConfig: LocalFilesKnowledgeSourceConfig,
     private val embeddingStore: EmbeddingStore<TextSegment>,
     private val embeddingModel: EmbeddingModel,
     private val appContext: AppContext,
-) : IndexingCoordinator {
+) : IndexingCoordinator<LocalFilesKnowledgeSourceConfig> {
     private val log = logger<LocalFilesIndexingCoordinator>()
+
+    private val filePaths = listOf(Paths.get(knowledgeSourceConfig.resourceIdentifier))
 
     private val resourceContentProcessor = ResourceContentProcessor(appContext)
     private val stateManager = IndexStateManager(projectId, "files")

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/UrlIndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/UrlIndexingCoordinator.kt
@@ -7,6 +7,7 @@ package io.askimo.core.rag.indexing
 import dev.langchain4j.data.segment.TextSegment
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.store.embedding.EmbeddingStore
+import io.askimo.core.chat.domain.UrlKnowledgeSourceConfig
 import io.askimo.core.chat.util.UrlContentExtractor
 import io.askimo.core.context.AppContext
 import io.askimo.core.logging.logger
@@ -27,12 +28,14 @@ import java.util.concurrent.atomic.AtomicInteger
 class UrlIndexingCoordinator(
     private val projectId: String,
     private val projectName: String,
-    private val urls: List<String>,
+    override val knowledgeSourceConfig: UrlKnowledgeSourceConfig,
     private val embeddingStore: EmbeddingStore<TextSegment>,
     private val embeddingModel: EmbeddingModel,
     private val appContext: AppContext,
-) : IndexingCoordinator {
+) : IndexingCoordinator<UrlKnowledgeSourceConfig> {
     private val log = logger<UrlIndexingCoordinator>()
+
+    private val urls = listOf(knowledgeSourceConfig.resourceIdentifier)
 
     private val resourceContentProcessor = ResourceContentProcessor(appContext)
     private val stateManager = IndexStateManager(projectId, "urls")

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFilesIndexingProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFilesIndexingProvider.kt
@@ -13,7 +13,6 @@ import io.askimo.core.context.AppContext
 import io.askimo.core.rag.indexing.IndexingCoordinator
 import io.askimo.core.rag.indexing.IndexingCoordinatorProvider
 import io.askimo.core.rag.indexing.LocalFilesIndexingCoordinator
-import java.nio.file.Paths
 
 /**
  * Provider for creating IndexingCoordinator instances for local file knowledge sources.
@@ -28,17 +27,12 @@ class LocalFilesIndexingProvider : IndexingCoordinatorProvider {
         embeddingStore: EmbeddingStore<TextSegment>,
         embeddingModel: EmbeddingModel,
         appContext: AppContext,
-    ): IndexingCoordinator {
-        val config = knowledgeSource as LocalFilesKnowledgeSourceConfig
-        val filePath = Paths.get(config.resourceIdentifier)
-
-        return LocalFilesIndexingCoordinator(
-            projectId = projectId,
-            projectName = projectName,
-            filePaths = listOf(filePath),
-            embeddingStore = embeddingStore,
-            embeddingModel = embeddingModel,
-            appContext = appContext,
-        )
-    }
+    ): IndexingCoordinator<KnowledgeSourceConfig> = LocalFilesIndexingCoordinator(
+        projectId = projectId,
+        projectName = projectName,
+        knowledgeSourceConfig = knowledgeSource as LocalFilesKnowledgeSourceConfig,
+        embeddingStore = embeddingStore,
+        embeddingModel = embeddingModel,
+        appContext = appContext,
+    )
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFoldersIndexingProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/LocalFoldersIndexingProvider.kt
@@ -13,7 +13,6 @@ import io.askimo.core.context.AppContext
 import io.askimo.core.rag.indexing.IndexingCoordinator
 import io.askimo.core.rag.indexing.IndexingCoordinatorProvider
 import io.askimo.core.rag.indexing.LocalFoldersIndexingCoordinator
-import java.nio.file.Paths
 
 /**
  * Provider for creating IndexingCoordinator instances for local folder knowledge sources.
@@ -28,17 +27,12 @@ class LocalFoldersIndexingProvider : IndexingCoordinatorProvider {
         embeddingStore: EmbeddingStore<TextSegment>,
         embeddingModel: EmbeddingModel,
         appContext: AppContext,
-    ): IndexingCoordinator {
-        val config = knowledgeSource as LocalFoldersKnowledgeSourceConfig
-        val folderPath = Paths.get(config.resourceIdentifier)
-
-        return LocalFoldersIndexingCoordinator(
-            projectId = projectId,
-            projectName = projectName,
-            paths = listOf(folderPath),
-            embeddingStore = embeddingStore,
-            embeddingModel = embeddingModel,
-            appContext = appContext,
-        )
-    }
+    ): IndexingCoordinator<KnowledgeSourceConfig> = LocalFoldersIndexingCoordinator(
+        projectId = projectId,
+        projectName = projectName,
+        knowledgeSourceConfig = knowledgeSource as LocalFoldersKnowledgeSourceConfig,
+        embeddingStore = embeddingStore,
+        embeddingModel = embeddingModel,
+        appContext = appContext,
+    )
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/UrlIndexingProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/providers/UrlIndexingProvider.kt
@@ -27,17 +27,12 @@ class UrlIndexingProvider : IndexingCoordinatorProvider {
         embeddingStore: EmbeddingStore<TextSegment>,
         embeddingModel: EmbeddingModel,
         appContext: AppContext,
-    ): IndexingCoordinator {
-        val config = knowledgeSource as UrlKnowledgeSourceConfig
-        val url = config.resourceIdentifier
-
-        return UrlIndexingCoordinator(
-            projectId = projectId,
-            projectName = projectName,
-            urls = listOf(url),
-            embeddingStore = embeddingStore,
-            embeddingModel = embeddingModel,
-            appContext = appContext,
-        )
-    }
+    ): IndexingCoordinator<KnowledgeSourceConfig> = UrlIndexingCoordinator(
+        projectId = projectId,
+        projectName = projectName,
+        knowledgeSourceConfig = knowledgeSource as UrlKnowledgeSourceConfig,
+        embeddingStore = embeddingStore,
+        embeddingModel = embeddingModel,
+        appContext = appContext,
+    )
 }


### PR DESCRIPTION
- Add ProjectIndexRemovalEvent to remove a single source from a project index
- Extend ProjectIndexingRequestedEvent to optionally target specific sources
- Make IndexingCoordinator generic and expose its KnowledgeSourceConfig
- Simplify indexing providers/coordinators to derive paths/urls from config
- Update desktop project UI to request removal events and keep selection state
- Improve jar signing task to handle pty4j jnilib resources on macOS