### PR TITLE
refactor: overhaul utility model handling and HTTP helpers

### DIFF
--- a/cli/src/main/kotlin/io/askimo/cli/commands/SetParamCommandHandler.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/commands/SetParamCommandHandler.kt
@@ -61,8 +61,6 @@ class SetParamCommandHandler(
                     .getOrPut(provider) { factory.defaultSettings() }
 
             key.applyTo(appContext.params, providerSettings, valueInput)
-
-            appContext.params.providerSettings[provider] = providerSettings
             appContext.save()
 
             CoroutineScope(Dispatchers.Default).launch {

--- a/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
@@ -15,8 +15,12 @@ import io.askimo.core.config.IndexingConfig
 import io.askimo.core.config.RetryConfig
 import io.askimo.core.config.ThrottleConfig
 import io.askimo.core.context.AppContextParams
+import io.askimo.core.context.ParamKey
+import io.askimo.core.providers.HasApiKey
+import io.askimo.core.providers.HasBaseUrl
 import io.askimo.core.providers.NoopProviderSettings
 import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.providers.SettingField
 import io.askimo.core.providers.anthropic.AnthropicSettings
 import io.askimo.core.providers.docker.DockerAiSettings
 import io.askimo.core.providers.gemini.GeminiSettings
@@ -48,7 +52,11 @@ class AskimoFeature : Feature {
             ThrottleConfig::class.java,
             IndexingConfig::class.java,
             AppContextParams::class.java,
+            ParamKey::class.java,
             ProviderSettings::class.java,
+            HasApiKey::class.java,
+            HasBaseUrl::class.java,
+            SettingField::class.java,
             OpenAiSettings::class.java,
             AnthropicSettings::class.java,
             GeminiSettings::class.java,

--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -2804,7 +2804,6 @@
           "io.askimo.core.config.IndexingConfig",
           "io.askimo.core.config.DeveloperConfig",
           "io.askimo.core.config.ChatConfig",
-          "io.askimo.core.config.BackupConfig",
           "io.askimo.core.config.RagConfig",
           "io.askimo.core.config.ModelsConfig",
           "io.askimo.core.config.ProxyConfig",
@@ -2820,7 +2819,6 @@
           "io.askimo.core.config.IndexingConfig",
           "io.askimo.core.config.DeveloperConfig",
           "io.askimo.core.config.ChatConfig",
-          "io.askimo.core.config.BackupConfig",
           "io.askimo.core.config.RagConfig",
           "io.askimo.core.config.ModelsConfig",
           "io.askimo.core.config.ProxyConfig",
@@ -2829,7 +2827,6 @@
           "kotlin.jvm.internal.DefaultConstructorMarker"
         ]
       },
-      { "name": "getBackup", "parameterTypes": [] },
       { "name": "getChat", "parameterTypes": [] },
       { "name": "getContext", "parameterTypes": [] },
       { "name": "getDeveloper", "parameterTypes": [] },
@@ -2943,44 +2940,6 @@
         "name": "updateRagField should handle useAbsolutePathInCitations",
         "parameterTypes": []
       }
-    ]
-  },
-  {
-    "name": "io.askimo.core.config.BackupConfig",
-    "allDeclaredFields": true,
-    "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true,
-    "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "boolean",
-          "boolean",
-          "int",
-          "int",
-          "boolean",
-          "boolean"
-        ]
-      },
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "boolean",
-          "boolean",
-          "int",
-          "int",
-          "boolean",
-          "boolean",
-          "int",
-          "kotlin.jvm.internal.DefaultConstructorMarker"
-        ]
-      },
-      { "name": "getAutoBackupEnabled", "parameterTypes": [] },
-      { "name": "getAutoBackupIntervalHours", "parameterTypes": [] },
-      { "name": "getAutoBackupOnStartup", "parameterTypes": [] },
-      { "name": "getCreateBackupBeforeRestore", "parameterTypes": [] },
-      { "name": "getCreateBackupOnUpgrade", "parameterTypes": [] },
-      { "name": "getMaxAutoBackupsToKeep", "parameterTypes": [] }
     ]
   },
   {
@@ -3419,15 +3378,7 @@
     "queryAllDeclaredMethods": true,
     "queryAllDeclaredConstructors": true,
     "methods": [
-      {
-        "name": "<init>",
-        "parameterTypes": [
-          "int",
-          "io.askimo.core.providers.ModelProvider",
-          "java.util.Map",
-          "kotlinx.serialization.internal.SerializationConstructorMarker"
-        ]
-      },
+      { "name": "<init>", "parameterTypes": [] },
       {
         "name": "<init>",
         "parameterTypes": [
@@ -3453,9 +3404,6 @@
       },
       { "name": "setModel", "parameterTypes": ["java.lang.String"] }
     ]
-  },
-  {
-    "name": "io.askimo.core.context.AppContextParams$$serializer"
   },
   {
     "name": "io.askimo.core.context.AppContextParams$Companion"
@@ -4560,7 +4508,7 @@
     ]
   },
   {
-    "name": "io.askimo.core.providers.ChatClient$MockitoMock$IF65kB5h",
+    "name": "io.askimo.core.providers.ChatClient$MockitoMock$0PyMcV5P",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
@@ -4794,27 +4742,12 @@
     "methods": [
       {
         "name": "<init>",
-        "parameterTypes": [
-          "int",
-          "java.lang.String",
-          "java.lang.String",
-          "kotlinx.serialization.internal.SerializationConstructorMarker"
-        ]
-      },
-      {
-        "name": "<init>",
         "parameterTypes": ["java.lang.String", "java.lang.String"]
       },
       { "name": "getApiKey", "parameterTypes": [] },
       { "name": "getDefaultModel", "parameterTypes": [] },
       { "name": "setApiKey", "parameterTypes": ["java.lang.String"] }
     ]
-  },
-  {
-    "name": "io.askimo.core.providers.openai.OpenAiSettings$$serializer"
-  },
-  {
-    "name": "io.askimo.core.providers.openai.OpenAiSettings$Companion"
   },
   {
     "name": "io.askimo.core.providers.xai.XAiModelFactoryTest",
@@ -6934,7 +6867,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$BZYu1Jix",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$lxecrjiJ",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/cli/src/test/kotlin/io/askimo/core/config/AppConfigTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/config/AppConfigTest.kt
@@ -36,28 +36,28 @@ class AppConfigTest {
         assertTrue(models[ModelProvider.OLLAMA].availableModels.isEmpty())
 
         // Anthropic
-        assertEquals("claude-sonnet-4-6", models[ModelProvider.ANTHROPIC].utilityModel)
+        assertEquals("", models[ModelProvider.ANTHROPIC].utilityModel)
         assertEquals("claude-sonnet-4-6", models[ModelProvider.ANTHROPIC].visionModel)
         assertEquals("claude-sonnet-4-6", models[ModelProvider.ANTHROPIC].imageModel)
         assertEquals(45L, models[ModelProvider.ANTHROPIC].utilityModelTimeoutSeconds)
         assertEquals(listOf("claude-opus-4-6", "claude-sonnet-4-6"), models[ModelProvider.ANTHROPIC].availableModels)
 
         // Gemini
-        assertEquals("gemini-2.5-flash-lite", models[ModelProvider.GEMINI].utilityModel)
+        assertEquals("", models[ModelProvider.GEMINI].utilityModel)
         assertEquals("gemini-embedding-001", models[ModelProvider.GEMINI].embeddingModel)
         assertEquals("gemini-1.5-pro", models[ModelProvider.GEMINI].visionModel)
         assertEquals("gemini-2.0-flash-exp", models[ModelProvider.GEMINI].imageModel)
         assertTrue(models[ModelProvider.GEMINI].availableModels.isEmpty())
 
         // OpenAI
-        assertEquals("gpt-3.5-turbo", models[ModelProvider.OPENAI].utilityModel)
+        assertEquals("", models[ModelProvider.OPENAI].utilityModel)
         assertEquals("text-embedding-3-small", models[ModelProvider.OPENAI].embeddingModel)
         assertEquals("gpt-4o", models[ModelProvider.OPENAI].visionModel)
         assertEquals("dall-e-3", models[ModelProvider.OPENAI].imageModel)
         assertTrue(models[ModelProvider.OPENAI].availableModels.isEmpty())
 
         // XAI
-        assertEquals("grok-3-mini", models[ModelProvider.XAI].utilityModel)
+        assertEquals("", models[ModelProvider.XAI].utilityModel)
         assertEquals("grok-2-vision-latest", models[ModelProvider.XAI].visionModel)
         assertEquals("grok-2-vision-latest", models[ModelProvider.XAI].imageModel)
         assertTrue(models[ModelProvider.XAI].availableModels.isEmpty())

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatViewModel.kt
@@ -992,9 +992,20 @@ class ChatViewModel(
      * Note: A new session will be created automatically when the first message is sent.
      */
     fun clearChat() {
+        // Cancel any in-flight streaming for the previous session so it does not
+        // bleed its isLoading / isThinking state into the new blank session.
+        currentJob?.cancel()
+        currentJob = null
+        activeSubscriptions.values.forEach { it.cancel() }
+        activeSubscriptions.clear()
+        stopThinkingTimer()
+
         messages = listOf()
         errorMessage = null
         currentResponse = ""
+        isLoading = false
+        isThinking = false
+        thinkingElapsedSeconds = 0
 
         // Reset pagination state
         currentCursor = null

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -469,21 +469,21 @@ object AppConfig {
         models:
           anthropic:
             available_models: ${'$'}{ASKIMO_ANTHROPIC_MODELS:claude-opus-4-6,claude-sonnet-4-6}
-            utility_model: ${'$'}{ASKIMO_ANTHROPIC_UTILITY_MODEL:claude-sonnet-4-6}
+            utility_model: ${'$'}{ASKIMO_ANTHROPIC_UTILITY_MODEL:}
             utility_model_timeout_seconds: ${'$'}{ASKIMO_ANTHROPIC_UTILITY_TIMEOUT:45}
             embedding_model: ${'$'}{ASKIMO_ANTHROPIC_EMBEDDING_MODEL:}
             vision_model: ${'$'}{ASKIMO_ANTHROPIC_VISION_MODEL:claude-sonnet-4-6}
             image_model: ${'$'}{ASKIMO_ANTHROPIC_IMAGE_MODEL:claude-sonnet-4-6}
           gemini:
             available_models: ${'$'}{ASKIMO_GEMINI_MODELS:}
-            utility_model: ${'$'}{ASKIMO_GEMINI_UTILITY_MODEL:gemini-2.5-flash-lite}
+            utility_model: ${'$'}{ASKIMO_GEMINI_UTILITY_MODEL:}
             utility_model_timeout_seconds: ${'$'}{ASKIMO_GEMINI_UTILITY_TIMEOUT:45}
             embedding_model: ${'$'}{ASKIMO_GEMINI_EMBEDDING_MODEL:gemini-embedding-001}
             vision_model: ${'$'}{ASKIMO_GEMINI_VISION_MODEL:gemini-1.5-pro}
             image_model: ${'$'}{ASKIMO_GEMINI_IMAGE_MODEL:gemini-2.0-flash-exp}
           openai:
             available_models: ${'$'}{ASKIMO_OPENAI_MODELS:}
-            utility_model: ${'$'}{ASKIMO_OPENAI_UTILITY_MODEL:gpt-3.5-turbo}
+            utility_model: ${'$'}{ASKIMO_OPENAI_UTILITY_MODEL:}
             utility_model_timeout_seconds: ${'$'}{ASKIMO_OPENAI_UTILITY_TIMEOUT:45}
             embedding_model: ${'$'}{ASKIMO_OPENAI_EMBEDDING_MODEL:text-embedding-3-small}
             vision_model: ${'$'}{ASKIMO_OPENAI_VISION_MODEL:gpt-4o}
@@ -518,7 +518,7 @@ object AppConfig {
             image_model: ${'$'}{ASKIMO_LMSTUDIO_IMAGE_MODEL:stable-diffusion}
           xai:
             available_models: ${'$'}{ASKIMO_XAI_MODELS:}
-            utility_model: ${'$'}{ASKIMO_XAI_UTILITY_MODEL:grok-3-mini}
+            utility_model: ${'$'}{ASKIMO_XAI_UTILITY_MODEL:}
             utility_model_timeout_seconds: ${'$'}{ASKIMO_XAI_UTILITY_TIMEOUT:45}
             embedding_model: ${'$'}{ASKIMO_XAI_EMBEDDING_MODEL:}
             vision_model: ${'$'}{ASKIMO_XAI_VISION_MODEL:grok-2-vision-latest}

--- a/shared/src/main/kotlin/io/askimo/core/context/AppContextParams.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/AppContextParams.kt
@@ -8,9 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.SettingField
-import kotlinx.serialization.Serializable
 
-@Serializable
 data class AppContextParams(
     /**
      * The currently active model provider.

--- a/shared/src/main/kotlin/io/askimo/core/providers/LocalModelValidator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/LocalModelValidator.kt
@@ -5,8 +5,8 @@
 package io.askimo.core.providers
 
 import io.askimo.core.logging.logger
-import java.net.HttpURLConnection
-import java.net.URI
+import io.askimo.core.util.httpGet
+import io.askimo.core.util.httpPost
 
 /**
  * Result of checking if a model is available on a local provider
@@ -34,13 +34,6 @@ object LocalModelValidator {
     /**
      * Check if a model exists on the provider.
      * This is a generic method that works for both chat models and embedding models.
-     *
-     * @param provider The provider type
-     * @param baseUrl The base URL of the provider
-     * @param modelName The name of the model to check
-     * @param connectTimeoutMs Connection timeout in milliseconds
-     * @param readTimeoutMs Read timeout in milliseconds
-     * @return ModelAvailabilityResult indicating if the model is available
      */
     fun checkModelExists(
         provider: ModelProvider,
@@ -75,27 +68,24 @@ object LocalModelValidator {
         readTimeoutMs: Int,
         canAutoPull: Boolean,
     ): ModelAvailabilityResult {
-        try {
-            val url = URI("${baseUrl.removeSuffix("/")}$apiPath").toURL()
-            val conn = (url.openConnection() as HttpURLConnection).apply {
-                this.connectTimeout = connectTimeoutMs
-                this.readTimeout = readTimeoutMs
-                requestMethod = "GET"
-                doInput = true
-            }
+        return try {
+            val url = "${baseUrl.removeSuffix("/")}$apiPath"
+            val (statusCode, body) = httpGet(
+                url = url,
+                connectTimeoutMs = connectTimeoutMs.toLong(),
+                readTimeoutMs = readTimeoutMs.toLong(),
+            )
 
-            val responseCode = conn.responseCode
-            if (responseCode !in 200..299) {
+            if (statusCode !in 200..299) {
                 return ModelAvailabilityResult.ProviderUnreachable(
                     baseUrl = baseUrl,
-                    error = "Cannot connect to $providerName at $baseUrl (HTTP $responseCode)",
+                    error = "Cannot connect to $providerName at $baseUrl (HTTP $statusCode)",
                 )
             }
 
-            val response = conn.inputStream.bufferedReader().use { it.readText() }
-            val hasModel = response.contains("\"id\":\"$modelName\"") || response.contains("\"id\": \"$modelName\"")
+            val hasModel = body.contains("\"id\":\"$modelName\"") || body.contains("\"id\": \"$modelName\"")
 
-            return if (hasModel) {
+            if (hasModel) {
                 ModelAvailabilityResult.Available
             } else {
                 ModelAvailabilityResult.NotAvailable(
@@ -105,7 +95,7 @@ object LocalModelValidator {
             }
         } catch (e: Exception) {
             log.error("Error checking $providerName model: ${e.message}", e)
-            return ModelAvailabilityResult.ProviderUnreachable(
+            ModelAvailabilityResult.ProviderUnreachable(
                 baseUrl = baseUrl,
                 error = e.message ?: "Unknown error",
             )
@@ -121,24 +111,15 @@ object LocalModelValidator {
         connectTimeoutMs: Int = 15_000,
         readTimeoutMs: Int = 600_000,
     ): Boolean = try {
-        val url = URI("${baseUrl.removeSuffix("/")}/api/pull").toURL()
-        val conn = (url.openConnection() as HttpURLConnection).apply {
-            this.connectTimeout = connectTimeoutMs
-            this.readTimeout = readTimeoutMs
-            requestMethod = "POST"
-            doOutput = true
-            setRequestProperty("Content-Type", "application/json")
-        }
-
+        val url = "${baseUrl.removeSuffix("/")}/api/pull"
         val payload = """{"name":"$modelName","stream":false}"""
-        conn.outputStream.use { it.write(payload.toByteArray()) }
-
-        val code = conn.responseCode
-        (if (code in 200..299) conn.inputStream else conn.errorStream)
-            ?.bufferedReader()
-            ?.use { it.readText() }
-
-        code in 200..299
+        val (statusCode, _) = httpPost(
+            url = url,
+            body = payload,
+            connectTimeoutMs = connectTimeoutMs.toLong(),
+            readTimeoutMs = readTimeoutMs.toLong(),
+        )
+        statusCode in 200..299
     } catch (e: Exception) {
         log.error("Failed to pull Ollama model $modelName from $baseUrl: ${e.message}", e)
         false

--- a/shared/src/main/kotlin/io/askimo/core/providers/ProviderModelUtils.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ProviderModelUtils.kt
@@ -9,12 +9,11 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage
 import io.askimo.core.logging.displayError
 import io.askimo.core.logging.logger
 import io.askimo.core.util.appJson
+import io.askimo.core.util.httpGet
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import java.net.HttpURLConnection
-import java.net.URI
 
 object ProviderModelUtils {
     private val log = logger<ProviderModelUtils>()
@@ -39,23 +38,13 @@ object ProviderModelUtils {
         url: String,
         providerName: ModelProvider,
     ): List<String> = try {
-        val uri = URI(url).toURL()
-        val connection = uri.openConnection() as HttpURLConnection
-        connection.requestMethod = "GET"
-        connection.setRequestProperty("Authorization", "Bearer $apiKey")
-        connection.setRequestProperty("Content-Type", "application/json")
-
-        connection.inputStream.bufferedReader().use { reader ->
-            val jsonElement = appJson.parseToJsonElement(reader.readText())
-
-            val data = jsonElement.jsonObject["data"]?.jsonArray.orEmpty()
-
-            data
-                .mapNotNull { element ->
-                    element.jsonObject["id"]?.jsonPrimitive?.contentOrNull
-                }.distinct()
-                .sorted()
-        }
+        val (_, body) = httpGet(url, headers = mapOf("Authorization" to "Bearer $apiKey"))
+        val jsonElement = appJson.parseToJsonElement(body)
+        val data = jsonElement.jsonObject["data"]?.jsonArray.orEmpty()
+        data
+            .mapNotNull { it.jsonObject["id"]?.jsonPrimitive?.contentOrNull }
+            .distinct()
+            .sorted()
     } catch (e: Exception) {
         log.displayError("⚠️ Failed to fetch models from $providerName: ${e.message}", e)
         emptyList()

--- a/shared/src/main/kotlin/io/askimo/core/providers/SettingField.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/SettingField.kt
@@ -15,7 +15,6 @@ sealed class SettingField {
     companion object {
         const val API_KEY = "apiKey"
         const val BASE_URL = "baseUrl"
-        const val STYLE = "style"
         const val DEFAULT_MODEL = "defaultModel"
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -87,10 +87,13 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
 
+        val modelName = AppConfig.models[ModelProvider.ANTHROPIC].utilityModel
+            .ifBlank { settings.defaultModel }
+
         return AnthropicChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[ModelProvider.ANTHROPIC].utilityModel)
+            .modelName(modelName)
             .baseUrl(settings.baseUrl)
             .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.ANTHROPIC].utilityModelTimeoutSeconds))
             .build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicSettings.kt
@@ -8,14 +8,11 @@ import io.askimo.core.providers.HasApiKey
 import io.askimo.core.providers.ProviderConfigField
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.SettingField
-import kotlinx.serialization.Serializable
 
-@Serializable
 data class AnthropicSettings(
     val baseUrl: String = "https://api.anthropic.com/v1",
     override var apiKey: String = "",
     override val defaultModel: String = "",
-    val enableAiSummarization: Boolean = true,
 ) : ProviderSettings,
     HasApiKey {
     override fun describe(): List<String> = listOf(

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -107,10 +107,13 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
 
+        val modelName = AppConfig.models[GEMINI].utilityModel
+            .ifBlank { settings.defaultModel }
+
         return GoogleAiGeminiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[GEMINI].utilityModel)
+            .modelName(modelName)
             .timeout(Duration.ofSeconds(AppConfig.models[GEMINI].utilityModelTimeoutSeconds))
             .build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiSettings.kt
@@ -15,7 +15,6 @@ data class GeminiSettings(
     val baseUrl: String = "https://generativelanguage.googleapis.com/v1beta/openai",
     override var apiKey: String = "",
     override val defaultModel: String = "",
-    val enableAiSummarization: Boolean = true,
 ) : ProviderSettings,
     HasApiKey {
     override fun describe(): List<String> = listOf(

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
@@ -111,7 +111,7 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
             .apiKey("localai")
-            .modelName(AppConfig.models[LOCALAI].utilityModel.ifBlank { AppContext.getInstance().params.model })
+            .modelName(AppConfig.models[LOCALAI].utilityModel.ifBlank { settings.defaultModel })
             .timeout(Duration.ofSeconds(AppConfig.models[LOCALAI].utilityModelTimeoutSeconds))
             .build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -116,7 +116,7 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
             .apiKey("ollama")
-            .modelName(AppConfig.models[ModelProvider.OLLAMA].utilityModel.ifBlank { AppContext.getInstance().params.model })
+            .modelName(AppConfig.models[ModelProvider.OLLAMA].utilityModel.ifBlank { settings.defaultModel })
             .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.OLLAMA].utilityModelTimeoutSeconds))
             .logger(log)
             .logRequests(log.isDebugEnabled)

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -111,11 +111,13 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
     private fun createSecondaryChatModel(settings: OpenAiSettings): ChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val modelName = AppConfig.models[OPENAI].utilityModel
+            .ifBlank { settings.defaultModel }
 
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[OPENAI].utilityModel)
+            .modelName(modelName)
             .timeout(Duration.ofSeconds(AppConfig.models[OPENAI].utilityModelTimeoutSeconds))
             .build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
@@ -8,9 +8,7 @@ import io.askimo.core.providers.HasApiKey
 import io.askimo.core.providers.ProviderConfigField
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.SettingField
-import kotlinx.serialization.Serializable
 
-@Serializable
 data class OpenAiSettings(
     override var apiKey: String = "",
     override val defaultModel: String = "",

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
@@ -93,7 +93,7 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
     ): ImageModel = OpenAiImageModel.builder()
         .baseUrl(settings.baseUrl)
         .apiKey(safeApiKey(settings.apiKey))
-        .modelName(AppConfig.models[ModelProvider.XAI].imageModel)
+        .modelName(AppConfig.models[XAI].imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
         .logResponses(log.isTraceEnabled)
@@ -103,12 +103,15 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
 
+        val modelName = AppConfig.models[XAI].utilityModel
+            .ifBlank { settings.defaultModel }
+
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppContext.getInstance().params.model)
-            .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.XAI].utilityModelTimeoutSeconds))
+            .modelName(modelName)
+            .timeout(Duration.ofSeconds(AppConfig.models[XAI].utilityModelTimeoutSeconds))
             .build()
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/util/HttpUtils.kt
+++ b/shared/src/main/kotlin/io/askimo/core/util/HttpUtils.kt
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.util
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Perform a GET request to a local/remote URL with proxy support.
+ * Returns the HTTP status code and response body, or throws on connection failure.
+ */
+fun httpGet(
+    url: String,
+    headers: Map<String, String> = emptyMap(),
+    connectTimeoutMs: Long = 5_000,
+    readTimeoutMs: Long = 8_000,
+): Pair<Int, String> {
+    val client = ProxyUtil.configureProxy(HttpClient.newBuilder(), url)
+        .connectTimeout(Duration.ofMillis(connectTimeoutMs))
+        .build()
+    val requestBuilder = HttpRequest.newBuilder()
+        .uri(URI(url))
+        .timeout(Duration.ofMillis(readTimeoutMs))
+        .GET()
+    headers.forEach { (k, v) -> requestBuilder.header(k, v) }
+    val response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+    return response.statusCode() to response.body()
+}
+
+/**
+ * Perform a POST request with a JSON body to a local/remote URL with proxy support.
+ * Returns the HTTP status code and response body, or throws on connection failure.
+ */
+fun httpPost(
+    url: String,
+    body: String,
+    headers: Map<String, String> = emptyMap(),
+    connectTimeoutMs: Long = 15_000,
+    readTimeoutMs: Long = 600_000,
+): Pair<Int, String> {
+    val client = ProxyUtil.configureProxy(HttpClient.newBuilder(), url)
+        .connectTimeout(Duration.ofMillis(connectTimeoutMs))
+        .build()
+    val requestBuilder = HttpRequest.newBuilder()
+        .uri(URI(url))
+        .timeout(Duration.ofMillis(readTimeoutMs))
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(body))
+    headers.forEach { (k, v) -> requestBuilder.header(k, v) }
+    val response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
+    return response.statusCode() to response.body()
+}

--- a/shared/src/main/kotlin/io/askimo/core/util/Serialization.kt
+++ b/shared/src/main/kotlin/io/askimo/core/util/Serialization.kt
@@ -4,43 +4,10 @@
  */
 package io.askimo.core.util
 
-import io.askimo.core.providers.ProviderSettings
-import io.askimo.core.providers.anthropic.AnthropicSettings
-import io.askimo.core.providers.docker.DockerAiSettings
-import io.askimo.core.providers.gemini.GeminiSettings
-import io.askimo.core.providers.lmstudio.LmStudioSettings
-import io.askimo.core.providers.localai.LocalAiSettings
-import io.askimo.core.providers.ollama.OllamaSettings
-import io.askimo.core.providers.openai.OpenAiSettings
-import io.askimo.core.providers.xai.XAiSettings
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
 
-val coreProvidersModule =
-    SerializersModule {
-        polymorphic(ProviderSettings::class) {
-            subclass(OpenAiSettings::class, OpenAiSettings.serializer())
-            subclass(OllamaSettings::class, OllamaSettings.serializer())
-            subclass(DockerAiSettings::class, DockerAiSettings.serializer())
-            subclass(XAiSettings::class, XAiSettings.serializer())
-            subclass(GeminiSettings::class, GeminiSettings.serializer())
-            subclass(AnthropicSettings::class, AnthropicSettings.serializer())
-            subclass(LmStudioSettings::class, LmStudioSettings.serializer())
-            subclass(LocalAiSettings::class, LocalAiSettings.serializer())
-        }
-    }
-
-fun buildJson(vararg extraModules: SerializersModule): Json = Json {
+val appJson: Json = Json {
     prettyPrint = true
     encodeDefaults = true
     ignoreUnknownKeys = true
-    classDiscriminator = "__type" // -> "ollama"/"openai" in saved JSON
-    serializersModule =
-        SerializersModule {
-            include(coreProvidersModule)
-            extraModules.forEach { include(it) }
-        }
 }
-
-val appJson = buildJson()


### PR DESCRIPTION
- Replace legacy providerSettings usage with defaultModel fallback when utilityModel is blank
- Add HttpUtils providing httpGet and httpPost helpers
- Simplify LocalModelValidator to use HttpUtils and return status code check
- Update ProviderModelUtils to use HttpUtils and streamline data extraction
- Remove unnecessary SettingField constants and @Serializable annotations from settings
- Update AppConfig defaults: leave utility_model empty to trigger fallback
- Clean serialization: drop classDiscriminator for provider modules
- Adjust AskimoFeature to import new types and reflect-config entries
- Update tests to expect empty utilityModel defaults
- Minor code style and import cleanup across CLI, desktop, shared modules