### PR TITLE
feat(providers): add OpenAI‑compatible provider support

### DIFF
--- a/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
@@ -28,6 +28,7 @@ import io.askimo.core.providers.lmstudio.LmStudioSettings
 import io.askimo.core.providers.localai.LocalAiSettings
 import io.askimo.core.providers.ollama.OllamaSettings
 import io.askimo.core.providers.openai.OpenAiSettings
+import io.askimo.core.providers.openaicompatible.OpenAiCompatibleSettings
 import io.askimo.core.providers.xai.XAiSettings
 import io.askimo.tools.fs.LocalFsTools
 import io.askimo.tools.git.GitTools
@@ -65,6 +66,7 @@ class AskimoFeature : Feature {
             DockerAiSettings::class.java,
             LocalAiSettings::class.java,
             LmStudioSettings::class.java,
+            OpenAiCompatibleSettings::class.java,
             NoopProviderSettings::class.java,
         )
 

--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -3134,12 +3134,14 @@
           "io.askimo.core.config.ProviderModelConfig",
           "io.askimo.core.config.ProviderModelConfig",
           "io.askimo.core.config.ProviderModelConfig",
+          "io.askimo.core.config.ProviderModelConfig",
           "io.askimo.core.config.ProviderModelConfig"
         ]
       },
       {
         "name": "<init>",
         "parameterTypes": [
+          "io.askimo.core.config.ProviderModelConfig",
           "io.askimo.core.config.ProviderModelConfig",
           "io.askimo.core.config.ProviderModelConfig",
           "io.askimo.core.config.ProviderModelConfig",
@@ -3159,6 +3161,7 @@
       { "name": "getLocalai", "parameterTypes": [] },
       { "name": "getOllama", "parameterTypes": [] },
       { "name": "getOpenai", "parameterTypes": [] },
+      { "name": "getOpenai_compatible", "parameterTypes": [] },
       { "name": "getXai", "parameterTypes": [] }
     ]
   },
@@ -4508,7 +4511,7 @@
     ]
   },
   {
-    "name": "io.askimo.core.providers.ChatClient$MockitoMock$0PyMcV5P",
+    "name": "io.askimo.core.providers.ChatClient$MockitoMock$xR8jsBv8",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
@@ -4748,6 +4751,9 @@
       { "name": "getDefaultModel", "parameterTypes": [] },
       { "name": "setApiKey", "parameterTypes": ["java.lang.String"] }
     ]
+  },
+  {
+    "name": "io.askimo.core.providers.openaicompatible.OpenAiCompatibleSettings"
   },
   {
     "name": "io.askimo.core.providers.xai.XAiModelFactoryTest",
@@ -6867,7 +6873,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$lxecrjiJ",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$FO4GttvF",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -304,6 +304,7 @@ data class ModelsConfig(
     val localai: ProviderModelConfig = ProviderModelConfig(),
     val lmstudio: ProviderModelConfig = ProviderModelConfig(),
     val xai: ProviderModelConfig = ProviderModelConfig(),
+    val openai_compatible: ProviderModelConfig = ProviderModelConfig(),
 ) {
     operator fun get(provider: ModelProvider): ProviderModelConfig = when (provider) {
         ModelProvider.OPENAI -> openai
@@ -314,6 +315,7 @@ data class ModelsConfig(
         ModelProvider.DOCKER -> docker
         ModelProvider.LOCALAI -> localai
         ModelProvider.LMSTUDIO -> lmstudio
+        ModelProvider.OPENAI_COMPATIBLE -> openai_compatible
         ModelProvider.UNKNOWN -> ProviderModelConfig()
     }
 
@@ -326,6 +328,7 @@ data class ModelsConfig(
         ModelProvider.DOCKER -> copy(docker = updated)
         ModelProvider.LOCALAI -> copy(localai = updated)
         ModelProvider.LMSTUDIO -> copy(lmstudio = updated)
+        ModelProvider.OPENAI_COMPATIBLE -> copy(openai_compatible = updated)
         ModelProvider.UNKNOWN -> this
     }
 }
@@ -523,6 +526,13 @@ object AppConfig {
             embedding_model: ${'$'}{ASKIMO_XAI_EMBEDDING_MODEL:}
             vision_model: ${'$'}{ASKIMO_XAI_VISION_MODEL:grok-2-vision-latest}
             image_model: ${'$'}{ASKIMO_XAI_IMAGE_MODEL:grok-2-vision-latest}
+          openai_compatible:
+            available_models:
+            utility_model:
+            utility_model_timeout_seconds: 45
+            embedding_model:
+            vision_model:
+            image_model:
 
         proxy:
           type: ${'$'}{ASKIMO_PROXY_TYPE:NONE}
@@ -975,6 +985,13 @@ object AppConfig {
                 embeddingModel = env("ASKIMO_XAI_EMBEDDING_MODEL", ""),
                 visionModel = env("ASKIMO_XAI_VISION_MODEL", "grok-2-vision-latest"),
                 imageModel = env("ASKIMO_XAI_IMAGE_MODEL", "grok-2-vision-latest"),
+            ),
+            openai_compatible = ProviderModelConfig(
+                utilityModel = "",
+                utilityModelTimeoutSeconds = 45L,
+                embeddingModel = "",
+                visionModel = "",
+                imageModel = "",
             ),
         )
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ModelProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ModelProvider.kt
@@ -64,6 +64,12 @@ enum class ModelProvider {
     LMSTUDIO,
 
     /**
+     * Represents any OpenAI API-compatible provider (e.g., custom endpoints, proxies, etc.).
+     */
+    @SerialName("OPENAI_COMPATIBLE")
+    OPENAI_COMPATIBLE,
+
+    /**
      * Represents an unidentified or unsupported model provider.
      */
     @SerialName("UNKNOWN")
@@ -82,6 +88,7 @@ enum class ModelProvider {
         ANTHROPIC -> "anthropic"
         LOCALAI -> "localai"
         LMSTUDIO -> "lmstudio"
+        OPENAI_COMPATIBLE -> "openai-compatible"
         UNKNOWN -> "unknown"
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ProviderRegistry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ProviderRegistry.kt
@@ -11,6 +11,7 @@ import io.askimo.core.providers.ModelProvider.LMSTUDIO
 import io.askimo.core.providers.ModelProvider.LOCALAI
 import io.askimo.core.providers.ModelProvider.OLLAMA
 import io.askimo.core.providers.ModelProvider.OPENAI
+import io.askimo.core.providers.ModelProvider.OPENAI_COMPATIBLE
 import io.askimo.core.providers.ModelProvider.XAI
 import io.askimo.core.providers.anthropic.AnthropicModelFactory
 import io.askimo.core.providers.docker.DockerAiModelFactory
@@ -19,6 +20,7 @@ import io.askimo.core.providers.lmstudio.LmStudioModelFactory
 import io.askimo.core.providers.localai.LocalAiModelFactory
 import io.askimo.core.providers.ollama.OllamaModelFactory
 import io.askimo.core.providers.openai.OpenAiModelFactory
+import io.askimo.core.providers.openaicompatible.OpenAiCompatibleModelFactory
 import io.askimo.core.providers.xai.XAiModelFactory
 
 /**
@@ -47,6 +49,7 @@ object ProviderRegistry {
             ANTHROPIC to AnthropicModelFactory(),
             LOCALAI to LocalAiModelFactory(),
             LMSTUDIO to LmStudioModelFactory(),
+            OPENAI_COMPATIBLE to OpenAiCompatibleModelFactory(),
         )
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/ProviderSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ProviderSettings.kt
@@ -14,6 +14,7 @@ import io.askimo.core.providers.lmstudio.LmStudioSettings
 import io.askimo.core.providers.localai.LocalAiSettings
 import io.askimo.core.providers.ollama.OllamaSettings
 import io.askimo.core.providers.openai.OpenAiSettings
+import io.askimo.core.providers.openaicompatible.OpenAiCompatibleSettings
 import io.askimo.core.providers.xai.XAiSettings
 
 /**
@@ -34,6 +35,7 @@ import io.askimo.core.providers.xai.XAiSettings
     JsonSubTypes.Type(value = DockerAiSettings::class, name = "docker"),
     JsonSubTypes.Type(value = LocalAiSettings::class, name = "localai"),
     JsonSubTypes.Type(value = LmStudioSettings::class, name = "lmstudio"),
+    JsonSubTypes.Type(value = OpenAiCompatibleSettings::class, name = "openai_compatible"),
 )
 interface ProviderSettings {
     val defaultModel: String

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -1,0 +1,147 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.providers.openaicompatible
+
+import dev.langchain4j.http.client.jdk.JdkHttpClient
+import dev.langchain4j.memory.ChatMemory
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.model.image.ImageModel
+import dev.langchain4j.model.openai.OpenAiChatModel
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
+import dev.langchain4j.model.openai.OpenAiImageModel
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel
+import dev.langchain4j.rag.content.retriever.ContentRetriever
+import dev.langchain4j.service.AiServices
+import dev.langchain4j.service.tool.ToolProvider
+import io.askimo.core.config.AppConfig
+import io.askimo.core.context.AppContext
+import io.askimo.core.context.ExecutionMode
+import io.askimo.core.logging.logger
+import io.askimo.core.providers.AiServiceBuilder
+import io.askimo.core.providers.ChatClient
+import io.askimo.core.providers.ChatModelFactory
+import io.askimo.core.providers.ModelProvider
+import io.askimo.core.providers.ProviderModelUtils.fetchModels
+import io.askimo.core.telemetry.TelemetryChatModelListener
+import io.askimo.core.util.ApiKeyUtils.safeApiKey
+import io.askimo.core.util.ProxyUtil
+import java.net.http.HttpClient
+import java.time.Duration
+
+class OpenAiCompatibleModelFactory : ChatModelFactory<OpenAiCompatibleSettings> {
+    private val log = logger<OpenAiCompatibleModelFactory>()
+
+    override fun getProvider(): ModelProvider = ModelProvider.OPENAI_COMPATIBLE
+
+    private fun createHttpClientBuilder(baseUrl: String) = JdkHttpClient.builder().httpClientBuilder(
+        ProxyUtil.configureProxy(
+            HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1),
+            baseUrl,
+        ),
+    )
+
+    override fun availableModels(settings: OpenAiCompatibleSettings): List<String> = fetchModels(
+        apiKey = settings.apiKey.ifBlank { "not-needed" },
+        url = "${settings.baseUrl.removeSuffix("/")}/models",
+        providerName = ModelProvider.OPENAI_COMPATIBLE,
+    )
+
+    override fun defaultSettings(): OpenAiCompatibleSettings = OpenAiCompatibleSettings()
+
+    override fun getNoModelsHelpText(): String = """
+        One possible reason is that your server URL or API key is not configured.
+
+        1. Set the Base URL for your OpenAI-compatible server (e.g., http://localhost:8000/v1)
+        2. Add an API key if your server requires it
+    """.trimIndent()
+
+    override fun create(
+        sessionId: String?,
+        settings: OpenAiCompatibleSettings,
+        toolProvider: ToolProvider?,
+        retriever: ContentRetriever?,
+        executionMode: ExecutionMode,
+        chatMemory: ChatMemory?,
+    ): ChatClient {
+        val telemetry = AppContext.getInstance().telemetry
+        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
+        val apiKey = settings.apiKey.ifBlank { "not-needed" }
+
+        val chatModel = OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey(safeApiKey(apiKey))
+            .modelName(settings.defaultModel)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OPENAI_COMPATIBLE.providerKey())))
+            .build()
+
+        return AiServiceBuilder.buildChatClient(
+            sessionId = sessionId,
+            settings = settings,
+            provider = ModelProvider.OPENAI_COMPATIBLE,
+            chatModel = chatModel,
+            secondaryChatModel = createSecondaryChatModel(settings),
+            chatMemory = chatMemory,
+            toolProvider = toolProvider,
+            retriever = retriever,
+            executionMode = executionMode,
+        )
+    }
+
+    override fun createImageModel(settings: OpenAiCompatibleSettings): ImageModel {
+        val apiKey = settings.apiKey.ifBlank { "not-needed" }
+        return OpenAiImageModel.builder()
+            .baseUrl(settings.baseUrl)
+            .apiKey(safeApiKey(apiKey))
+            .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].imageModel)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .build()
+    }
+
+    private fun createSecondaryChatModel(settings: OpenAiCompatibleSettings): ChatModel {
+        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
+        val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].utilityModel
+            .ifBlank { settings.defaultModel }
+        val apiKey = settings.apiKey.ifBlank { "not-needed" }
+
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey(safeApiKey(apiKey))
+            .modelName(modelName)
+            .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].utilityModelTimeoutSeconds))
+            .build()
+    }
+
+    override fun createUtilityClient(settings: OpenAiCompatibleSettings): ChatClient = AiServices.builder(ChatClient::class.java)
+        .chatModel(createSecondaryChatModel(settings))
+        .build()
+
+    override fun supportsEmbedding(): Boolean = true
+
+    override fun createEmbeddingModel(settings: OpenAiCompatibleSettings): EmbeddingModel {
+        val apiKey = settings.apiKey.ifBlank { "not-needed" }
+        return OpenAiEmbeddingModelBuilder()
+            .baseUrl(settings.baseUrl)
+            .apiKey(safeApiKey(apiKey))
+            .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel)
+            .build()
+    }
+
+    override fun getEmbeddingTokenLimit(settings: OpenAiCompatibleSettings): Int {
+        val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel.lowercase()
+        return when {
+            modelName.contains("text-embedding-3") -> 8191
+            modelName.contains("ada-002") -> 8191
+            else -> 8191
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.core.providers.openaicompatible
+
+import io.askimo.core.providers.HasApiKey
+import io.askimo.core.providers.HasBaseUrl
+import io.askimo.core.providers.ProviderConfigField
+import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.providers.SettingField
+
+/**
+ * Settings for OpenAI API-compatible providers (custom endpoints, proxies, etc.).
+ */
+data class OpenAiCompatibleSettings(
+    override var apiKey: String = "",
+    override var baseUrl: String = "http://localhost:8000/v1",
+    override val defaultModel: String = "",
+) : ProviderSettings,
+    HasApiKey,
+    HasBaseUrl {
+    override fun describe(): List<String> = listOf(
+        "baseUrl: $baseUrl",
+        "apiKey:  ${maskApiKey()}",
+    )
+
+    override fun toString(): String = "OpenAiCompatibleSettings(baseUrl=$baseUrl, apiKey=${maskApiKey()})"
+
+    override fun getFields(): List<SettingField> = listOf(
+        SettingField.TextField(
+            name = SettingField.BASE_URL,
+            label = "Base URL",
+            description = "OpenAI-compatible server URL",
+            value = baseUrl,
+        ),
+        SettingField.TextField(
+            name = SettingField.API_KEY,
+            label = "API Key",
+            description = "API key (optional if your server does not require it)",
+            value = apiKey,
+            isPassword = true,
+        ),
+    )
+
+    override fun updateField(fieldName: String, value: String): ProviderSettings = when (fieldName) {
+        SettingField.BASE_URL -> copy(baseUrl = value)
+        SettingField.API_KEY -> copy(apiKey = value)
+        SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        else -> this
+    }
+
+    override fun validate(): Boolean = baseUrl.isNotBlank()
+
+    override fun getSetupHelpText(messageResolver: (String) -> String): String = messageResolver("provider.openai_compatible.setup.help")
+
+    override fun getConfigFields(messageResolver: (String) -> String): List<ProviderConfigField> {
+        val hasStoredKey = apiKey.isNotBlank() && (apiKey == "***keychain***" || apiKey.startsWith("encrypted:"))
+
+        val apiKeyDescription = if (hasStoredKey) {
+            messageResolver("provider.openai_compatible.apikey.stored")
+        } else {
+            messageResolver("provider.openai_compatible.apikey.description")
+        }
+
+        return listOf(
+            ProviderConfigField.BaseUrlField(
+                description = messageResolver("provider.openai_compatible.baseurl.description"),
+                value = baseUrl,
+            ),
+            ProviderConfigField.ApiKeyField(
+                description = apiKeyDescription,
+                value = apiKey,
+                hasExistingValue = hasStoredKey,
+            ),
+        )
+    }
+
+    override fun applyConfigFields(fields: Map<String, String>): ProviderSettings {
+        val newBaseUrl = fields["baseUrl"]?.takeIf { it.isNotBlank() } ?: baseUrl
+        val newApiKey = fields["apiKey"]?.takeIf { it.isNotBlank() } ?: apiKey
+        return copy(baseUrl = newBaseUrl, apiKey = newApiKey)
+    }
+
+    override fun deepCopy(): ProviderSettings = copy()
+}


### PR DESCRIPTION
- Extend ModelProvider enum with OPENAI_COMPATIBLE.
- Register new factory and settings for the provider.
- Update reflection config for native image.
- Add new config entries in AppConfig.
- Wire new settings into ProviderRegistry and related imports.