### PR TITLE
feat(image-model): preserve generated images without re-uploading them

### DIFF
--- a/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
@@ -61,10 +61,36 @@ data class MemoryMessage(
 
     companion object {
         /**
-         * Create a MemoryMessage from a LangChain4j ChatMessage
+         * Regex that matches a Markdown image whose src is a base64 data URL.
+         * Captures the alt text so we can replace the whole tag with a short placeholder.
+         *
+         * Pattern: ![alt](data:image/...;base64,<data>)
+         */
+        private val BASE64_IMAGE_REGEX =
+            Regex("""!\[([^]]*?)]\(data:image/[^;]+;base64,[A-Za-z0-9+/=\r\n]+\)""")
+
+        /**
+         * Remove all inline base64 images from [text], replacing each with a short
+         * human-readable placeholder.  Any surrounding blank lines are collapsed to
+         * a single blank line so the rest of the message still reads naturally.
+         */
+        fun stripBase64Images(text: String): String {
+            val stripped = BASE64_IMAGE_REGEX.replace(text) { match ->
+                val alt = match.groupValues[1].trim()
+                if (alt.isNotEmpty()) "[Image: $alt]" else "[Image]"
+            }
+            // Collapse runs of blank lines left behind by the removal
+            return stripped.replace(Regex("\n{3,}"), "\n\n").trim()
+        }
+
+        /**
+         * Create a MemoryMessage from a LangChain4j ChatMessage.
+         * Base64 image data is stripped and replaced with a short placeholder so
+         * images are never persisted to the database or re-sent on every API call.
          */
         fun from(chatMessage: ChatMessage): MemoryMessage {
-            val content = chatMessage.getTextContent()
+            val rawContent = chatMessage.getTextContent()
+            val content = stripBase64Images(rawContent)
             val type = when (chatMessage) {
                 is UserMessage -> MessageRole.USER.value
                 is AiMessage -> MessageRole.ASSISTANT.value
@@ -90,6 +116,21 @@ fun ChatMessage.getTextContent(): String = when (this) {
     is SystemMessage -> this.text() ?: ""
     is ToolExecutionResultMessage -> this.text() ?: ""
     else -> ""
+}
+
+/**
+ * Returns a copy of this [ChatMessage] with all inline base64 images stripped.
+ * The message type is preserved; only the text content is sanitised.
+ */
+fun ChatMessage.stripImages(): ChatMessage {
+    val stripped = MemoryMessage.stripBase64Images(getTextContent())
+    return when (this) {
+        is UserMessage -> UserMessage.from(stripped)
+        is AiMessage -> AiMessage.from(stripped)
+        is SystemMessage -> SystemMessage.from(stripped)
+        is ToolExecutionResultMessage -> ToolExecutionResultMessage.builder().text(stripped).build()
+        else -> UserMessage.from(stripped)
+    }
 }
 
 /**

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -171,7 +171,9 @@ class TokenAwareSummarizingMemory(
             )
         }
 
-        addAll(messages)
+        // Strip base64 image data before sending to the AI so images are never
+        // re-uploaded on every subsequent request (cost + latency).
+        addAll(messages.map { it.stripImages() })
     }
 
     override fun clear() {
@@ -264,10 +266,12 @@ class TokenAwareSummarizingMemory(
     }
 
     /**
-     * Estimates total token count of all messages in memory (thread-safe)
+     * Estimates total token count of all messages in memory (thread-safe).
+     * Base64 image data is stripped before counting so images don't inflate the estimate.
      */
     private fun estimateTotalTokens(): Int = synchronized(messages) {
         messages
+            .map { it.stripImages() }
             .filter { it.getTextContent().isNotBlank() }
             .sumOf { message ->
                 tokenEstimator(message)
@@ -415,10 +419,11 @@ class TokenAwareSummarizingMemory(
     /**
      * Build conversation text from messages for AI summarization.
      * Only includes User and AI messages, excluding system messages as they are instructions.
+     * Base64 image data is stripped and replaced with placeholders.
      */
     private fun buildConversationText(messages: List<ChatMessage>): String = buildString {
         messages.filterNot { it.type() == ChatMessageType.SYSTEM }.forEach { message ->
-            appendLine("${message.type()}: ${message.getTextContent()}")
+            appendLine("${message.type()}: ${MemoryMessage.stripBase64Images(message.getTextContent())}")
             appendLine()
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -5,6 +5,7 @@
 package io.askimo.core.providers
 
 import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.model.googleai.GeneratedImageHelper
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ChatContext
 import io.askimo.core.exception.ToolExecutionException
@@ -102,7 +103,20 @@ fun ChatClient.sendStreamingMessageWithCallback(
                         .onPartialResponse { chunk ->
                             sb.append(chunk)
                             onToken(chunk)
-                        }.onCompleteResponse {
+                        }.onCompleteResponse { response ->
+                            val aiMessage = response.aiMessage()
+                            if (GeneratedImageHelper.hasGeneratedImages(aiMessage)) {
+                                val generatedImages = GeneratedImageHelper.getGeneratedImages(aiMessage)
+                                generatedImages?.forEach { image ->
+                                    if (image != null) {
+                                        val base64Data = image.base64Data()
+                                        val mimeType = image.mimeType() ?: "image/png"
+                                        val markdownImage = "\n![Generated Image](data:$mimeType;base64,$base64Data)\n"
+                                        sb.append(markdownImage)
+                                        onToken(markdownImage)
+                                    }
+                                }
+                            }
                             done.countDown()
                         }.onToolExecuted { tool ->
 //                            if (tool.hasFailed()) {


### PR DESCRIPTION
- Append generated image outputs as markdown data URLs in streamed AI responses
- Strip base64 image payloads from memory messages before reuse and summarization
- Replace embedded images with short placeholders to retain conversational context
- Exclude image data from token estimates to avoid inflated counts
- Reduce repeated image upload cost and latency on subsequent requests