### PR TITLE
refactor(global-error-handler): add global error handler and refactor error dialog to use state

### DIFF
--- a/.github/workflows/shared-tests.yml
+++ b/.github/workflows/shared-tests.yml
@@ -1,0 +1,40 @@
+name: Shared Tests
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ "v*" ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  shared-test:
+    name: shared-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Run shared tests
+        run: ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx2g" :shared:test
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared-test-report-attempt${{ github.run_attempt }}
+          path: shared/build/reports/tests/test
+          retention-days: 7
+

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Think of it as having multiple AI assistants in one app: use Claude for coding, 
 ✅ **Use multiple AI models** - Switch between ChatGPT, Claude, Gemini, Ollama & more  
 ✅ **Ask questions about your files** - Connect folders, files, and web URLs to get answers from your documents  
 ✅ **Automate tasks** - Works from command line for scripts and workflows  
+✅ **Connect custom tools** - Extend AI with MCP (Model Context Protocol) integrations supporting both **stdio** and **HTTP** transports  
 ✅ **Your data stays private** - Everything saved on your computer  
 ✅ **Free & open source** - Free forever with full source code access
 
@@ -111,7 +112,7 @@ Installers available for macOS (Apple Silicon & Intel), Windows, and Linux (ARM6
 - 🔄 **Use the Best AI for Each Task** - Need help with code? Use Claude. General questions? Try ChatGPT. Writing a quick email? Use a free local model. Switch instantly between different AIs
 - 🔒 **Complete Privacy** - Everything stays on your computer. Your conversations, your data, your control. Nothing is sent to the cloud unless you choose to ask an AI
 - 🧠 **Ask Questions About Your Files** - Point Askimo to folders, files, or web URLs and ask "What does this project do?" or "How does the login work?" Get answers from your actual documents and code
-- 🔌 **Connect Custom Tools (Experimental)** - Extend AI capabilities with custom MCP (Model Context Protocol) integrations. Connect your own tools and services for specialized workflows
+✅ **Connect Custom Tools (Experimental)** - Extend AI capabilities with MCP (Model Context Protocol) integrations supporting both **stdio** and **HTTP** transports. Connect your own tools and services for specialized workflows
 - ⭐ **Stay Organized** - Star your favorite conversations, search through everything you've ever asked, and keep work separate from personal chats
 - 📊 **Beautiful Formatting** - See code with syntax highlighting, tables, diagrams, and properly formatted text. Copy and paste ready to use
 - 🎯 **Save Your Favorite Prompts** - Create reusable templates for things you ask often. One click to use your "proofreader" or "code reviewer" assistant

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -70,10 +70,6 @@ import io.askimo.core.context.getConfigInfo
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.Event
 import io.askimo.core.event.EventBus
-import io.askimo.core.event.error.IndexingErrorEvent
-import io.askimo.core.event.error.IndexingErrorType
-import io.askimo.core.event.error.ModelNotAvailableEvent
-import io.askimo.core.event.error.SendMessageErrorEvent
 import io.askimo.core.event.internal.LanguageDirectiveChangedEvent
 import io.askimo.core.event.system.InvalidateCacheEvent
 import io.askimo.core.i18n.LocalizationManager
@@ -122,11 +118,13 @@ import io.askimo.desktop.settings.aboutDialog
 import io.askimo.desktop.settings.fileViewerDialog
 import io.askimo.desktop.settings.providerSelectionDialog
 import io.askimo.desktop.settings.settingsViewWithSidebar
+import io.askimo.desktop.shell.ErrorDialogState
 import io.askimo.desktop.shell.NativeMenuBar
 import io.askimo.desktop.shell.UpdateViewModel
 import io.askimo.desktop.shell.eventLogPanel
 import io.askimo.desktop.shell.eventLogWindow
 import io.askimo.desktop.shell.footerBar
+import io.askimo.desktop.shell.globalErrorHandler
 import io.askimo.desktop.shell.globalSearchDialog
 import io.askimo.desktop.shell.navigationSidebar
 import io.askimo.desktop.shell.starPromptDialog
@@ -308,11 +306,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
     var showEditProjectDialog by remember { mutableStateOf(false) }
     var showGlobalSearchDialog by remember { mutableStateOf(false) }
     var editingProjectId by remember { mutableStateOf<String?>(null) }
-    var showErrorDialog by remember { mutableStateOf(false) }
-    var errorDialogTitle by remember { mutableStateOf("") }
-    var errorDialogMessage by remember { mutableStateOf("") }
-    var errorDialogLinkText by remember { mutableStateOf<String?>(null) }
-    var errorDialogLinkUrl by remember { mutableStateOf<String?>(null) }
+    var errorDialogState by remember { mutableStateOf(ErrorDialogState()) }
     var showFileViewerDialog by remember { mutableStateOf(false) }
     var fileViewerPath by remember { mutableStateOf("") }
     var fileViewerContent by remember { mutableStateOf("") }
@@ -364,68 +358,8 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
         }
     }
 
-    // Listen for errors
-    LaunchedEffect(Unit) {
-        EventBus.errorEvents.collect { event ->
-            when (event) {
-                is IndexingErrorEvent -> {
-                    when (event.errorType) {
-                        IndexingErrorType.EMBEDDING_MODEL_NOT_FOUND -> {
-                            val modelName = event.details["modelName"] ?: "unknown"
-                            val provider = event.details["provider"] ?: "AI provider"
-                            errorDialogTitle = LocalizationManager.getString("error.indexing.model_not_found.title")
-                            errorDialogMessage = LocalizationManager.getString("error.indexing.model_not_found.message", modelName, provider)
-                            errorDialogLinkText = null
-                            errorDialogLinkUrl = null
-                            showErrorDialog = true
-                        }
-                        IndexingErrorType.IO_ERROR -> {
-                            errorDialogTitle = LocalizationManager.getString("error.indexing.io_error.title")
-                            errorDialogMessage = event.details["message"] ?: LocalizationManager.getString("error.indexing.io_error.message")
-                            errorDialogLinkText = null
-                            errorDialogLinkUrl = null
-                            showErrorDialog = true
-                        }
-                        IndexingErrorType.UNKNOWN_ERROR -> {
-                            errorDialogTitle = LocalizationManager.getString("error.indexing.unknown.title")
-                            errorDialogMessage = event.details["message"] ?: LocalizationManager.getString("error.indexing.unknown.message")
-                            errorDialogLinkText = null
-                            errorDialogLinkUrl = null
-                            showErrorDialog = true
-                        }
-                    }
-                }
-                is ModelNotAvailableEvent -> {
-                    errorDialogTitle = if (event.isEmbedding) {
-                        LocalizationManager.getString("error.model.not_available.title.embedding")
-                    } else {
-                        LocalizationManager.getString("error.model.not_available.title.chat")
-                    }
-                    errorDialogMessage = if (event.isEmbedding) {
-                        LocalizationManager.getString("error.model.not_available.message.embedding", event.modelName)
-                    } else {
-                        LocalizationManager.getString("error.model.not_available.message.chat", event.modelName)
-                    }
-                    if (event.isEmbedding) {
-                        errorDialogLinkText = LocalizationManager.getString("error.model.not_available.config_link")
-                        errorDialogLinkUrl = LocalizationManager.getString("error.model.not_available.config_url")
-                    } else {
-                        errorDialogLinkText = null
-                        errorDialogLinkUrl = null
-                    }
-                    showErrorDialog = true
-                }
-                is SendMessageErrorEvent -> {
-                    errorDialogTitle = LocalizationManager.getString("error.send_message.title")
-                    errorDialogMessage = event.throwable.message
-                        ?: LocalizationManager.getString("error.send_message.message")
-                    errorDialogLinkText = null
-                    errorDialogLinkUrl = null
-                    showErrorDialog = true
-                }
-            }
-        }
-    }
+    // Listen for errors – handled by the dedicated GlobalErrorHandler
+    globalErrorHandler { state -> errorDialogState = state }
 
     val scope = rememberCoroutineScope()
 
@@ -456,18 +390,18 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                         BackupManager.exportBackup(Paths.get(selectedPath))
                     }
 
-                    errorDialogTitle = LocalizationManager.getString("backup.export.success.title")
-                    errorDialogMessage = LocalizationManager.getString("backup.export.success.message", backupFile.toString())
-                    errorDialogLinkText = null
-                    errorDialogLinkUrl = null
-                    showErrorDialog = true
+                    errorDialogState = ErrorDialogState(
+                        show = true,
+                        title = LocalizationManager.getString("backup.export.success.title"),
+                        message = LocalizationManager.getString("backup.export.success.message", backupFile.toString()),
+                    )
                 }
             } catch (e: Exception) {
-                errorDialogTitle = LocalizationManager.getString("backup.export.error.title")
-                errorDialogMessage = LocalizationManager.getString("backup.export.error.message", e.message ?: "Unknown error")
-                errorDialogLinkText = null
-                errorDialogLinkUrl = null
-                showErrorDialog = true
+                errorDialogState = ErrorDialogState(
+                    show = true,
+                    title = LocalizationManager.getString("backup.export.error.title"),
+                    message = LocalizationManager.getString("backup.export.error.message", e.message ?: "Unknown error"),
+                )
                 log.error("Error exporting backup", e)
             }
         }
@@ -490,11 +424,11 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                     showImportBackupConfirm = true
                 }
             } catch (e: Exception) {
-                errorDialogTitle = LocalizationManager.getString("backup.import.error.title")
-                errorDialogMessage = LocalizationManager.getString("backup.import.error.message", e.message ?: "Unknown error")
-                errorDialogLinkText = null
-                errorDialogLinkUrl = null
-                showErrorDialog = true
+                errorDialogState = ErrorDialogState(
+                    show = true,
+                    title = LocalizationManager.getString("backup.import.error.title"),
+                    message = LocalizationManager.getString("backup.import.error.message", e.message ?: "Unknown error"),
+                )
                 log.error("Error importing backup", e)
             }
         }
@@ -723,9 +657,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                     showFileViewerDialog = true
                 },
                 onShowError = { title, message ->
-                    errorDialogTitle = title
-                    errorDialogMessage = message
-                    showErrorDialog = true
+                    errorDialogState = ErrorDialogState(show = true, title = title, message = message)
                 },
             ),
         ) {
@@ -1190,17 +1122,17 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                                     BackupManager.importBackup(path)
                                                 }
 
-                                                errorDialogTitle = LocalizationManager.getString("backup.import.success.title")
-                                                errorDialogMessage = LocalizationManager.getString("backup.import.success.message")
-                                                errorDialogLinkText = null
-                                                errorDialogLinkUrl = null
-                                                showErrorDialog = true
+                                                errorDialogState = ErrorDialogState(
+                                                    show = true,
+                                                    title = LocalizationManager.getString("backup.import.success.title"),
+                                                    message = LocalizationManager.getString("backup.import.success.message"),
+                                                )
                                             } catch (e: Exception) {
-                                                errorDialogTitle = LocalizationManager.getString("backup.import.error.title")
-                                                errorDialogMessage = LocalizationManager.getString("backup.import.error.message", e.message ?: "Unknown error")
-                                                errorDialogLinkText = null
-                                                errorDialogLinkUrl = null
-                                                showErrorDialog = true
+                                                errorDialogState = ErrorDialogState(
+                                                    show = true,
+                                                    title = LocalizationManager.getString("backup.import.error.title"),
+                                                    message = LocalizationManager.getString("backup.import.error.message", e.message ?: "Unknown error"),
+                                                )
                                                 log.error("Error importing backup.", e)
                                             } finally {
                                                 pendingImportBackupPath = null
@@ -1562,16 +1494,14 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                     )
                 }
 
-                if (showErrorDialog) {
+                if (errorDialogState.show) {
                     errorDialog(
-                        title = errorDialogTitle,
-                        message = errorDialogMessage,
-                        linkText = errorDialogLinkText,
-                        linkUrl = errorDialogLinkUrl,
+                        title = errorDialogState.title,
+                        message = errorDialogState.message,
+                        linkText = errorDialogState.linkText,
+                        linkUrl = errorDialogState.linkUrl,
                         onDismiss = {
-                            showErrorDialog = false
-                            errorDialogLinkText = null
-                            errorDialogLinkUrl = null
+                            errorDialogState = ErrorDialogState()
                         },
                     )
                 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/common/dialog/ErrorDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/common/dialog/ErrorDialog.kt
@@ -38,7 +38,7 @@ fun errorDialog(
     linkText: String? = null,
     linkUrl: String? = null,
 ) {
-    val linkColor = MaterialTheme.colorScheme.primary
+    val linkColor = MaterialTheme.colorScheme.onSurface
 
     ComponentColors.themedAlertDialog(
         onDismissRequest = onDismiss,

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/GlobalErrorHandler.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/GlobalErrorHandler.kt
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.desktop.shell
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import io.askimo.core.event.EventBus
+import io.askimo.core.event.error.IndexingErrorEvent
+import io.askimo.core.event.error.IndexingErrorType
+import io.askimo.core.event.error.ModelNotAvailableEvent
+import io.askimo.core.event.error.SendMessageErrorEvent
+import io.askimo.core.i18n.LocalizationManager
+
+/**
+ * Holds the state for the global error dialog triggered by application-wide error events.
+ */
+data class ErrorDialogState(
+    val show: Boolean = false,
+    val title: String = "",
+    val message: String = "",
+    val linkText: String? = null,
+    val linkUrl: String? = null,
+)
+
+/**
+ * Listens to [EventBus.errorEvents] and surfaces errors through [ErrorDialogState].
+ *
+ * Call this composable once at the top-level [app] scope and pass the returned
+ * state (along with the dismiss callback) down to wherever the error dialog is rendered.
+ *
+ * @param onStateChange called whenever a new [ErrorDialogState] should be applied.
+ */
+@Composable
+fun globalErrorHandler(onStateChange: (ErrorDialogState) -> Unit) {
+    LaunchedEffect(Unit) {
+        EventBus.errorEvents.collect { event ->
+            when (event) {
+                is IndexingErrorEvent -> {
+                    when (event.errorType) {
+                        IndexingErrorType.EMBEDDING_MODEL_NOT_FOUND -> {
+                            val modelName = event.details["modelName"] ?: "unknown"
+                            val provider = event.details["provider"] ?: "AI provider"
+                            onStateChange(
+                                ErrorDialogState(
+                                    show = true,
+                                    title = LocalizationManager.getString("error.indexing.model_not_found.title"),
+                                    message = LocalizationManager.getString(
+                                        "error.indexing.model_not_found.message",
+                                        modelName,
+                                        provider,
+                                    ),
+                                ),
+                            )
+                        }
+                        IndexingErrorType.IO_ERROR -> {
+                            onStateChange(
+                                ErrorDialogState(
+                                    show = true,
+                                    title = LocalizationManager.getString("error.indexing.io_error.title"),
+                                    message = event.details["message"]
+                                        ?: LocalizationManager.getString("error.indexing.io_error.message"),
+                                ),
+                            )
+                        }
+                        IndexingErrorType.UNKNOWN_ERROR -> {
+                            onStateChange(
+                                ErrorDialogState(
+                                    show = true,
+                                    title = LocalizationManager.getString("error.indexing.unknown.title"),
+                                    message = event.details["message"]
+                                        ?: LocalizationManager.getString("error.indexing.unknown.message"),
+                                ),
+                            )
+                        }
+                    }
+                }
+                is ModelNotAvailableEvent -> {
+                    onStateChange(
+                        ErrorDialogState(
+                            show = true,
+                            title = if (event.isEmbedding) {
+                                LocalizationManager.getString("error.model.not_available.title.embedding")
+                            } else {
+                                LocalizationManager.getString("error.model.not_available.title.chat")
+                            },
+                            message = if (event.isEmbedding) {
+                                LocalizationManager.getString(
+                                    "error.model.not_available.message.embedding",
+                                    event.modelName,
+                                )
+                            } else {
+                                LocalizationManager.getString(
+                                    "error.model.not_available.message.chat",
+                                    event.modelName,
+                                )
+                            },
+                            linkText = if (event.isEmbedding) {
+                                LocalizationManager.getString("error.model.not_available.config_link")
+                            } else {
+                                null
+                            },
+                            linkUrl = if (event.isEmbedding) {
+                                LocalizationManager.getString("error.model.not_available.config_url")
+                            } else {
+                                null
+                            },
+                        ),
+                    )
+                }
+                is SendMessageErrorEvent -> {
+                    onStateChange(
+                        ErrorDialogState(
+                            show = true,
+                            title = LocalizationManager.getString("error.send_message.title"),
+                            message = event.throwable.message
+                                ?: LocalizationManager.getString("error.send_message.message"),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/desktop/src/main/kotlin/io/askimo/desktop/tutorial/TutorialWizardDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/tutorial/TutorialWizardDialog.kt
@@ -61,7 +61,7 @@ fun tutorialWizardDialog(
     onSkip: () -> Unit,
 ) {
     var currentStep by remember { mutableStateOf(0) }
-    val totalSteps = 4
+    val totalSteps = 3
     val scrollState = rememberScrollState()
 
     Dialog(onDismissRequest = { /* Prevent dismissal */ }) {
@@ -111,8 +111,7 @@ fun tutorialWizardDialog(
                         when (currentStep) {
                             0 -> tutorialStepQuickStart()
                             1 -> tutorialStepProjects()
-                            2 -> tutorialStepShortcuts()
-                            3 -> tutorialStepNextSteps()
+                            2 -> tutorialStepNextSteps()
                         }
                     }
 
@@ -282,32 +281,6 @@ private fun tutorialStepProjects() {
 }
 
 @Composable
-private fun tutorialStepShortcuts() {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(Spacing.medium),
-    ) {
-        Text(
-            text = stringResource("tutorial.step3.title"),
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.SemiBold,
-        )
-
-        Text(
-            text = stringResource("tutorial.step3.description"),
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        Spacer(modifier = Modifier.height(Spacing.small))
-
-        tutorialShortcutCard("tutorial.step3.shortcut.new.chat")
-        tutorialShortcutCard("tutorial.step3.shortcut.search")
-        tutorialShortcutCard("tutorial.step3.shortcut.projects")
-        tutorialShortcutCard("tutorial.step3.shortcut.settings")
-    }
-}
-
-@Composable
 private fun tutorialStepNextSteps() {
     val uriHandler = LocalUriHandler.current
 
@@ -390,39 +363,6 @@ private fun tutorialFeatureCard(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        }
-    }
-}
-
-@Composable
-private fun tutorialShortcutCard(key: String) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(Spacing.large),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(key),
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ),
-            ) {
-                Text(
-                    text = stringResource("$key.key"),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                )
-            }
         }
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -120,26 +120,7 @@ data class IndexingConfig(
     ),
     @field:JsonDeserialize(using = CommaSeparatedSetDeserializer::class)
     @field:JsonAlias("binaryExtensions")
-    val binaryExtensions: Set<String> = setOf(
-        // Images
-        "png", "jpg", "jpeg", "gif", "svg", "ico", "webp", "bmp", "tiff", "tif",
-        // Videos
-        "mp4", "avi", "mov", "mkv", "webm", "flv", "wmv", "m4v",
-        // Audio
-        "mp3", "wav", "ogg", "flac", "aac", "m4a", "wma",
-        // Archives
-        "zip", "tar", "gz", "bz2", "7z", "rar", "xz", "tgz",
-        // Executables
-        "exe", "dll", "so", "dylib", "bin", "obj", "o", "a", "lib",
-        // Databases
-        "db", "sqlite", "sqlite3", "mdb", "accdb",
-        // Documents (binary formats - now excluding pdf as we can extract text from it)
-        "doc", "docx", "xls", "xlsx", "ppt", "pptx",
-        // Fonts
-        "ttf", "otf", "woff", "woff2", "eot",
-        // Other binary
-        "class", "jar", "war", "ear", "pyc", "pyo",
-    ),
+    val binaryExtensions: Set<String> = setOf(),
     @field:JsonDeserialize(using = CommaSeparatedSetDeserializer::class)
     @field:JsonAlias("excludeFileNames")
     val excludeFileNames: Set<String> = setOf(
@@ -296,19 +277,6 @@ data class ChatConfig(
 )
 
 /**
- * Backup and restore configuration
- */
-// TODO: Remove @field:JsonAlias camelCase aliases in v1.2.25 - kept for backward compatibility with pre-snake_case config files
-data class BackupConfig(
-    @field:JsonAlias("autoBackupEnabled") val autoBackupEnabled: Boolean = true,
-    @field:JsonAlias("autoBackupOnStartup") val autoBackupOnStartup: Boolean = false,
-    @field:JsonAlias("autoBackupIntervalHours") val autoBackupIntervalHours: Int = 24,
-    @field:JsonAlias("maxAutoBackupsToKeep") val maxAutoBackupsToKeep: Int = 5,
-    @field:JsonAlias("createBackupOnUpgrade") val createBackupOnUpgrade: Boolean = true,
-    @field:JsonAlias("createBackupBeforeRestore") val createBackupBeforeRestore: Boolean = true,
-)
-
-/**
  * RAG (Retrieval-Augmented Generation) configuration.
  * Controls how relevant documents are retrieved from the knowledge base.
  */
@@ -380,7 +348,6 @@ data class AppConfigData(
     val indexing: IndexingConfig = IndexingConfig(),
     val developer: DeveloperConfig = DeveloperConfig(),
     val chat: ChatConfig = ChatConfig(),
-    val backup: BackupConfig = BackupConfig(),
     val rag: RagConfig = RagConfig(),
     val models: ModelsConfig = ModelsConfig(),
     val proxy: ProxyConfig = ProxyConfig(),
@@ -393,7 +360,6 @@ object AppConfig {
     val indexing: IndexingConfig get() = delegate.indexing
     val developer: DeveloperConfig get() = delegate.developer
     val chat: ChatConfig get() = delegate.chat
-    val backup: BackupConfig get() = delegate.backup
     val rag: RagConfig get() = delegate.rag
     val models: ModelsConfig get() = delegate.models
     val context: AppContextParams get() = delegate.context
@@ -502,7 +468,6 @@ object AppConfig {
           default_response_ai_locale:    ${'$'}{ASKIMO_CHAT_DEFAULT_RESPONSE_LOCALE:}
           sampling:
             temperature: ${'$'}{ASKIMO_CHAT_SAMPLING_TEMPERATURE:1.0}
-            top_p:       ${'$'}{ASKIMO_CHAT_SAMPLING_TOP_P:1.0}
             enabled:     ${'$'}{ASKIMO_CHAT_SAMPLING_ENABLED:true}
 
         rag:
@@ -511,14 +476,6 @@ object AppConfig {
           hybrid_max_results:             ${'$'}{ASKIMO_RAG_HYBRID_MAX_RESULTS:15}
           rank_fusion_constant:           ${'$'}{ASKIMO_RAG_RANK_FUSION_CONSTANT:60}
           use_absolute_path_in_citations: ${'$'}{ASKIMO_RAG_USE_ABSOLUTE_PATH:true}
-
-        backup:
-          auto_backup_enabled:          ${'$'}{ASKIMO_BACKUP_AUTO_ENABLED:true}
-          auto_backup_on_startup:       ${'$'}{ASKIMO_BACKUP_ON_STARTUP:false}
-          auto_backup_interval_hours:   ${'$'}{ASKIMO_BACKUP_INTERVAL_HOURS:24}
-          max_auto_backups_to_keep:     ${'$'}{ASKIMO_BACKUP_MAX_TO_KEEP:5}
-          create_backup_on_upgrade:     ${'$'}{ASKIMO_BACKUP_ON_UPGRADE:true}
-          create_backup_before_restore: ${'$'}{ASKIMO_BACKUP_BEFORE_RESTORE:true}
 
         models:
           anthropic:
@@ -662,12 +619,6 @@ object AppConfig {
             "enableAsyncSummarization:" to "enable_async_summarization:",
             "summarizationTimeoutSeconds:" to "summarization_timeout_seconds:",
             "defaultResponseAILocale:" to "default_response_ai_locale:",
-            "autoBackupEnabled:" to "auto_backup_enabled:",
-            "autoBackupOnStartup:" to "auto_backup_on_startup:",
-            "autoBackupIntervalHours:" to "auto_backup_interval_hours:",
-            "maxAutoBackupsToKeep:" to "max_auto_backups_to_keep:",
-            "createBackupOnUpgrade:" to "create_backup_on_upgrade:",
-            "createBackupBeforeRestore:" to "create_backup_before_restore:",
             "vectorSearchMaxResults:" to "vector_search_max_results:",
             "vectorSearchMinScore:" to "vector_search_min_score:",
             "hybridMaxResults:" to "hybrid_max_results:",
@@ -936,7 +887,7 @@ object AppConfig {
                 maxFileBytes = envLong("ASKIMO_EMBED_MAX_FILE_BYTES", 2_000_000L),
                 concurrentIndexingThreads = envInt("ASKIMO_INDEXING_CONCURRENT_THREADS", 10),
                 supportedExtensions = envList("ASKIMO_INDEXING_SUPPORTED_EXTENSIONS", "java,kt,kts,py,js,ts,jsx,tsx,go,rs,c,cpp,h,hpp,cs,rb,php,swift,scala,groovy,sh,bash,yaml,yml,json,xml,md,txt,gradle,properties,toml,pdf"),
-                binaryExtensions = envList("ASKIMO_INDEXING_BINARY_EXTENSIONS", "png,jpg,jpeg,gif,svg,ico,webp,bmp,mp4,avi,mov,mkv,mp3,wav,ogg,flac,zip,tar,gz,7z,rar,exe,dll,so,dylib,bin,db,sqlite,pdf,doc,docx,xls,xlsx,ppt,pptx,ttf,otf,woff,woff2,class,jar,pyc"),
+                binaryExtensions = envList("ASKIMO_INDEXING_BINARY_EXTENSIONS", "png,jpg,jpeg,gif,svg,ico,webp,bmp,mp4,avi,mov,mkv,mp3,wav,ogg,flac,zip,tar,gz,7z,rar,exe,dll,so,dylib,bin,db,sqlite,doc,docx,xls,xlsx,ppt,pptx,ttf,otf,woff,woff2,class,jar,pyc"),
                 excludeFileNames = envList("ASKIMO_INDEXING_EXCLUDE_FILE_NAMES", ".DS_Store,Thumbs.db,desktop.ini,package-lock.json,yarn.lock,pnpm-lock.yaml,poetry.lock,Gemfile.lock"),
                 commonExcludes = envList("ASKIMO_INDEXING_COMMON_EXCLUDES", ".git/,.svn/,.hg/,.idea/,.vscode/,.DS_Store,*.log,*.tmp,*.temp,*.swp,*.bak,.history/"),
                 filters = FilterConfig(
@@ -967,16 +918,6 @@ object AppConfig {
                     temperature = envDouble("ASKIMO_CHAT_SAMPLING_TEMPERATURE", 1.0),
                     enabled = System.getenv("ASKIMO_CHAT_SAMPLING_ENABLED")?.toBoolean() ?: true,
                 ),
-            )
-
-        val backup =
-            BackupConfig(
-                autoBackupEnabled = System.getenv("ASKIMO_BACKUP_AUTO_ENABLED")?.toBoolean() ?: true,
-                autoBackupOnStartup = System.getenv("ASKIMO_BACKUP_ON_STARTUP")?.toBoolean() ?: false,
-                autoBackupIntervalHours = envInt("ASKIMO_BACKUP_INTERVAL_HOURS", 24),
-                maxAutoBackupsToKeep = envInt("ASKIMO_BACKUP_MAX_TO_KEEP", 5),
-                createBackupOnUpgrade = System.getenv("ASKIMO_BACKUP_ON_UPGRADE")?.toBoolean() ?: true,
-                createBackupBeforeRestore = System.getenv("ASKIMO_BACKUP_BEFORE_RESTORE")?.toBoolean() ?: true,
             )
 
         val rag =
@@ -1057,7 +998,7 @@ object AppConfig {
                 password = env("ASKIMO_PROXY_PASSWORD", ""),
             )
 
-        return AppConfigData(emb, r, t, idx, dev, chat, backup, rag, models, proxy)
+        return AppConfigData(emb, r, t, idx, dev, chat, rag, models, proxy)
     }
 
     /**
@@ -1112,7 +1053,6 @@ object AppConfig {
                 "throttle" -> current.copy(throttle = updateThrottleField(current.throttle, field, value))
                 "embedding" -> current.copy(embedding = updateEmbeddingField(current.embedding, field, value))
                 "chat" -> current.copy(chat = updateChatField(current.chat, field, value))
-                "backup" -> current.copy(backup = updateBackupField(current.backup, field, value))
                 "rag" -> current.copy(rag = updateRagField(current.rag, field, value))
                 "models" -> current.copy(models = updateModelsField(current.models, field, value))
                 "proxy" -> current.copy(proxy = updateProxyField(current.proxy, field, value))
@@ -1173,16 +1113,6 @@ object AppConfig {
             )
             config.copy(defaultResponseAILocale = newLocale)
         }
-        else -> config
-    }
-
-    private fun updateBackupField(config: BackupConfig, field: String, value: Any): BackupConfig = when (field) {
-        "autoBackupEnabled" -> config.copy(autoBackupEnabled = value as Boolean)
-        "autoBackupOnStartup" -> config.copy(autoBackupOnStartup = value as Boolean)
-        "autoBackupIntervalHours" -> config.copy(autoBackupIntervalHours = value as Int)
-        "maxAutoBackupsToKeep" -> config.copy(maxAutoBackupsToKeep = value as Int)
-        "createBackupOnUpgrade" -> config.copy(createBackupOnUpgrade = value as Boolean)
-        "createBackupBeforeRestore" -> config.copy(createBackupBeforeRestore = value as Boolean)
         else -> config
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProviderRegistry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/IndexingCoordinatorProviderRegistry.kt
@@ -5,6 +5,7 @@
 package io.askimo.core.rag.indexing
 
 import io.askimo.core.chat.domain.KnowledgeSourceConfig
+import io.askimo.core.logging.logger
 import io.askimo.core.rag.indexing.providers.LocalFilesIndexingProvider
 import io.askimo.core.rag.indexing.providers.LocalFoldersIndexingProvider
 import io.askimo.core.rag.indexing.providers.UrlIndexingProvider
@@ -23,6 +24,8 @@ import java.util.concurrent.ConcurrentHashMap
  */
 object IndexingCoordinatorProviderRegistry {
     private val providers = ConcurrentHashMap<Class<out KnowledgeSourceConfig>, IndexingCoordinatorProvider>()
+
+    private val log = logger<IndexingCoordinatorProvider>()
 
     @Volatile
     private var initialized = false
@@ -58,6 +61,7 @@ object IndexingCoordinatorProviderRegistry {
         registerProvider(LocalFoldersIndexingProvider())
         registerProvider(LocalFilesIndexingProvider())
         registerProvider(UrlIndexingProvider())
+        log.debug("Registered built-in ${providers.size} providers")
     }
 
     /**

--- a/shared/src/test/kotlin/io/askimo/core/rag/filter/FilterChainTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/rag/filter/FilterChainTest.kt
@@ -5,6 +5,7 @@
 package io.askimo.core.rag.filter
 
 import io.askimo.core.config.AppConfig
+import io.askimo.test.extensions.AskimoTestHome
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -15,6 +16,7 @@ import kotlin.io.path.writeText
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@AskimoTestHome
 class FilterChainTest {
 
     @TempDir

--- a/shared/src/test/kotlin/io/askimo/core/rag/filter/ProjectTypeFilterTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/rag/filter/ProjectTypeFilterTest.kt
@@ -5,6 +5,7 @@
 package io.askimo.core.rag.filter
 
 import io.askimo.core.config.ProjectType
+import io.askimo.test.extensions.AskimoTestHome
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 
+@AskimoTestHome
 class ProjectTypeFilterTest {
 
     @Test

--- a/shared/src/test/kotlin/io/askimo/core/vision/ImageProcessorTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/vision/ImageProcessorTest.kt
@@ -27,7 +27,7 @@ class ImageProcessorTest {
         Assertions.assertTrue(result.processedHeight!! <= ImageProcessor.DEFAULT_MAX_HEIGHT)
 
         // Aspect ratio should be maintained (4:3)
-        val aspectRatio = result.processedWidth!!.toDouble() / result.processedHeight!!
+        val aspectRatio = result.processedWidth.toDouble() / result.processedHeight
         Assertions.assertEquals(4.0 / 3.0, aspectRatio, 0.01)
     }
 


### PR DESCRIPTION
- Create GlobalErrorHandler to centralise error event handling
- Shift error dialog parameters into ErrorDialogState for a cleaner API
- Update Main.kt to construct and clear dialog state properly
- Refine UI: replace link color with onSurface and reduce tutorial wizard steps
- Extend configuration with new binary extensions and backup defaults
- Add shared test extensions and a new CI workflow for shared tests