### PR TITLE
refactor(desktop): use shared terminal panel API and align module metadata

### DIFF
--- a/desktop-shared/build.gradle.kts
+++ b/desktop-shared/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     `maven-publish`
 }
 
+group = rootProject.group
+version = rootProject.version
+
 publishing {
     publications {
         create<MavenPublication>("maven") {

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.FrameWindowScope
@@ -997,8 +996,8 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                     if (showTerminalPanel) {
                         terminalPanel(
                             onClose = { showTerminalPanel = false },
-                            size = terminalPanelSize,
-                            onSizeChange = { newSize -> terminalPanelSize = newSize },
+                            panelHeight = terminalPanelSize,
+                            onHeightChange = { newSize -> terminalPanelSize = newSize },
                             pendingCommand = pendingTerminalCommand,
                             modifier = Modifier.fillMaxWidth(),
                         )
@@ -1700,24 +1699,4 @@ fun mainContent(
             }
         }
     }
-}
-
-/**
- * Terminal panel with resizable height
- */
-@Composable
-private fun terminalPanel(
-    onClose: () -> Unit,
-    size: Dp,
-    onSizeChange: (Dp) -> Unit,
-    pendingCommand: PendingTerminalCommand?,
-    modifier: Modifier = Modifier,
-) {
-    terminalPanel(
-        onClose = onClose,
-        panelHeight = size,
-        onHeightChange = onSizeChange,
-        pendingCommand = pendingCommand,
-        modifier = modifier.fillMaxWidth(),
-    )
 }


### PR DESCRIPTION
- remove the desktop-only terminal panel wrapper in favor of the shared API
- rename sizing usage to panelHeight to match the shared component contract
- set desktop-shared group and version from the root project for consistency
- reduce duplicated desktop code and keep module publishing metadata aligned