### PR TITLE
ci(publish): publish packages with the release version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -23,37 +25,28 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Read project version
+      - name: Bump patch version
         id: version
-        run: echo "version=$(grep '^projectVersion=' gradle.properties | cut -d'=' -f2)" >> $GITHUB_OUTPUT
-
-      - name: Delete existing package versions
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          PACKAGES=("io.askimo.shared" "io.askimo.desktop-shared")
-          for PACKAGE in "${PACKAGES[@]}"; do
-            echo "Looking for existing versions of $PACKAGE@$VERSION..."
-            VERSION_IDS=$(gh api \
-              "/user/packages/maven/${PACKAGE}/versions" \
-              --jq ".[] | select(.name == \"$VERSION\") | .id" 2>&1) || {
-              echo "Package $PACKAGE not found or no versions yet, skipping."
-              continue
-            }
-            for ID in $VERSION_IDS; do
-              echo "Deleting version $ID of $PACKAGE..."
-              gh api --method DELETE "/user/packages/maven/${PACKAGE}/versions/$ID" \
-                && echo "Deleted $ID" \
-                || echo "Warning: failed to delete $ID, continuing anyway"
-            done
-          done
-          # Give GitHub Packages a moment to propagate the deletion
-          sleep 5
+          CURRENT=$(grep '^projectVersion=' gradle.properties | cut -d'=' -f2)
+          MAJOR=$(echo $CURRENT | cut -d'.' -f1)
+          MINOR=$(echo $CURRENT | cut -d'.' -f2)
+          PATCH=$(echo $CURRENT | cut -d'.' -f3)
+          NEW="$MAJOR.$MINOR.$((PATCH + 1))"
+          sed -i "s/^projectVersion=.*/projectVersion=$NEW/" gradle.properties
+          echo "version=$NEW" >> $GITHUB_OUTPUT
+          echo "Bumped version: $CURRENT → $NEW"
+
+      - name: Commit bumped version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add gradle.properties
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          git push
 
       - name: Publish shared and desktop-shared to GitHub Packages
         run: ./gradlew :shared:publish :desktop-shared:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-

--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -760,7 +760,8 @@
     "name": "com.github.dockerjava.api.model.PeerNode",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true
+    "queryAllDeclaredConstructors": true,
+    "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
   {
     "name": "com.github.dockerjava.api.model.Ports",
@@ -4747,7 +4748,7 @@
     ]
   },
   {
-    "name": "io.askimo.core.providers.ChatClient$MockitoMock$95UhdKce",
+    "name": "io.askimo.core.providers.ChatClient$MockitoMock$uEgIRejj",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
@@ -5877,6 +5878,9 @@
     "allDeclaredClasses": true,
     "queryAllDeclaredMethods": true,
     "queryAllPublicMethods": true
+  },
+  {
+    "name": "java.lang.SecurityManager"
   },
   {
     "name": "java.lang.StackWalker",
@@ -7128,9 +7132,13 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$8mnnvm1i",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$J0OGsy2C",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
+  },
+  {
+    "name": "org.opentest4j.TestAbortedException",
+    "queryAllDeclaredMethods": true
   },
   {
     "name": "org.osgi.framework.FrameworkUtil"

--- a/cli/src/main/resources/META-INF/native-image/resource-config.json
+++ b/cli/src/main/resources/META-INF/native-image/resource-config.json
@@ -290,9 +290,6 @@
         "pattern": "\\Qorg/mockito/internal/creation/bytebuddy/inject-MockMethodDispatcher.raw\\E"
       },
       {
-        "pattern": "\\Qorg/slf4j/impl/StaticLoggerBinder.class\\E"
-      },
-      {
         "pattern": "\\Qorg/sqlite/native/Mac/aarch64/libsqlitejdbc.dylib\\E"
       },
       {

--- a/cli/src/main/resources/META-INF/native-image/serialization-config.json
+++ b/cli/src/main/resources/META-INF/native-image/serialization-config.json
@@ -1,10 +1,37 @@
 {
   "types": [
     {
+      "name": "byte[]"
+    },
+    {
       "name": "java.lang.Enum"
     },
     {
+      "name": "java.lang.Exception"
+    },
+    {
       "name": "java.lang.Object[]"
+    },
+    {
+      "name": "java.lang.RuntimeException"
+    },
+    {
+      "name": "java.lang.StackTraceElement"
+    },
+    {
+      "name": "java.lang.StackTraceElement[]"
+    },
+    {
+      "name": "java.lang.String"
+    },
+    {
+      "name": "java.lang.Throwable"
+    },
+    {
+      "name": "java.util.ArrayList"
+    },
+    {
+      "name": "java.util.Collections$EmptyList"
     },
     {
       "name": "java.util.HashSet"
@@ -32,6 +59,12 @@
     },
     {
       "name": "java.util.concurrent.locks.ReentrantLock$Sync"
+    },
+    {
+      "name": "org.opentest4j.IncompleteExecutionException"
+    },
+    {
+      "name": "org.opentest4j.TestAbortedException"
     }
   ],
   "lambdaCapturingTypes": [],


### PR DESCRIPTION
- grant workflow write access to commit and push version bumps
- configure checkout to use the GitHub token for authenticated pushes
- commit updated gradle.properties during publish to keep versions aligned
- refresh native-image reflect and serialization metadata for release builds
- remove obsolete StaticLoggerBinder resource entry from native-image config