### PR TITLE
refactor(mcp): return Result for MCP client and tool loading

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -4608,7 +4608,7 @@
     ]
   },
   {
-    "name": "io.askimo.core.providers.ChatClient$MockitoMock$9MnoMmTz",
+    "name": "io.askimo.core.providers.ChatClient$MockitoMock$czKLlMIH",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
@@ -5317,12 +5317,6 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.askimo.core.security.SecureSessionManager",
-    "allDeclaredClasses": true,
-    "queryAllDeclaredMethods": true,
-    "queryAllPublicMethods": true
-  },
-  {
     "name": "io.askimo.core.security.SecureSessionManagerTest",
     "allDeclaredFields": true,
     "allDeclaredClasses": true,
@@ -5368,12 +5362,6 @@
   },
   {
     "name": "io.askimo.core.security.TestProviderSettings$Companion",
-    "allDeclaredClasses": true,
-    "queryAllDeclaredMethods": true,
-    "queryAllPublicMethods": true
-  },
-  {
-    "name": "io.askimo.core.security.TestSecureSessionManager",
     "allDeclaredClasses": true,
     "queryAllDeclaredMethods": true,
     "queryAllPublicMethods": true
@@ -6984,7 +6972,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$IGApxVfY",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$dFuXftxe",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/cli/src/test/kotlin/io/askimo/core/security/SecureSessionManagerTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/security/SecureSessionManagerTest.kt
@@ -10,6 +10,7 @@ import io.askimo.core.providers.gemini.GeminiSettings
 import io.askimo.core.providers.openai.OpenAiSettings
 import io.askimo.core.providers.xai.XAiSettings
 import io.askimo.test.extensions.AskimoTestHome
+import io.askimo.test.extensions.TestSecureSessionManager
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
@@ -416,12 +417,4 @@ class SecureSessionManagerTest {
         val insecureDesc = SecureKeyManager.getStorageSecurityDescription(SecureKeyManager.StorageMethod.INSECURE_FALLBACK)
         assertTrue(insecureDesc.contains("INSECURE"))
     }
-}
-
-/**
- * Test-safe subclass of [SecureSessionManager] that prefixes all keychain keys with "test_"
- * to avoid overwriting a developer's real API keys during test runs.
- */
-private class TestSecureSessionManager : SecureSessionManager() {
-    override fun providerKey(provider: ModelProvider): String = "test_${provider.name.lowercase()}"
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatInputField.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ChatInputField.kt
@@ -74,6 +74,9 @@ import androidx.compose.ui.window.Popup
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.service.ChatSessionService
+import io.askimo.core.event.EventBus
+import io.askimo.core.event.error.AppErrorEvent
+import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.intent.ToolConfig
 import io.askimo.core.intent.ToolRegistry
 import io.askimo.core.logging.currentFileLogger
@@ -719,24 +722,36 @@ private fun toolsIndicatorButton(
         mcpServers = withContext(Dispatchers.IO) {
             // Load global MCP servers with their tools
             globalMcpService?.getInstances()?.filter { it.enabled }?.forEach { instance ->
-                val tools = try {
-                    globalMcpService.listTools(instance.id)
-                } catch (e: Exception) {
-                    log.error("Error loading tools for global server ${instance.name}", e)
-                    emptyList()
-                }
+                val tools = globalMcpService.listTools(instance.id)
+                    .getOrElse { e ->
+                        log.error("Error loading tools for global server ${instance.name}", e)
+                        EventBus.emit(
+                            AppErrorEvent(
+                                title = LocalizationManager.getString("error.app.title"),
+                                message = LocalizationManager.getString("error.app.message", e.message ?: instance.name),
+                                cause = e,
+                            ),
+                        )
+                        emptyList()
+                    }
                 servers.add(McpServerInfo(instance.name, instance.id, isGlobal = true, tools = tools))
             }
 
             // Load project MCP servers with their tools if in project context
             if (projectId != null) {
                 projectMcpService?.getInstances(projectId!!)?.filter { it.enabled }?.forEach { instance ->
-                    val tools = try {
-                        projectMcpService.listTools(projectId!!, instance.id)
-                    } catch (e: Exception) {
-                        log.error("Error loading tools for project server ${instance.name}", e)
-                        emptyList()
-                    }
+                    val tools = projectMcpService.listTools(projectId!!, instance.id)
+                        .getOrElse { e ->
+                            log.error("Error loading tools for project server ${instance.name}", e)
+                            EventBus.emit(
+                                AppErrorEvent(
+                                    title = LocalizationManager.getString("error.app.title"),
+                                    message = LocalizationManager.getString("error.app.message", e.message ?: instance.name),
+                                    cause = e,
+                                ),
+                            )
+                            emptyList()
+                        }
                     servers.add(McpServerInfo(instance.name, instance.id, isGlobal = false, tools = tools))
                 }
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/McpTabContent.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/McpTabContent.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.koin.core.context.GlobalContext as KoinGlobalContext
 
 /**
@@ -143,18 +144,20 @@ fun mcpTabContent(project: Project?) {
                                 coroutineScope.launch(Dispatchers.IO) {
                                     try {
                                         // Add timeout to prevent hanging
-                                        kotlinx.coroutines.withTimeout(15000L) {
+                                        withTimeout(15000L) {
                                             // 15 second timeout
-                                            val client = mcpService.createMcpClient(instance, "ui_${instance.id}")
-                                            if (client != null) {
-                                                val tools = client.listTools()
-                                                // Update UI state - no need for withContext since we're already in a coroutine
-                                                instanceTools = instanceTools + (instance.id to tools)
-                                                loadingTools = loadingTools - instance.id
-                                            } else {
-                                                loadingTools = loadingTools - instance.id
-                                                failedInstances = failedInstances + instance.id
-                                            }
+                                            val clientResult = mcpService.createMcpClient(instance, "ui_${instance.id}")
+                                            clientResult.fold(
+                                                onSuccess = { client ->
+                                                    val tools = client.listTools()
+                                                    instanceTools = instanceTools + (instance.id to tools)
+                                                    loadingTools = loadingTools - instance.id
+                                                },
+                                                onFailure = {
+                                                    loadingTools = loadingTools - instance.id
+                                                    failedInstances = failedInstances + instance.id
+                                                },
+                                            )
                                         }
                                     } catch (e: TimeoutCancellationException) {
                                         // Connection timeout

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/AddMcpIntegrationDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/AddMcpIntegrationDialog.kt
@@ -428,32 +428,29 @@ fun addMcpIntegrationDialog(
                                                     val tempInstance = tempInstanceData.toDomain()
 
                                                     // Try to fetch tools
-                                                    val mcpClient = mcpService.createMcpClient(
+                                                    val clientResult = mcpService.createMcpClient(
                                                         tempInstance,
                                                         "test-connection",
                                                     )
 
-                                                    if (mcpClient != null) {
-                                                        val tools = mcpClient.listTools()
-                                                        availableTools = tools
+                                                    clientResult.fold(
+                                                        onSuccess = { mcpClient ->
+                                                            val tools = mcpClient.listTools()
+                                                            availableTools = tools
 
-                                                        // Auto-infer categories and strategies for each tool
-                                                        val inferredCategories = mutableMapOf<String, ToolCategory>()
-                                                        val inferredStrategies = mutableMapOf<String, Int>()
-
-                                                        tools.forEach { toolSpec ->
-                                                            val category = mcpService.inferToolCategory(toolSpec)
-                                                            val strategy = mcpService.inferToolStrategy(toolSpec)
-
-                                                            inferredCategories[toolSpec.name()] = category
-                                                            inferredStrategies[toolSpec.name()] = strategy
-                                                        }
-
-                                                        toolCategories = inferredCategories
-                                                        toolStrategies = inferredStrategies
-                                                    } else {
-                                                        dialogState.setError("Failed to create MCP client. Check your parameters.")
-                                                    }
+                                                            val inferredCategories = mutableMapOf<String, ToolCategory>()
+                                                            val inferredStrategies = mutableMapOf<String, Int>()
+                                                            tools.forEach { toolSpec ->
+                                                                inferredCategories[toolSpec.name()] = mcpService.inferToolCategory(toolSpec)
+                                                                inferredStrategies[toolSpec.name()] = mcpService.inferToolStrategy(toolSpec)
+                                                            }
+                                                            toolCategories = inferredCategories
+                                                            toolStrategies = inferredStrategies
+                                                        },
+                                                        onFailure = { e ->
+                                                            dialogState.setError(e.message ?: "Failed to create MCP client")
+                                                        },
+                                                    )
                                                 }
                                             } catch (e: Exception) {
                                                 dialogState.setError(e, "Error loading tools")
@@ -673,23 +670,18 @@ fun addMcpIntegrationDialog(
                                                             updatedAt = now,
                                                         )
                                                         val tempInstance = tempInstanceData.toDomain()
-                                                        val mcpClient = mcpService.createMcpClient(tempInstance, "auto-load-tools")
-
-                                                        if (mcpClient != null) {
-                                                            val tools = mcpClient.listTools()
-                                                            val inferredCategories = mutableMapOf<String, ToolCategory>()
-                                                            val inferredStrategies = mutableMapOf<String, Int>()
-
-                                                            tools.forEach { toolSpec ->
-                                                                val category = mcpService.inferToolCategory(toolSpec)
-                                                                val strategy = mcpService.inferToolStrategy(toolSpec)
-                                                                inferredCategories[toolSpec.name()] = category
-                                                                inferredStrategies[toolSpec.name()] = strategy
+                                                        mcpService.createMcpClient(tempInstance, "auto-load-tools")
+                                                            .onSuccess { mcpClient ->
+                                                                val tools = mcpClient.listTools()
+                                                                val inferredCategories = mutableMapOf<String, ToolCategory>()
+                                                                val inferredStrategies = mutableMapOf<String, Int>()
+                                                                tools.forEach { toolSpec ->
+                                                                    inferredCategories[toolSpec.name()] = mcpService.inferToolCategory(toolSpec)
+                                                                    inferredStrategies[toolSpec.name()] = mcpService.inferToolStrategy(toolSpec)
+                                                                }
+                                                                toolCategories = inferredCategories
+                                                                toolStrategies = inferredStrategies
                                                             }
-
-                                                            toolCategories = inferredCategories
-                                                            toolStrategies = inferredStrategies
-                                                        }
                                                     }
                                                 } catch (e: Exception) {
                                                     // If auto-load fails, continue without tools

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/McpToolsDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/McpToolsDialog.kt
@@ -91,18 +91,23 @@ fun mcpToolsDialog(
         isLoading = true
         errorMessage = null
         try {
-            tools = withContext(Dispatchers.IO) {
+            val result = withContext(Dispatchers.IO) {
                 mcpClientFactory.listTools(instance)
             }
+            result.fold(
+                onSuccess = { tools = it },
+                onFailure = { e ->
+                    val isTimeout = e is TimeoutException ||
+                        e.cause is TimeoutException ||
+                        e.message?.contains("TimeoutException", ignoreCase = true) == true
+                    errorMessage = if (isTimeout) {
+                        "Connection timeout: Unable to connect to MCP server. Please check if the server is running and accessible."
+                    } else {
+                        e.message ?: "Failed to load tools"
+                    }
+                },
+            )
         } catch (e: Exception) {
-            val isTimeout = e is TimeoutException ||
-                e.cause is TimeoutException ||
-                e.message?.contains("TimeoutException", ignoreCase = true) == true
-            errorMessage = if (isTimeout) {
-                "Connection timeout: Unable to connect to MCP server. Please check if the server is running and accessible."
-            } else {
-                "Failed to load tools: ${e.message ?: "Unknown error occurred"}"
-            }
         } finally {
             isLoading = false
         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AddGlobalMcpInstanceDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AddGlobalMcpInstanceDialog.kt
@@ -266,18 +266,21 @@ fun addGlobalMcpInstanceDialog(
                         updatedAt = now,
                     )
 
-                    val mcpClient = mcpClientFactory.createMcpClient(
+                    val clientResult = mcpClientFactory.createMcpClient(
                         instance,
                         "test-connection-$serverId",
                     )
 
-                    if (mcpClient != null) {
-                        val tools = mcpClient.listTools()
-                        availableTools = tools
-                        return@withContext true to serverId
-                    } else {
-                        return@withContext false to null
-                    }
+                    clientResult.fold(
+                        onSuccess = { mcpClient ->
+                            val tools = mcpClient.listTools()
+                            availableTools = tools
+                        },
+                        onFailure = { e ->
+                            return@withContext false to e.message
+                        },
+                    )
+                    return@withContext true to serverId
                 } finally {
                     // Clean up temporary server definition only if not editing
                     if (existingInstance == null) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/GlobalErrorHandler.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/GlobalErrorHandler.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import io.askimo.core.event.EventBus
+import io.askimo.core.event.error.AppErrorEvent
 import io.askimo.core.event.error.IndexingErrorEvent
 import io.askimo.core.event.error.IndexingErrorType
 import io.askimo.core.event.error.ModelNotAvailableEvent
@@ -118,6 +119,15 @@ fun globalErrorHandler(onStateChange: (ErrorDialogState) -> Unit) {
                             title = LocalizationManager.getString("error.send_message.title"),
                             message = event.throwable.message
                                 ?: LocalizationManager.getString("error.send_message.message"),
+                        ),
+                    )
+                }
+                is AppErrorEvent -> {
+                    onStateChange(
+                        ErrorDialogState(
+                            show = true,
+                            title = event.title,
+                            message = event.message,
                         ),
                     )
                 }

--- a/desktop/src/main/resources/i18n/messages.properties
+++ b/desktop/src/main/resources/i18n/messages.properties
@@ -719,6 +719,10 @@ error.model.not_available.message.embedding=Embedding model ''{0}'' is not avail
 error.model.not_available.config_link=Configure Embedding Model
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=Something Went Wrong
+error.app.message=An unexpected error occurred: {0}
+
 # Send Message Errors
 error.send_message.title=Failed to Send Message
 error.send_message.message=Failed to send your message to the AI. Please try again.

--- a/desktop/src/main/resources/i18n/messages_de.properties
+++ b/desktop/src/main/resources/i18n/messages_de.properties
@@ -723,6 +723,10 @@ error.model.not_available.message.embedding=Das Einbettungsmodell ''{0}'' ist ni
 error.model.not_available.config_link=Einbettungsmodell konfigurieren
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=Etwas ist schiefgelaufen
+error.app.message=Ein unerwarteter Fehler ist aufgetreten: {0}
+
 # Send Message Errors
 error.send_message.title=Nachricht konnte nicht gesendet werden
 error.send_message.message=Ihre Nachricht konnte nicht an die KI gesendet werden. Bitte versuchen Sie es erneut.

--- a/desktop/src/main/resources/i18n/messages_es.properties
+++ b/desktop/src/main/resources/i18n/messages_es.properties
@@ -721,6 +721,10 @@ error.model.not_available.message.embedding=El modelo de incrustación ''{0}'' n
 error.model.not_available.config_link=Configurar modelo de incrustación
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=Algo salió mal
+error.app.message=Ocurrió un error inesperado: {0}
+
 # Send Message Errors
 error.send_message.title=No se pudo enviar el mensaje
 error.send_message.message=No se pudo enviar tu mensaje a la IA. Por favor, inténtalo de nuevo.

--- a/desktop/src/main/resources/i18n/messages_fr.properties
+++ b/desktop/src/main/resources/i18n/messages_fr.properties
@@ -721,6 +721,10 @@ error.model.not_available.message.embedding=Le modèle d’embedding ''{0}'' n�
 error.model.not_available.config_link=Configurer le modèle d’embedding
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=Une erreur s’est produite
+error.app.message=Une erreur inattendue s’est produite : {0}
+
 # Send Message Errors
 error.send_message.title=Échec de l’envoi du message
 error.send_message.message=Impossible d’envoyer votre message à l’IA. Veuillez réessayer.

--- a/desktop/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop/src/main/resources/i18n/messages_ja_JP.properties
@@ -722,6 +722,10 @@ error.model.not_available.message.embedding=埋め込みモデル ''{0}'' は利
 error.model.not_available.config_link=埋め込みモデルを設定
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=問題が発生しました
+error.app.message=予期しないエラーが発生しました: {0}
+
 # Send Message Errors
 error.send_message.title=メッセージの送信に失敗しました
 error.send_message.message=AI にメッセージを送信できませんでした。もう一度お試しください。

--- a/desktop/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop/src/main/resources/i18n/messages_ko_KR.properties
@@ -723,6 +723,10 @@ error.model.not_available.message.embedding=임베딩 모델 ''{0}''을(를) 사
 error.model.not_available.config_link=임베딩 모델 설정
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=문제가 발생했습니다
+error.app.message=예기치 않은 오류가 발생했습니다: {0}
+
 # Send Message Errors
 error.send_message.title=메시지 전송 실패
 error.send_message.message=AI로 메시지를 전송하지 못했습니다. 다시 시도해 주세요.

--- a/desktop/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop/src/main/resources/i18n/messages_pt_BR.properties
@@ -723,6 +723,10 @@ error.model.not_available.message.embedding=O modelo de embedding ''{0}'' não e
 error.model.not_available.config_link=Configurar modelo de embedding
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=Algo deu errado
+error.app.message=Ocorreu um erro inesperado: {0}
+
 # Send Message Errors
 error.send_message.title=Falha ao enviar mensagem
 error.send_message.message=Não foi possível enviar sua mensagem para a IA. Tente novamente.

--- a/desktop/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop/src/main/resources/i18n/messages_vi_VN.properties
@@ -720,6 +720,10 @@ error.model.not_available.message.embedding=Mô hình embedding ''{0}'' không k
 error.model.not_available.config_link=Cấu hình mô hình embedding
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=Đã xảy ra lỗi
+error.app.message=Đã xảy ra lỗi không mong muốn: {0}
+
 # Send Message Errors
 error.send_message.title=Gửi tin nhắn thất bại
 error.send_message.message=Không thể gửi tin nhắn của bạn đến AI. Vui lòng thử lại.

--- a/desktop/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_CN.properties
@@ -722,6 +722,10 @@ error.model.not_available.message.embedding=嵌入模型 ''{0}'' 不可用。\n\
 error.model.not_available.config_link=配置嵌入模型
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=出现错误
+error.app.message=发生了一个意外错误：{0}
+
 # Send Message Errors
 error.send_message.title=发送消息失败
 error.send_message.message=无法将你的消息发送给 AI。请重试。

--- a/desktop/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop/src/main/resources/i18n/messages_zh_TW.properties
@@ -723,6 +723,10 @@ error.model.not_available.message.embedding=嵌入模型 ''{0}'' 無法使用。
 error.model.not_available.config_link=設定嵌入模型
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
+# Generic Application Errors
+error.app.title=發生錯誤
+error.app.message=發生未預期的錯誤：{0}
+
 # Send Message Errors
 error.send_message.title=傳送訊息失敗
 error.send_message.message=無法將你的訊息傳送給 AI。請再試一次。

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -369,6 +369,17 @@ object AppConfig {
 
     @Volatile private var cached: AppConfigData? = null
 
+    @Volatile private var secureSessionManager: SecureSessionManager = SecureSessionManager()
+
+    /**
+     * Replaces the [SecureSessionManager] used by [saveContext].
+     * **For testing only** — call from [AppConfig.initForTest] to prevent keychain collisions.
+     */
+    @Synchronized
+    fun setSecureSessionManagerForTest(manager: SecureSessionManager) {
+        secureSessionManager = manager
+    }
+
     /**
      * Clears the cached configuration, forcing it to be reloaded on next access.
      * Useful for testing to ensure clean state between tests.
@@ -376,6 +387,7 @@ object AppConfig {
     @Synchronized
     fun reset() {
         cached = null
+        secureSessionManager = SecureSessionManager()
     }
 
     /**
@@ -989,7 +1001,7 @@ object AppConfig {
      */
     fun saveContext(params: AppContextParams) {
         synchronized(this) {
-            val sanitized = SecureSessionManager().saveSecureSession(params)
+            val sanitized = secureSessionManager.saveSecureSession(params)
             val current = cached ?: loadOnce()
             cached = current.copy(context = sanitized)
 

--- a/shared/src/main/kotlin/io/askimo/core/event/error/AppErrorEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/event/error/AppErrorEvent.kt
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.core.event.error
+
+import io.askimo.core.event.Event
+import io.askimo.core.event.EventSource
+import io.askimo.core.event.EventType
+import java.time.Instant
+
+/**
+ * Generic application error event for errors that do not warrant a dedicated event type.
+ *
+ * Use this for non-critical, "fire-and-forget" UI errors where no other component needs
+ * to react programmatically. The [title] and [message] are already-resolved strings so
+ * that [shared] stays free of any UI/i18n dependency — resolution happens at the call site.
+ *
+ * For errors that significantly impact UX flow (e.g. model unavailable, send failure),
+ * prefer a dedicated event type so that other components can react specifically.
+ *
+ * @param title Short, user-facing title for the error dialog.
+ * @param message Detailed, user-facing description of what went wrong.
+ * @param cause Optional underlying throwable, used for debug logging only.
+ */
+data class AppErrorEvent(
+    val title: String,
+    val message: String,
+    val cause: Throwable? = null,
+    override val timestamp: Instant = Instant.now(),
+    override val source: EventSource = EventSource.SYSTEM,
+) : Event {
+    override val type = EventType.ERROR
+
+    override fun getDetails() = "[$source] $title: $message"
+}

--- a/shared/src/main/kotlin/io/askimo/core/mcp/GlobalMcpInstanceService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/GlobalMcpInstanceService.kt
@@ -89,11 +89,11 @@ class GlobalMcpInstanceService(
      *
      * Note: For MVP, we call through [ProjectMcpInstanceService.getProjectTools] directly.
      */
-    suspend fun getGlobalTools(): List<ToolConfig> = delegate.getProjectTools(GLOBAL_MCP_SCOPE_ID)
+    suspend fun getGlobalTools(): Result<List<ToolConfig>> = delegate.getProjectTools(GLOBAL_MCP_SCOPE_ID)
 
     fun getToolVectorIndex(): ToolVectorIndex? = delegate.getToolVectorIndex(GLOBAL_MCP_SCOPE_ID)
 
-    suspend fun listTools(instanceId: String): List<ToolConfig> = delegate.listTools(GLOBAL_MCP_SCOPE_ID, instanceId)
+    suspend fun listTools(instanceId: String): Result<List<ToolConfig>> = delegate.listTools(GLOBAL_MCP_SCOPE_ID, instanceId)
 
     fun getMcpClientForTool(toolName: String): DefaultMcpClient? = delegate.getMcpClientForTool(GLOBAL_MCP_SCOPE_ID, toolName)
 

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
@@ -29,31 +29,25 @@ class McpClientFactory(
     private val serversConfig: McpServersConfig = McpServersConfig,
 ) {
 
-    // ── Client creation ───────────────────────────────────────────────────────
-
     /**
      * Creates a [DefaultMcpClient] for the given [instance].
      *
-     * Steps:
-     * 1. Look up the [McpServerDefinition] by [McpInstance.serverId]
-     * 2. Build and validate the connector
-     * 3. Create the transport
-     * 4. Build and return the client
-     *
-     * Returns `null` (instead of throwing) if any step fails, so callers can
-     * decide whether to skip or surface the error.
+     * Returns [Result.failure] with the root-cause exception intact so callers
+     * can surface a meaningful message to the user instead of a generic error.
      */
     suspend fun createMcpClient(
         instance: McpInstance,
         clientKey: String,
-    ): DefaultMcpClient? {
+    ): Result<DefaultMcpClient> {
         return try {
-            val definition = serversConfig.get(instance.serverId) ?: run {
-                log.warn("Server definition not found for instance '${instance.name}': ${instance.serverId}")
-                return null
-            }
+            val definition = serversConfig.get(instance.serverId)
+                ?: return Result.failure(
+                    IllegalStateException(
+                        "Server definition not found for '${instance.name}' (serverId: ${instance.serverId}). " +
+                            "The server may have been deleted.",
+                    ),
+                )
 
-            // Resolve secret references before creating connector
             val resolvedDefinition = ServerDefinitionSecretManager.resolveSecrets(definition)
 
             log.trace("Creating connector for instance '${instance.name}' (${instance.serverId})")
@@ -62,19 +56,23 @@ class McpClientFactory(
             log.trace("Validating connector '${instance.name}'")
             val validationResult = connector.validate()
             if (!validationResult.isValid) {
-                log.warn("Connector '${instance.name}' validation failed: ${validationResult.errors.joinToString(", ")}")
-                return null
+                return Result.failure(
+                    IllegalStateException(
+                        "Invalid configuration for '${instance.name}': ${validationResult.errors.joinToString(", ")}",
+                    ),
+                )
             }
 
             log.trace("Creating transport for connector '${instance.name}'")
             val transport = try {
                 connector.createTransport()
             } catch (e: Exception) {
-                log.error(
-                    "Failed to create transport for '${instance.name}': ${e.javaClass.simpleName}: ${e.message}",
-                    e,
+                return Result.failure(
+                    IllegalStateException(
+                        "Cannot connect to '${instance.name}': ${e.message}",
+                        e,
+                    ),
                 )
-                return null
             }
 
             log.trace("Creating MCP client for instance '${instance.name}'")
@@ -84,34 +82,43 @@ class McpClientFactory(
                 .build()
 
             log.debug("Successfully created MCP client for '${instance.name}'")
-            client
+            Result.success(client)
         } catch (e: Exception) {
-            log.error(
-                "Failed to create MCP client for '${instance.name}': ${e.javaClass.simpleName}: ${e.message}",
-                e,
+            Result.failure(
+                IllegalStateException(
+                    "Failed to create MCP client for '${instance.name}': ${e.message}",
+                    e,
+                ),
             )
-            null
         }
     }
 
     /**
      * Connects to [instance], fetches its tool list, and returns classified [ToolConfig]s.
      *
-     * This overload requires no `projectId` — it is suitable for one-off tool listing
-     * (e.g. the Tools dialog, the Add Integration dialog preview) where caching is
-     * handled by the caller or not needed at all.
+     * Returns [Result.failure] with the root cause so callers can surface a meaningful message.
      */
-    suspend fun listTools(instance: McpInstance): List<ToolConfig> {
+    suspend fun listTools(instance: McpInstance): Result<List<ToolConfig>> {
         val clientKey = "list_${instance.id}_${System.currentTimeMillis()}"
         val mcpClient = createMcpClient(instance, clientKey)
-            ?: throw IllegalStateException("Failed to create MCP client for instance '${instance.name}'")
+            .getOrElse { return Result.failure(it) }
 
-        return mcpClient.listTools().map { toolSpec ->
-            ToolConfig(
-                specification = toolSpec,
-                category = inferToolCategory(toolSpec),
-                strategy = inferToolStrategy(toolSpec),
-                source = ToolSource.MCP_EXTERNAL,
+        return try {
+            val tools = mcpClient.listTools().map { toolSpec ->
+                ToolConfig(
+                    specification = toolSpec,
+                    category = inferToolCategory(toolSpec),
+                    strategy = inferToolStrategy(toolSpec),
+                    source = ToolSource.MCP_EXTERNAL,
+                )
+            }
+            Result.success(tools)
+        } catch (e: Exception) {
+            Result.failure(
+                IllegalStateException(
+                    "Failed to list tools from '${instance.name}': ${e.message}",
+                    e,
+                ),
             )
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/mcp/ProjectMcpInstanceService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/ProjectMcpInstanceService.kt
@@ -211,7 +211,7 @@ class ProjectMcpInstanceService(
     suspend fun createMcpClient(
         instance: McpInstance,
         clientKey: String,
-    ): DefaultMcpClient? = mcpClientFactory.createMcpClient(instance, clientKey)
+    ): Result<DefaultMcpClient> = mcpClientFactory.createMcpClient(instance, clientKey)
 
     /** Delegates to [McpClientFactory.inferToolCategory]. */
     fun inferToolCategory(toolSpec: ToolSpecification): ToolCategory = mcpClientFactory.inferToolCategory(toolSpec)
@@ -221,30 +221,19 @@ class ProjectMcpInstanceService(
 
     /**
      * Fetch, classify and cache tools from a single MCP instance.
-     * This is the single source of truth for:
-     *  - MCP client creation
-     *  - Tool listing
-     *  - Client cache population (so [getMcpClientForTool] works immediately)
-     *  - Category / strategy inference vs. user-override lookup
-     *  - Accumulation of newly-inferred configs for the caller to persist
      *
-     * @param projectId The project ID
-     * @param instance The MCP instance to fetch tools from
-     * @param userConfigs Persisted user-customized tool configs keyed by "instanceId:toolName"
-     * @param newlyInferredConfigs Mutable list accumulating newly-inferred configs for the caller to persist
-     * @return List of classified [ToolConfig], or null if the MCP client could not be created
+     * @return [Result.failure] with the root cause if the MCP client could not be created
+     *         or tool listing fails, so the caller can surface the real error to the user.
      */
     private suspend fun fetchToolsFromInstance(
         projectId: String,
         instance: McpInstance,
         userConfigs: Map<String, ToolConfigData> = emptyMap(),
         newlyInferredConfigs: MutableList<ToolConfigData> = mutableListOf(),
-    ): List<ToolConfig>? {
+    ): Result<List<ToolConfig>> {
         val clientKey = "tools_${projectId}_${instance.id}"
-        val mcpClient = createMcpClient(instance, clientKey) ?: run {
-            log.warn("Failed to create MCP client for instance '${instance.name}'")
-            return null
-        }
+        val mcpClient = createMcpClient(instance, clientKey)
+            .getOrElse { return Result.failure(it) }
 
         log.debug("Fetching tools from MCP client for '${instance.name}'")
         val toolSpecs = mcpClient.listTools()
@@ -256,48 +245,50 @@ class ProjectMcpInstanceService(
 
         log.debug("Fetched ${toolSpecs.size} tools from instance '${instance.name}'")
 
-        return toolSpecs.map { toolSpec ->
-            val toolName = toolSpec.name()
-            val compositeKey = "${instance.id}:$toolName"
-            val userConfig = userConfigs[compositeKey]
+        return Result.success(
+            toolSpecs.map { toolSpec ->
+                val toolName = toolSpec.name()
+                val compositeKey = "${instance.id}:$toolName"
+                val userConfig = userConfigs[compositeKey]
 
-            if (userConfig != null && !userConfig.autoInferred) {
-                // Use user's custom classification
-                log.trace("Using user-customized config for tool '{}': {}, {}", toolName, userConfig.category, userConfig.strategy)
-                ToolConfig(
-                    specification = toolSpec,
-                    category = ToolCategory.valueOf(userConfig.category),
-                    strategy = userConfig.strategy,
-                    source = ToolSource.MCP_EXTERNAL,
-                    serverId = instance.id,
-                )
-            } else {
-                // Auto-infer classification
-                val inferredCategory = inferToolCategory(toolSpec)
-                val inferredStrategy = inferToolStrategy(toolSpec)
-                log.trace("Auto-inferred tool '{}': {}, {}", toolName, inferredCategory, inferredStrategy)
+                if (userConfig != null && !userConfig.autoInferred) {
+                    // Use user's custom classification
+                    log.trace("Using user-customized config for tool '{}': {}, {}", toolName, userConfig.category, userConfig.strategy)
+                    ToolConfig(
+                        specification = toolSpec,
+                        category = ToolCategory.valueOf(userConfig.category),
+                        strategy = userConfig.strategy,
+                        source = ToolSource.MCP_EXTERNAL,
+                        serverId = instance.id,
+                    )
+                } else {
+                    // Auto-infer classification
+                    val inferredCategory = inferToolCategory(toolSpec)
+                    val inferredStrategy = inferToolStrategy(toolSpec)
+                    log.trace("Auto-inferred tool '{}': {}, {}", toolName, inferredCategory, inferredStrategy)
 
-                if (userConfig == null) {
-                    newlyInferredConfigs.add(
-                        ToolConfigData(
-                            toolName = toolName,
-                            instanceId = instance.id,
-                            category = inferredCategory.name,
-                            strategy = inferredStrategy,
-                            autoInferred = true,
-                        ),
+                    if (userConfig == null) {
+                        newlyInferredConfigs.add(
+                            ToolConfigData(
+                                toolName = toolName,
+                                instanceId = instance.id,
+                                category = inferredCategory.name,
+                                strategy = inferredStrategy,
+                                autoInferred = true,
+                            ),
+                        )
+                    }
+
+                    ToolConfig(
+                        specification = toolSpec,
+                        category = inferredCategory,
+                        strategy = inferredStrategy,
+                        source = ToolSource.MCP_EXTERNAL,
+                        serverId = instance.id,
                     )
                 }
-
-                ToolConfig(
-                    specification = toolSpec,
-                    category = inferredCategory,
-                    strategy = inferredStrategy,
-                    source = ToolSource.MCP_EXTERNAL,
-                    serverId = instance.id,
-                )
-            }
-        }
+            },
+        )
     }
 
     /**
@@ -320,11 +311,11 @@ class ProjectMcpInstanceService(
      * @param projectId The project ID
      * @return List of [ToolConfig] with hybrid user/auto classifications
      */
-    suspend fun getProjectTools(projectId: String): List<ToolConfig> {
+    suspend fun getProjectTools(projectId: String): Result<List<ToolConfig>> = runCatching {
         val cachedTools = projectToolsCache.getIfPresent(projectId)
         if (cachedTools != null) {
             log.debug("Returning cached tools for project {} ({} tools)", projectId, cachedTools.size)
-            return cachedTools
+            return@runCatching cachedTools
         }
 
         log.debug("Cache miss for project {}, fetching tools from MCP servers", projectId)
@@ -332,7 +323,7 @@ class ProjectMcpInstanceService(
         val instances = getEnabledInstances(projectId)
         if (instances.isEmpty()) {
             log.debug("No active MCP instances for project {}, returning empty list", projectId)
-            return emptyList()
+            return@runCatching emptyList()
         }
 
         val userConfigs = ProjectMcpToolsConfig.load(projectId)
@@ -340,13 +331,12 @@ class ProjectMcpInstanceService(
         val allTools = mutableListOf<ToolConfig>()
 
         instances.forEach { instance ->
-            try {
-                val tools = fetchToolsFromInstance(projectId, instance, userConfigs, newlyInferredConfigs)
-                    ?: return@forEach
-                allTools.addAll(tools)
-            } catch (e: Exception) {
-                log.error("Failed to fetch tools from instance '${instance.name}': ${e.message}", e)
-            }
+            val tools = fetchToolsFromInstance(projectId, instance, userConfigs, newlyInferredConfigs)
+                .getOrElse { e ->
+                    log.warn("Skipping instance '${instance.name}': ${e.message}")
+                    return@forEach
+                }
+            allTools.addAll(tools)
         }
 
         if (newlyInferredConfigs.isNotEmpty()) {
@@ -368,11 +358,9 @@ class ProjectMcpInstanceService(
         projectToolsCache.put(projectId, allTools)
         log.debug("Cached {} tools for project {}", allTools.size, projectId)
 
-        // Build and cache the vector index from the freshly loaded tools.
-        // Done here so the index is always consistent with the tools cache.
         buildAndCacheVectorIndex(projectId, allTools)
 
-        return allTools
+        allTools
     }
 
     /**
@@ -447,50 +435,6 @@ class ProjectMcpInstanceService(
     }
 
     /**
-     * Allow user to customize tool classification.
-     * This overrides auto-inferred category/strategy.
-     *
-     * @param projectId The project ID
-     * @param instanceId The MCP instance ID
-     * @param toolName The tool name to customize
-     * @param category User-selected category
-     * @param strategy User-selected strategy
-     * @return Result with updated ToolConfigData
-     */
-    fun customizeToolConfig(
-        projectId: String,
-        instanceId: String,
-        toolName: String,
-        category: ToolCategory,
-        strategy: Int,
-    ): Result<ToolConfigData> {
-        return try {
-            // Get existing config (might be auto-inferred or user-customized)
-            val existing = ProjectMcpToolsConfig.get(projectId, instanceId, toolName)
-                ?: return Result.failure(IllegalArgumentException("Tool not found: $toolName"))
-
-            // Update with user's custom values
-            val updated = existing.copy(
-                category = category.name,
-                strategy = strategy,
-                autoInferred = false, // ✅ Mark as user-customized!
-                updatedAt = LocalDateTime.now(),
-            )
-
-            ProjectMcpToolsConfig.update(projectId, updated)
-
-            // Invalidate tools cache to pick up the customization
-            invalidateProjectToolsCache(projectId)
-
-            log.debug("User customized tool '$toolName': $category, $strategy")
-            Result.success(updated)
-        } catch (e: Exception) {
-            log.warn("Failed to customize tool config: ${e.message}")
-            Result.failure(e)
-        }
-    }
-
-    /**
      * List available tools for a specific MCP server instance.
      *
      * Reuses [fetchToolsFromInstance] so the MCP client is cached and
@@ -498,16 +442,12 @@ class ProjectMcpInstanceService(
      *
      * @param projectId The project ID
      * @param instanceId The instance ID to get tools for
-     * @return List of [ToolConfig]
-     * @throws IllegalArgumentException if instance is not found
-     * @throws IllegalStateException if MCP client creation fails
      */
-    suspend fun listTools(projectId: String, instanceId: String): List<ToolConfig> {
+    suspend fun listTools(projectId: String, instanceId: String): Result<List<ToolConfig>> {
         val instance = getInstance(projectId, instanceId)
-            ?: throw IllegalArgumentException("Instance not found: $instanceId")
+            ?: return Result.failure(IllegalArgumentException("Instance not found: $instanceId"))
 
         return fetchToolsFromInstance(projectId, instance)
-            ?: throw IllegalStateException("Failed to create MCP client for instance '${instance.name}'")
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/ToolProviderImpl.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ToolProviderImpl.kt
@@ -124,12 +124,20 @@ class ToolProviderImpl(
         // Project-scoped tools — only when inside a project
         val projectTools: List<ToolConfig> = if (projectId != null) {
             runBlocking { projectMcpInstanceService.getProjectTools(projectId) }
+                .getOrElse { e ->
+                    log.warn("Failed to load project MCP tools for project {}: {}", projectId, e.message)
+                    emptyList()
+                }
         } else {
             emptyList()
         }
 
         // Global tools — always available in every chat
         val globalTools: List<ToolConfig> = runBlocking { globalMcpInstanceService.getGlobalTools() }
+            .getOrElse { e ->
+                log.warn("Failed to load global MCP tools: {}", e.message)
+                emptyList()
+            }
 
         // Merge: project tools take precedence over global tools with same name
         val projectToolNames = projectTools.map { it.specification.name() }.toSet()

--- a/shared/src/testFixtures/kotlin/io/askimo/test/extensions/AskimoTestHome.kt
+++ b/shared/src/testFixtures/kotlin/io/askimo/test/extensions/AskimoTestHome.kt
@@ -99,6 +99,7 @@ class AskimoTestHomeExtension :
         // any code that calls AppConfig will load the default values from the YAML
         // (e.g. models[OLLAMA].embeddingModel == "nomic-embed-text:latest")
         AppConfig.initForTest(AskimoHome.base())
+        AppConfig.setSecureSessionManagerForTest(TestSecureSessionManager())
 
         // Also use thread-local for compatibility
         val testBaseScope = AskimoHome.withTestBase(tempDir, profileName)

--- a/shared/src/testFixtures/kotlin/io/askimo/test/extensions/TestSecureSessionManager.kt
+++ b/shared/src/testFixtures/kotlin/io/askimo/test/extensions/TestSecureSessionManager.kt
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.test.extensions
+
+import io.askimo.core.providers.ModelProvider
+import io.askimo.core.security.SecureSessionManager
+
+/**
+ * Test-safe subclass of [SecureSessionManager] that prefixes all keychain keys with "test_"
+ * to prevent test runs from reading or overwriting a developer's real API keys in the keychain.
+ */
+class TestSecureSessionManager : SecureSessionManager() {
+    override fun providerKey(provider: ModelProvider): String = "test_${provider.name.lowercase()}"
+}


### PR DESCRIPTION
- Replace nullable MCP client creation with Result-based APIs in shared services
- Propagate tool listing failures to callers so UI flows can handle errors safely
- Show localized application error dialogs when chat tool loading fails unexpectedly
- Update MCP dialogs and tab content to fold success and failure paths explicitly
- Move test secure session manager into shared test fixtures to avoid keychain collisions
- Add generic localized app error messages and align tool provider fallbacks with warnings