### PR TITLE
feat(ui): improve chat styling and trigger project indexing on view enter

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatInputField.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatInputField.kt
@@ -171,11 +171,12 @@ fun chatInputField(
     val padding = 36.dp // Top and bottom padding for the text field
     val calculatedHeight = (lineHeight * estimatedLineCount) + padding
 
-    // Reset height to default when message is sent (detected by empty input text)
+    // Reset height and creation mode to default when message is sent (detected by empty input text)
     LaunchedEffect(inputText.text) {
         if (inputText.text.isEmpty()) {
             textFieldHeight = defaultTextFieldHeight
             manuallyResized = false
+            creationMode = CreationMode.Chat
         }
     }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatView.kt
@@ -193,7 +193,7 @@ fun chatView(
                 }
             }
 
-            EventBus.userEvents.collect { event ->
+            EventBus.internalEvents.collect { event ->
                 val eventProjectId = when (event) {
                     is IndexingStartedEvent -> event.projectId
                     is IndexingInProgressEvent -> event.projectId

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/MessageComponents.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/MessageComponents.kt
@@ -430,20 +430,20 @@ fun messageBubble(
                                     },
                                 ),
                             colors = CardDefaults.cardColors(
-                                containerColor = if (isOutdatedMessage) {
-                                    if (message.isUser) {
-                                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
-                                    } else {
-                                        MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
-                                    }
-                                } else {
-                                    MaterialTheme.colorScheme.primaryContainer
+                                containerColor = when {
+                                    isOutdatedMessage && message.isUser -> ComponentColors.userMessageBackground().copy(alpha = 0.5f)
+                                    isOutdatedMessage && !message.isUser -> Color.Transparent
+                                    message.isUser -> ComponentColors.userMessageBackground()
+                                    else -> Color.Transparent
                                 },
                                 contentColor = if (isOutdatedMessage) {
                                     MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                 } else {
-                                    MaterialTheme.colorScheme.onPrimaryContainer
+                                    ComponentColors.userMessageContentColor()
                                 },
+                            ),
+                            elevation = CardDefaults.cardElevation(
+                                defaultElevation = if (message.isUser) 2.dp else 0.dp,
                             ),
                         ) {
                             Column {
@@ -638,7 +638,7 @@ fun messageBubble(
                                             imageVector = Icons.Default.ContentCopy,
                                             contentDescription = stringResource("message.copy.description"),
                                             modifier = Modifier.size(16.dp).pointerHoverIcon(PointerIcon.Hand),
-                                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
                                     }
                                 }
@@ -658,7 +658,7 @@ fun messageBubble(
                                                 imageVector = Icons.Default.Edit,
                                                 contentDescription = stringResource("message.ai.edit.description"),
                                                 modifier = Modifier.size(16.dp).pointerHoverIcon(PointerIcon.Hand),
-                                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                             )
                                         }
                                     }
@@ -672,14 +672,10 @@ fun messageBubble(
                                         IconButton(
                                             onClick = {
                                                 message.id?.let { messageId ->
-                                                    // Check if this is the latest AI message
                                                     val isLatestMessage = allMessages.lastOrNull { !it.isUser }?.id == messageId
-
                                                     if (isLatestMessage) {
-                                                        // Directly retry for latest message
                                                         onRetryMessage.invoke(messageId)
                                                     } else {
-                                                        // Show confirmation dialog for mid-conversation retry
                                                         onShowRetryConfirmDialog?.invoke(messageId)
                                                     }
                                                 }
@@ -690,7 +686,7 @@ fun messageBubble(
                                                 imageVector = Icons.Default.Refresh,
                                                 contentDescription = stringResource("message.ai.try.again.description"),
                                                 modifier = Modifier.size(16.dp).pointerHoverIcon(PointerIcon.Hand),
-                                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                             )
                                         }
                                     }
@@ -780,7 +776,7 @@ fun messageBubble(
                                                     imageVector = Icons.Default.ContentCopy,
                                                     contentDescription = stringResource("message.copy.description"),
                                                     modifier = Modifier.size(16.dp).pointerHoverIcon(PointerIcon.Hand),
-                                                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                                 )
                                             }
                                         }
@@ -800,7 +796,7 @@ fun messageBubble(
                                                         imageVector = Icons.Default.Edit,
                                                         contentDescription = stringResource("message.edit.description"),
                                                         modifier = Modifier.size(16.dp).pointerHoverIcon(PointerIcon.Hand),
-                                                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                                     )
                                                 }
                                             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/theme/ComponentColors.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/theme/ComponentColors.kt
@@ -185,6 +185,90 @@ object ComponentColors {
     }
 
     /**
+     * Background color for user message bubbles.
+     * Computed as a neutral darkened/lightened step from the surface color so it is
+     * always accent-neutral. surfaceContainerHigh inherits surfaceTint (the
+     * accent colour) and looks tinted (e.g. purple/grey) in light mode.
+     * - Light theme: surface darkened by 8% — subtle grey, no accent tint.
+     * - Dark theme:  surface lightened by 10% — slightly lighter dark surface.
+     */
+    @Composable
+    fun userMessageBackground(): Color {
+        val surface = MaterialTheme.colorScheme.surface
+        val isLight = surface.luminance() > 0.5
+        return if (isLight) {
+            Color(
+                red = (surface.red * 0.92f).coerceIn(0f, 1f),
+                green = (surface.green * 0.92f).coerceIn(0f, 1f),
+                blue = (surface.blue * 0.92f).coerceIn(0f, 1f),
+                alpha = surface.alpha,
+            )
+        } else {
+            Color(
+                red = (surface.red + 0.10f).coerceIn(0f, 1f),
+                green = (surface.green + 0.10f).coerceIn(0f, 1f),
+                blue = (surface.blue + 0.10f).coerceIn(0f, 1f),
+                alpha = surface.alpha,
+            )
+        }
+    }
+
+    /**
+     * Content (text/icon) color for user message bubbles.
+     */
+    @Composable
+    fun userMessageContentColor(): Color = MaterialTheme.colorScheme.onSurface
+
+    /**
+     * Background color for code blocks in AI responses.
+     * Computed directly from surface to stay accent-neutral.
+     * surfaceContainerHighest/Low inherit surfaceTint (the accent colour)
+     * and appear tinted in themed modes.
+     * - Light theme: surface darkened by 15% — clear contrast, no accent tint.
+     * - Dark theme:  surface darkened by 15% — deeper dark, keeps dark syntax colors readable.
+     */
+    @Composable
+    fun codeBlockBackground(): Color {
+        val surface = MaterialTheme.colorScheme.surface
+        val isLight = surface.luminance() > 0.5
+        return if (isLight) {
+            Color(
+                red = (surface.red * 0.85f).coerceIn(0f, 1f),
+                green = (surface.green * 0.85f).coerceIn(0f, 1f),
+                blue = (surface.blue * 0.85f).coerceIn(0f, 1f),
+                alpha = surface.alpha,
+            )
+        } else {
+            Color(
+                red = (surface.red * 0.75f).coerceIn(0f, 1f),
+                green = (surface.green * 0.75f).coerceIn(0f, 1f),
+                blue = (surface.blue * 0.75f).coerceIn(0f, 1f),
+                alpha = surface.alpha,
+            )
+        }
+    }
+
+    /**
+     * Text/content color for code blocks (used as the fallback/unstyled token color).
+     * Paired with codeBlockBackground() to ensure readable contrast.
+     */
+    @Composable
+    fun codeBlockContentColor(): Color = MaterialTheme.colorScheme.onSurface
+
+    /**
+     * Border color for code blocks.
+     */
+    @Composable
+    fun codeBlockBorderColor(): Color = MaterialTheme.colorScheme.outlineVariant
+
+    /**
+     * Returns true when the code block background is dark, so the caller can
+     * pick the correct syntax highlight theme (dark vs light).
+     */
+    @Composable
+    fun isCodeBlockDark(): Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5
+
+    /**
      * Sidebar header color - uses secondaryContainer for a subtle accent
      * - Lighter than primaryContainer (used by buttons)
      * - Makes header visually distinct but not overwhelming

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
@@ -130,6 +130,18 @@ fun projectView(
     // Get repository
     val projectRepository = remember { DatabaseManager.getInstance().getProjectRepository() }
 
+    // Broadcast indexing request when entering the project view so that
+    // all knowledge sources are (re-)indexed / watched for changes.
+    LaunchedEffect(currentProject.id) {
+        EventBus.post(
+            ProjectIndexingRequestedEvent(
+                projectId = currentProject.id,
+                knowledgeSources = null,
+                watchForChanges = true,
+            ),
+        )
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.2.17
+projectVersion=1.2.18
 
 # About information
 author=Hai Nguyen

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -30,7 +30,6 @@ import io.askimo.core.db.DatabaseManager
 import io.askimo.core.db.Pageable
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ModelChangedEvent
-import io.askimo.core.event.internal.ProjectIndexingRequestedEvent
 import io.askimo.core.event.internal.SessionCreatedEvent
 import io.askimo.core.event.internal.SessionTitleUpdatedEvent
 import io.askimo.core.logging.logger
@@ -254,16 +253,6 @@ class ChatSessionService(
                     .build(),
             )
 
-            EventBus.post(
-                ProjectIndexingRequestedEvent(
-                    projectId = project.id,
-                    embeddingStore = embeddingStore,
-                    embeddingModel = embeddingModel,
-                    watchForChanges = true,
-                ),
-            )
-
-            log.info("✓ RAG retriever created, indexing started in background for project ${project.id}")
             return vectorRetriever
         } catch (e: Exception) {
             log.error("Failed to create content retriever for project ${project.id}", e)

--- a/shared/src/main/kotlin/io/askimo/core/rag/ProjectIndexer.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/ProjectIndexer.kt
@@ -79,7 +79,7 @@ class ProjectIndexer(
             EventBus.internalEvents
                 .filterIsInstance<ProjectIndexRemovalEvent>()
                 .collect { event ->
-                    log.info("Indexing requested for project ${event.projectId}")
+                    log.info("Indexing removal requested for project ${event.projectId}")
                     handleRemoveIndexEvent(event)
                 }
         }


### PR DESCRIPTION
- Reset chat creation mode after sending a message to avoid stale state
- Use internal event stream for chat view updates
- Introduce neutral component colors for message bubbles and code blocks
- Refine markdown rendering and reposition image download overlay
- Start (re-)indexing knowledge sources when opening a project and centralize avatar loading
- Bump version to 1.2.18