### PR TITLE
refactor(ui-theme): rename ComponentColors to AppComponents

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -86,7 +86,7 @@ import io.askimo.core.util.TimeUtil
 import io.askimo.core.util.formatFileSize
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.util.Platform
@@ -275,7 +275,7 @@ fun chatInputField(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 8.dp),
-                colors = ComponentColors.bannerCardColors(),
+                colors = AppComponents.bannerCardColors(),
             ) {
                 Row(
                     modifier = Modifier
@@ -439,7 +439,7 @@ fun chatInputField(
                             } else {
                                 null
                             },
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
 
                         // Status badge bar - height is 0 when no status
@@ -519,7 +519,7 @@ fun chatInputField(
                                 IconButton(
                                     onClick = { onSendMessage(creationMode, disabledServerIds) },
                                     enabled = inputText.text.isNotBlank(),
-                                    colors = ComponentColors.primaryIconButtonColors(),
+                                    colors = AppComponents.primaryIconButtonColors(),
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                 ) {
                                     Icon(
@@ -579,7 +579,7 @@ fun chatInputField(
                             },
                             enabled = !isLoading,
                             colors = if (creationMode is CreationMode.Image) {
-                                ComponentColors.primaryIconButtonColors()
+                                AppComponents.primaryIconButtonColors()
                             } else {
                                 IconButtonDefaults.iconButtonColors()
                             },
@@ -934,7 +934,7 @@ private fun mcpServerItem(
     Box {
         Card(
             modifier = Modifier.fillMaxWidth(),
-            colors = ComponentColors.surfaceVariantCardColors(),
+            colors = AppComponents.surfaceVariantCardColors(),
         ) {
             Row(
                 modifier = Modifier
@@ -1023,7 +1023,7 @@ private fun mcpServerItem(
         }
 
         // Submenu dropdown with tools
-        ComponentColors.themedDropdownMenu(
+        AppComponents.dropdownMenu(
             expanded = showToolsSubmenu,
             onDismissRequest = {
                 showToolsSubmenu = false
@@ -1080,7 +1080,7 @@ private fun mcpServerItem(
                                 }
                             },
                             onClick = { /* Tools are read-only for now */ },
-                            colors = ComponentColors.menuItemColors(),
+                            colors = AppComponents.menuItemColors(),
                         )
                     }
                 }
@@ -1096,7 +1096,7 @@ private fun fileAttachmentItem(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.surfaceVariantCardColors(),
+        colors = AppComponents.surfaceVariantCardColors(),
     ) {
         Row(
             modifier = Modifier

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -90,7 +90,7 @@ import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.KeyMapManager.AppShortcut
 import io.askimo.ui.common.preferences.ApplicationPreferences
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.service.AvatarService
@@ -381,7 +381,7 @@ fun chatView(
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                     colors = CardDefaults.cardColors(
-                        containerColor = ComponentColors.sidebarSurfaceColor(),
+                        containerColor = AppComponents.sidebarSurfaceColor(),
                         contentColor = MaterialTheme.colorScheme.onSurface,
                     ),
                 ) {
@@ -649,7 +649,7 @@ fun chatView(
                                     }
                                 }
 
-                                ComponentColors.themedDropdownMenu(
+                                AppComponents.dropdownMenu(
                                     expanded = directiveDropdownExpanded,
                                     onDismissRequest = { directiveDropdownExpanded = false },
                                     modifier = Modifier.fillMaxWidth(0.3f),
@@ -843,7 +843,7 @@ fun chatView(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Row(
                         modifier = Modifier
@@ -868,7 +868,7 @@ fun chatView(
                                 .focusRequester(searchFocusRequester),
                             placeholder = { Text(stringResource("chat.search.placeholder")) },
                             singleLine = true,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
 
                         // Result count

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/McpTabContent.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/McpTabContent.kt
@@ -56,7 +56,7 @@ import io.askimo.core.chat.domain.Project
 import io.askimo.core.mcp.McpInstance
 import io.askimo.core.mcp.ProjectMcpInstanceService
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
@@ -232,7 +232,7 @@ private fun mcpInstanceItem(
                 } else {
                     stringResource("rag.tree.expand")
                 },
-                tint = ComponentColors.secondaryIconColor(),
+                tint = AppComponents.secondaryIconColor(),
                 modifier = Modifier.size(20.dp),
             )
 
@@ -243,7 +243,7 @@ private fun mcpInstanceItem(
                 tint = if (instance.enabled) {
                     MaterialTheme.colorScheme.onSurface
                 } else {
-                    ComponentColors.secondaryIconColor()
+                    AppComponents.secondaryIconColor()
                 },
                 modifier = Modifier.size(20.dp),
             )
@@ -265,7 +265,7 @@ private fun mcpInstanceItem(
                     Text(
                         text = stringResource("mcp.instance.disabled"),
                         style = MaterialTheme.typography.bodySmall,
-                        color = ComponentColors.secondaryTextColor(),
+                        color = AppComponents.secondaryTextColor(),
                     )
                 }
             }
@@ -309,7 +309,7 @@ private fun mcpInstanceItem(
                             Text(
                                 text = stringResource("mcp.tools.loading"),
                                 style = MaterialTheme.typography.bodySmall,
-                                color = ComponentColors.secondaryTextColor(),
+                                color = AppComponents.secondaryTextColor(),
                             )
                         }
                     }
@@ -336,7 +336,7 @@ private fun mcpInstanceItem(
                         Text(
                             text = stringResource("mcp.tools.none"),
                             style = MaterialTheme.typography.bodySmall,
-                            color = ComponentColors.secondaryTextColor(),
+                            color = AppComponents.secondaryTextColor(),
                             modifier = Modifier.padding(8.dp),
                         )
                     }
@@ -422,14 +422,14 @@ private fun toolItem(
                                         Text(
                                             text = "• $paramName",
                                             style = MaterialTheme.typography.bodySmall,
-                                            color = ComponentColors.secondaryTextColor(),
+                                            color = AppComponents.secondaryTextColor(),
                                         )
                                     }
                                     if (properties.size > 5) {
                                         Text(
                                             text = "... and ${properties.size - 5} more",
                                             style = MaterialTheme.typography.bodySmall,
-                                            color = ComponentColors.tertiaryTextColor(),
+                                            color = AppComponents.tertiaryTextColor(),
                                             fontStyle = FontStyle.Italic,
                                         )
                                     }
@@ -502,7 +502,7 @@ private fun mcpEmptyState() {
                 imageVector = Icons.Default.Extension,
                 contentDescription = null,
                 modifier = Modifier.size(64.dp),
-                tint = ComponentColors.tertiaryIconColor(),
+                tint = AppComponents.tertiaryIconColor(),
             )
 
             Text(
@@ -515,7 +515,7 @@ private fun mcpEmptyState() {
             Text(
                 text = stringResource("mcp.description"),
                 style = MaterialTheme.typography.bodySmall,
-                color = ComponentColors.secondaryTextColor(),
+                color = AppComponents.secondaryTextColor(),
                 textAlign = TextAlign.Center,
             )
         }
@@ -539,7 +539,7 @@ private fun mcpNoInstancesState() {
                 imageVector = Icons.Default.ExtensionOff,
                 contentDescription = null,
                 modifier = Modifier.size(64.dp),
-                tint = ComponentColors.tertiaryIconColor(),
+                tint = AppComponents.tertiaryIconColor(),
             )
 
             Text(
@@ -552,7 +552,7 @@ private fun mcpNoInstancesState() {
             Text(
                 text = stringResource("mcp.no.instances.description"),
                 style = MaterialTheme.typography.bodySmall,
-                color = ComponentColors.secondaryTextColor(),
+                color = AppComponents.secondaryTextColor(),
                 textAlign = TextAlign.Center,
             )
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -70,7 +70,7 @@ import io.askimo.core.util.formatFileSize
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.markdownText
 import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.common.ui.util.highlightSearchText
@@ -185,7 +185,7 @@ fun messageList(
 
     // Retry confirmation dialog
     if (showRetryConfirmDialog) {
-        ComponentColors.themedAlertDialog(
+        AppComponents.alertDialog(
             onDismissRequest = {
                 showRetryConfirmDialog = false
                 retryMessageId = null
@@ -325,14 +325,14 @@ fun messageBubble(
                                     ),
                                 colors = CardDefaults.cardColors(
                                     containerColor = if (isOutdatedMessage) {
-                                        ComponentColors.userMessageBackground().copy(alpha = 0.5f)
+                                        AppComponents.userMessageBackground().copy(alpha = 0.5f)
                                     } else {
-                                        ComponentColors.userMessageBackground()
+                                        AppComponents.userMessageBackground()
                                     },
                                     contentColor = if (isOutdatedMessage) {
                                         MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                     } else {
-                                        ComponentColors.userMessageContentColor()
+                                        AppComponents.userMessageContentColor()
                                     },
                                 ),
                                 elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -908,7 +908,7 @@ fun aiMessageEditDialog(
                         .fillMaxWidth()
                         .height(400.dp),
                     textStyle = MaterialTheme.typography.bodyMedium,
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                     label = { Text(stringResource("message.ai.edit.content.label")) },
                 )
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ProjectSidePanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ProjectSidePanel.kt
@@ -69,7 +69,7 @@ import io.askimo.core.event.internal.ProjectReIndexEvent
 import io.askimo.core.event.internal.ProjectRefreshEvent
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.project.addReferenceMaterialDialog
 import io.askimo.ui.project.buildKnowledgeSourceConfigs
 import io.askimo.ui.project.mergeKnowledgeSourceConfigs
@@ -121,7 +121,7 @@ fun projectSidePanel(
             .width(animatedWidth)
             .fillMaxHeight(),
         colors = CardDefaults.cardColors(
-            containerColor = ComponentColors.sidebarSurfaceColor(),
+            containerColor = AppComponents.sidebarSurfaceColor(),
             contentColor = MaterialTheme.colorScheme.onSurface,
         ),
     ) {
@@ -195,7 +195,7 @@ fun projectSidePanel(
                                     }
 
                                     // Dropdown menu
-                                    ComponentColors.themedDropdownMenu(
+                                    AppComponents.dropdownMenu(
                                         expanded = showContextMenu,
                                         onDismissRequest = { showContextMenu = false },
                                     ) {
@@ -544,7 +544,7 @@ private fun ragSourcesEmptyState(
                 imageVector = Icons.Default.FolderOpen,
                 contentDescription = null,
                 modifier = Modifier.size(64.dp),
-                tint = ComponentColors.tertiaryIconColor(),
+                tint = AppComponents.tertiaryIconColor(),
             )
 
             Text(
@@ -557,7 +557,7 @@ private fun ragSourcesEmptyState(
             Text(
                 text = stringResource("rag.empty.description"),
                 style = MaterialTheme.typography.bodySmall,
-                color = ComponentColors.secondaryTextColor(),
+                color = AppComponents.secondaryTextColor(),
                 textAlign = TextAlign.Center,
             )
 
@@ -582,7 +582,7 @@ private fun ragSourcesEmptyState(
             Text(
                 text = stringResource("rag.empty.coming.soon"),
                 style = MaterialTheme.typography.labelSmall,
-                color = ComponentColors.tertiaryTextColor(),
+                color = AppComponents.tertiaryTextColor(),
             )
         }
     }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/RagSourcesTree.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/RagSourcesTree.kt
@@ -53,7 +53,7 @@ import io.askimo.core.chat.domain.LocalFilesKnowledgeSourceConfig
 import io.askimo.core.chat.domain.LocalFoldersKnowledgeSourceConfig
 import io.askimo.core.chat.domain.UrlKnowledgeSourceConfig
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import java.awt.Desktop
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
@@ -253,7 +253,7 @@ private fun folderNodeItem(
                         } else {
                             stringResource("rag.tree.expand")
                         },
-                        tint = ComponentColors.secondaryIconColor(),
+                        tint = AppComponents.secondaryIconColor(),
                         modifier = Modifier.size(16.dp),
                     )
 
@@ -265,7 +265,7 @@ private fun folderNodeItem(
                             Icons.Default.Folder
                         },
                         contentDescription = null,
-                        tint = ComponentColors.secondaryIconColor(),
+                        tint = AppComponents.secondaryIconColor(),
                         modifier = Modifier.size(18.dp),
                     )
 
@@ -399,7 +399,7 @@ private fun fileNodeItem(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.InsertDriveFile,
                     contentDescription = null,
-                    tint = ComponentColors.secondaryIconColor(),
+                    tint = AppComponents.secondaryIconColor(),
                     modifier = Modifier.size(18.dp),
                 )
 
@@ -527,7 +527,7 @@ private fun urlNodeItem(
                 Icon(
                     imageVector = Icons.Default.Language,
                     contentDescription = null,
-                    tint = ComponentColors.secondaryIconColor(),
+                    tint = AppComponents.secondaryIconColor(),
                     modifier = Modifier.size(18.dp),
                 )
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/DialogState.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/DialogState.kt
@@ -73,4 +73,4 @@ class DialogState {
  * @return A remembered DialogState instance
  */
 @Composable
-fun rememberDialogState() = remember { _root_ide_package_.io.askimo.ui.common.components.DialogState() }
+fun rememberDialogState() = remember { DialogState() }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/ErrorDisplay.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/ErrorDisplay.kt
@@ -35,7 +35,7 @@ fun inlineErrorMessage(
                 text = errorMessage,
                 color = MaterialTheme.colorScheme.onErrorContainer,
                 style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(_root_ide_package_.io.askimo.ui.common.theme.Spacing.medium),
+                modifier = Modifier.padding(Spacing.medium),
             )
         }
     }
@@ -63,7 +63,7 @@ fun inlineSuccessMessage(
                 text = message,
                 color = MaterialTheme.colorScheme.onTertiaryContainer,
                 style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(_root_ide_package_.io.askimo.ui.common.theme.Spacing.medium),
+                modifier = Modifier.padding(Spacing.medium),
             )
         }
     }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/ErrorDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/ErrorDialog.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 
 @Composable
 fun errorDialog(
@@ -51,7 +51,7 @@ fun errorDialog(
     val linkColor = MaterialTheme.colorScheme.onSurface
     var showDetails by remember { mutableStateOf(false) }
 
-    _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Row(
@@ -143,11 +143,11 @@ fun errorDialog(
             }
         },
         confirmButton = {
-            _root_ide_package_.io.askimo.ui.common.components.primaryButton(
+            primaryButton(
                 onClick = onDismiss,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(_root_ide_package_.io.askimo.ui.common.i18n.stringResource("action.ok"))
+                Text(stringResource("action.ok"))
             }
         },
     )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/UpdateDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/UpdateDialog.kt
@@ -25,9 +25,8 @@ import io.askimo.core.service.UpdateInfo
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.markdownText
-import io.askimo.ui.shell.UpdateViewModel
 
 @Composable
 fun updateCheckDialog(
@@ -36,7 +35,7 @@ fun updateCheckDialog(
 ) {
     when {
         viewModel.showUpdateDialog && viewModel.releaseInfo?.isNewVersion == true -> {
-            _root_ide_package_.io.askimo.ui.common.dialog.newVersionDialog(
+            newVersionDialog(
                 releaseInfo = viewModel.releaseInfo!!,
                 currentVersion = viewModel.getCurrentVersion(),
                 onDownload = {
@@ -47,13 +46,13 @@ fun updateCheckDialog(
             )
         }
         viewModel.releaseInfo != null && !viewModel.releaseInfo!!.isNewVersion -> {
-            _root_ide_package_.io.askimo.ui.common.dialog.upToDateDialog(
+            upToDateDialog(
                 currentVersion = viewModel.getCurrentVersion(),
                 onDismiss = onDismiss,
             )
         }
         viewModel.errorMessage != null -> {
-            _root_ide_package_.io.askimo.ui.common.dialog.errorDialog(
+            errorDialog(
                 message = viewModel.errorMessage!!,
                 onDismiss = onDismiss,
             )
@@ -68,11 +67,11 @@ private fun newVersionDialog(
     onDownload: () -> Unit,
     onLater: () -> Unit,
 ) {
-    _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onLater,
         title = {
             Text(
-                text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.title"),
+                text = stringResource("update.dialog.title"),
                 style = MaterialTheme.typography.headlineSmall,
             )
         },
@@ -85,7 +84,7 @@ private fun newVersionDialog(
             ) {
                 // Header message
                 Text(
-                    text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.new.version.available"),
+                    text = stringResource("update.dialog.new.version.available"),
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
@@ -94,7 +93,7 @@ private fun newVersionDialog(
                 // Version info card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -102,7 +101,7 @@ private fun newVersionDialog(
                     ) {
                         Column {
                             Text(
-                                text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.current.version.label"),
+                                text = stringResource("update.dialog.current.version.label"),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
                             )
@@ -114,7 +113,7 @@ private fun newVersionDialog(
                         }
                         Column(horizontalAlignment = Alignment.End) {
                             Text(
-                                text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.new.version.label"),
+                                text = stringResource("update.dialog.new.version.label"),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
                             )
@@ -131,7 +130,7 @@ private fun newVersionDialog(
                 // Release info
                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(
-                        text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.release.date"),
+                        text = stringResource("update.dialog.release.date"),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                     )
@@ -144,13 +143,13 @@ private fun newVersionDialog(
                 // Release notes
                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(
-                        text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.release.notes"),
+                        text = stringResource("update.dialog.release.notes"),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                     )
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.bannerCardColors(),
+                        colors = AppComponents.bannerCardColors(),
                     ) {
                         Column(
                             modifier = Modifier
@@ -159,7 +158,7 @@ private fun newVersionDialog(
                                 .verticalScroll(rememberScrollState())
                                 .padding(12.dp),
                         ) {
-                            _root_ide_package_.io.askimo.ui.common.ui.markdownText(
+                            markdownText(
                                 markdown = releaseInfo.releaseNotes,
                                 modifier = Modifier.fillMaxWidth(),
                             )
@@ -169,17 +168,17 @@ private fun newVersionDialog(
             }
         },
         confirmButton = {
-            _root_ide_package_.io.askimo.ui.common.components.primaryButton(
+            primaryButton(
                 onClick = onDownload,
             ) {
-                Text(_root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.download"))
+                Text(stringResource("update.dialog.download"))
             }
         },
         dismissButton = {
-            _root_ide_package_.io.askimo.ui.common.components.secondaryButton(
+            secondaryButton(
                 onClick = onLater,
             ) {
-                Text(_root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.later"))
+                Text(stringResource("update.dialog.later"))
             }
         },
     )
@@ -190,30 +189,30 @@ private fun upToDateDialog(
     currentVersion: String,
     onDismiss: () -> Unit,
 ) {
-    _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
-                text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.title"),
+                text = stringResource("update.dialog.title"),
                 style = MaterialTheme.typography.headlineSmall,
             )
         },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
-                    text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.check.up.to.date"),
+                    text = stringResource("update.check.up.to.date"),
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier.padding(16.dp),
                         verticalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         Text(
-                            text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.dialog.current.version.label"),
+                            text = stringResource("update.dialog.current.version.label"),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
                         )
@@ -227,10 +226,10 @@ private fun upToDateDialog(
             }
         },
         confirmButton = {
-            _root_ide_package_.io.askimo.ui.common.components.primaryButton(
+            primaryButton(
                 onClick = onDismiss,
             ) {
-                Text(_root_ide_package_.io.askimo.ui.common.i18n.stringResource("action.ok"))
+                Text(stringResource("action.ok"))
             }
         },
     )
@@ -241,11 +240,11 @@ private fun errorDialog(
     message: String,
     onDismiss: () -> Unit,
 ) {
-    _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
-                text = _root_ide_package_.io.askimo.ui.common.i18n.stringResource("update.check.failed"),
+                text = stringResource("update.check.failed"),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.error,
             )
@@ -253,7 +252,7 @@ private fun errorDialog(
         text = {
             Card(
                 modifier = Modifier.fillMaxWidth(),
-                colors = _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.bannerCardColors(),
+                colors = AppComponents.bannerCardColors(),
             ) {
                 Text(
                     text = message,
@@ -264,10 +263,10 @@ private fun errorDialog(
             }
         },
         confirmButton = {
-            _root_ide_package_.io.askimo.ui.common.components.primaryButton(
+            primaryButton(
                 onClick = onDismiss,
             ) {
-                Text(_root_ide_package_.io.askimo.ui.common.i18n.stringResource("action.ok"))
+                Text(stringResource("action.ok"))
             }
         },
     )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/i18n/Localization.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/i18n/Localization.kt
@@ -32,7 +32,7 @@ fun provideLocalization(
     }
 
     CompositionLocalProvider(
-        _root_ide_package_.io.askimo.ui.common.i18n.defaultLocale provides locale,
+        defaultLocale provides locale,
     ) {
         content()
     }
@@ -49,7 +49,7 @@ fun provideLocalization(
 @Composable
 fun stringResource(key: String, vararg args: Any): String {
     // Access the locale to trigger recomposition when it changes
-    val currentLocale = _root_ide_package_.io.askimo.ui.common.i18n.defaultLocale.current
+    val currentLocale = defaultLocale.current
 
     // Trigger recomposition when locale changes by using it in a derived state
     return remember(key, currentLocale, *args) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/keymap/KeyMapManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/keymap/KeyMapManager.kt
@@ -24,7 +24,7 @@ object KeyMapManager {
     /**
      * Determines if the primary modifier key (Command on macOS, Ctrl on others) is pressed
      */
-    fun KeyEvent.isPrimaryModifierPressed(): Boolean = if (_root_ide_package_.io.askimo.ui.util.Platform.isMac) isMetaPressed else isCtrlPressed
+    fun KeyEvent.isPrimaryModifierPressed(): Boolean = if (Platform.isMac) isMetaPressed else isCtrlPressed
 
     /**
      * Defines all application shortcuts
@@ -100,28 +100,28 @@ object KeyMapManager {
             val parts = mutableListOf<String>()
 
             if (requiresPrimaryModifier) {
-                parts.add(_root_ide_package_.io.askimo.ui.util.Platform.modifierKey)
+                parts.add(Platform.modifierKey)
             }
             if (requiresCtrl) {
-                parts.add(if (_root_ide_package_.io.askimo.ui.util.Platform.isMac) "⌃" else "Ctrl")
+                parts.add(if (Platform.isMac) "⌃" else "Ctrl")
             }
             if (requiresShift) {
-                parts.add(if (_root_ide_package_.io.askimo.ui.util.Platform.isMac) "⇧" else "Shift")
+                parts.add(if (Platform.isMac) "⇧" else "Shift")
             }
             if (requiresAlt) {
-                parts.add(if (_root_ide_package_.io.askimo.ui.util.Platform.isMac) "⌥" else "Alt")
+                parts.add(if (Platform.isMac) "⌥" else "Alt")
             }
 
             // Special key names
             val keyName = when (key) {
-                Key.Enter -> if (_root_ide_package_.io.askimo.ui.util.Platform.isMac) "↵" else "Enter"
-                Key.Escape -> if (_root_ide_package_.io.askimo.ui.util.Platform.isMac) "⎋" else "Esc"
+                Key.Enter -> if (Platform.isMac) "↵" else "Enter"
+                Key.Escape -> if (Platform.isMac) "⎋" else "Esc"
                 Key.Comma -> ","
                 else -> key.keyCode.toInt().toChar().uppercaseChar().toString()
             }
             parts.add(keyName)
 
-            return parts.joinToString(if (_root_ide_package_.io.askimo.ui.util.Platform.isMac) "" else "+")
+            return parts.joinToString(if (Platform.isMac) "" else "+")
         }
     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -7,13 +7,11 @@ package io.askimo.ui.common.theme
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -35,13 +33,10 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 
-object ComponentColors {
+object AppComponents {
 
-    /**
-     * Navigation drawer item colors that use custom theme colors
-     * - Unselected: transparent background, normal text/icon colors
-     * - Selected: primaryContainer background (accent color), onPrimaryContainer text/icon
-     */
+    // ── Navigation ───────────────────────────────────────────────────────────
+
     @Composable
     fun navigationDrawerItemColors(): NavigationDrawerItemColors = NavigationDrawerItemDefaults.colors(
         selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -54,11 +49,6 @@ object ComponentColors {
         unselectedBadgeColor = MaterialTheme.colorScheme.onSurfaceVariant,
     )
 
-    /**
-     * Navigation rail item colors that use custom theme colors
-     * - Unselected: normal icon color
-     * - Selected: primaryContainer indicator (accent color), onPrimaryContainer icon
-     */
     @Composable
     fun navigationRailItemColors(): NavigationRailItemColors = NavigationRailItemDefaults.colors(
         selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -66,92 +56,47 @@ object ComponentColors {
         indicatorColor = MaterialTheme.colorScheme.primaryContainer,
     )
 
-    /**
-     * Primary card colors (for important info cards like Provider/Model header, selected options)
-     * - Container: primaryContainer (accent color)
-     * - Content: onPrimaryContainer
-     */
+    // ── Cards ─────────────────────────────────────────────────────────────────
+
     @Composable
     fun primaryCardColors(): CardColors = CardDefaults.cardColors(
         containerColor = MaterialTheme.colorScheme.primaryContainer,
         contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
     )
 
-    /**
-     * Banner card colors (for section headers like Chat Configuration, Font Settings)
-     * - Container: secondaryContainer (subtle accent-related color)
-     * - Content: onSecondaryContainer
-     */
     @Composable
     fun bannerCardColors(): CardColors = CardDefaults.cardColors(
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
     )
 
-    /**
-     * Secondary card colors (for search indicators, file attachments in input)
-     * - Container: secondaryContainer
-     * - Content: onSecondaryContainer
-     */
     @Composable
     fun secondaryCardColors(): CardColors = CardDefaults.cardColors(
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
     )
 
-    /**
-     * Surface variant card colors (for general cards like About page)
-     * - Container: surfaceVariant
-     * - Content: onSurfaceVariant
-     */
     @Composable
     fun surfaceVariantCardColors(): CardColors = CardDefaults.cardColors(
         containerColor = MaterialTheme.colorScheme.surfaceVariant,
         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
     )
 
-    /**
-     * Primary icon button colors
-     * - Content: primary color (accent)
-     * - Disabled: onSurface with alpha
-     */
+    // ── Buttons & Icons ───────────────────────────────────────────────────────
+
     @Composable
     fun primaryIconButtonColors(): IconButtonColors = IconButtonDefaults.iconButtonColors(
         contentColor = MaterialTheme.colorScheme.primary,
         disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
     )
 
-    /**
-     * Text button colors for primary actions
-     * - Content: primary color (accent)
-     */
     @Composable
     fun primaryTextButtonColors(): ButtonColors = ButtonDefaults.textButtonColors(
         contentColor = MaterialTheme.colorScheme.primary,
     )
 
-    /**
-     * Subtle button colors with lighter background
-     * - Container: secondaryContainer (lighter than primaryContainer)
-     * - Content: onSecondaryContainer
-     * - More subtle appearance than default buttons
-     */
-    @Composable
-    fun subtleButtonColors(): ButtonColors = ButtonDefaults.buttonColors(
-        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-    )
+    // ── Inputs ────────────────────────────────────────────────────────────────
 
-    /**
-     * Provides themed colors for outlined text fields with good contrast.
-     * - Focused border: onSurface (matches text color for consistency)
-     * - Unfocused border: outlineVariant (subtle)
-     * - Focused label: onSurface (matches text color)
-     * - Unfocused label: onSurfaceVariant (muted)
-     * - Cursor: onSurface (matches text color)
-     * - Text: onSurface (default, good contrast)
-     * - Placeholder: onSurfaceVariant (muted)
-     */
     @Composable
     fun outlinedTextFieldColors(): TextFieldColors = OutlinedTextFieldDefaults.colors(
         focusedBorderColor = MaterialTheme.colorScheme.onSurface,
@@ -161,24 +106,24 @@ object ComponentColors {
         cursorColor = MaterialTheme.colorScheme.onSurface,
     )
 
-    /**
-     * Sidebar surface color with subtle accent tint
-     * - Applies a noticeable tint of the accent color to the surface
-     * - Makes sidebar visually distinct from main content
-     * - Adapts to light/dark mode (8% tint for light, 12% for dark)
-     * - Ties into custom theme colors
-     */
+    @Composable
+    fun menuItemColors(): MenuItemColors = MenuDefaults.itemColors(
+        textColor = MaterialTheme.colorScheme.onSurface,
+        leadingIconColor = MaterialTheme.colorScheme.onSurface,
+        trailingIconColor = MaterialTheme.colorScheme.onSurface,
+        disabledTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+        disabledLeadingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+        disabledTrailingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+    )
+
+    // ── Surface Colors ────────────────────────────────────────────────────────
+
     @Composable
     fun sidebarSurfaceColor(): Color {
         val surfaceColor = MaterialTheme.colorScheme.surface
         val primaryColor = MaterialTheme.colorScheme.primary
-
-        // Determine if we're in light or dark mode
         val isLight = surfaceColor.luminance() > 0.5
-
-        // Apply noticeable tint (8% for light mode, 12% for dark mode)
         val tintAmount = if (isLight) 0.08f else 0.12f
-
         return Color(
             red = surfaceColor.red + (primaryColor.red - surfaceColor.red) * tintAmount,
             green = surfaceColor.green + (primaryColor.green - surfaceColor.green) * tintAmount,
@@ -187,14 +132,9 @@ object ComponentColors {
         )
     }
 
-    /**
-     * Background color for user message bubbles.
-     * Computed as a neutral darkened/lightened step from the surface color so it is
-     * always accent-neutral. surfaceContainerHigh inherits surfaceTint (the
-     * accent colour) and looks tinted (e.g. purple/grey) in light mode.
-     * - Light theme: surface darkened by 8% — subtle grey, no accent tint.
-     * - Dark theme:  surface lightened by 10% — slightly lighter dark surface.
-     */
+    @Composable
+    fun sidebarHeaderColor(): Color = MaterialTheme.colorScheme.secondaryContainer
+
     @Composable
     fun userMessageBackground(): Color {
         val surface = MaterialTheme.colorScheme.surface
@@ -216,20 +156,9 @@ object ComponentColors {
         }
     }
 
-    /**
-     * Content (text/icon) color for user message bubbles.
-     */
     @Composable
     fun userMessageContentColor(): Color = MaterialTheme.colorScheme.onSurface
 
-    /**
-     * Background color for code blocks in AI responses.
-     * Computed directly from surface to stay accent-neutral.
-     * surfaceContainerHighest/Low inherit surfaceTint (the accent colour)
-     * and appear tinted in themed modes.
-     * - Light theme: surface darkened by 15% — clear contrast, no accent tint.
-     * - Dark theme:  surface darkened by 15% — deeper dark, keeps dark syntax colors readable.
-     */
     @Composable
     fun codeBlockBackground(): Color {
         val surface = MaterialTheme.colorScheme.surface
@@ -251,100 +180,36 @@ object ComponentColors {
         }
     }
 
-    /**
-     * Text/content color for code blocks (used as the fallback/unstyled token color).
-     * Paired with codeBlockBackground() to ensure readable contrast.
-     */
     @Composable
     fun codeBlockContentColor(): Color = MaterialTheme.colorScheme.onSurface
 
-    /**
-     * Border color for code blocks.
-     */
     @Composable
     fun codeBlockBorderColor(): Color = MaterialTheme.colorScheme.outlineVariant
 
-    /**
-     * Returns true when the code block background is dark, so the caller can
-     * pick the correct syntax highlight theme (dark vs light).
-     */
     @Composable
     fun isCodeBlockDark(): Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5
 
-    /**
-     * Sidebar header color - uses secondaryContainer for a subtle accent
-     * - Lighter than primaryContainer (used by buttons)
-     * - Makes header visually distinct but not overwhelming
-     * - Consistent with Material3 design system
-     */
-    @Composable
-    fun sidebarHeaderColor(): Color = MaterialTheme.colorScheme.secondaryContainer
+    // ── Icon & Text Tints ─────────────────────────────────────────────────────
 
-    /**
-     * Icon tint for secondary/muted icons
-     * - Used for icons that need less emphasis than primary content
-     * - Examples: collapsed sidebar icons, secondary actions, metadata icons
-     * - Provides good contrast while being visually subdued
-     */
     @Composable
     fun secondaryIconColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
 
-    /**
-     * Icon tint for disabled or very subtle icons
-     * - Used for disabled state or very low emphasis elements
-     * - Examples: placeholder icons, disabled actions
-     * - Follows Material Design 3 guidelines (38% alpha)
-     */
     @Composable
     fun disabledIconColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
 
-    /**
-     * Icon tint for tertiary/muted icons with very low emphasis
-     * - Used for background icons or decorative elements
-     * - Examples: empty state icons, watermarks
-     * - More subdued than secondaryIconColor
-     */
     @Composable
     fun tertiaryIconColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
 
-    /**
-     * Text color for secondary text
-     * - Used for supporting text that needs less emphasis
-     * - Examples: descriptions, metadata, helper text
-     * - Better readability than tertiary text
-     */
     @Composable
     fun secondaryTextColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
 
-    /**
-     * Text color for tertiary text with minimal emphasis
-     * - Used for very subtle text elements
-     * - Examples: "(Coming soon)" labels, footnotes, timestamps
-     * - More subdued than secondary text
-     */
     @Composable
     fun tertiaryTextColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
 
-    /**
-     * Themed DropdownMenu that uses correct theme colors.
-     *
-     * DropdownMenu in Material3 uses surfaceContainer by default, which doesn't follow
-     * custom theme colors. This wrapper overrides the color scheme to use the proper
-     * surface color from the theme.
-     *
-     * Usage:
-     * ```kotlin
-     * ComponentColors.themedDropdownMenu(
-     *     expanded = expanded,
-     *     onDismissRequest = { expanded = false }
-     * ) {
-     *     DropdownMenuItem(...)
-     *     DropdownMenuItem(...)
-     * }
-     * ```
-     */
+    // ── Themed Composable Wrappers ────────────────────────────────────────────
+
     @Composable
-    fun themedDropdownMenu(
+    fun dropdownMenu(
         expanded: Boolean,
         onDismissRequest: () -> Unit,
         modifier: Modifier = Modifier,
@@ -356,57 +221,22 @@ object ComponentColors {
                 surfaceContainer = MaterialTheme.colorScheme.surface,
             ),
         ) {
-            DropdownMenu(
+            androidx.compose.material3.DropdownMenu(
                 expanded = expanded,
                 onDismissRequest = onDismissRequest,
                 offset = offset,
-                modifier = modifier
-                    .border(
-                        width = 1.dp,
-                        color = MaterialTheme.colorScheme.outlineVariant,
-                        shape = RoundedCornerShape(4.dp),
-                    ),
+                modifier = modifier.border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    shape = RoundedCornerShape(4.dp),
+                ),
                 content = content,
             )
         }
     }
 
-    /**
-     * Menu item colors that disable the hover/focus background effect.
-     * This prevents the rectangular border/background from appearing when hovering
-     * over menu items that already have their own background styling.
-     *
-     * Use this for DropdownMenuItem components to avoid hover artifacts.
-     */
     @Composable
-    fun menuItemColors(): MenuItemColors = MenuDefaults.itemColors(
-        textColor = MaterialTheme.colorScheme.onSurface,
-        leadingIconColor = MaterialTheme.colorScheme.onSurface,
-        trailingIconColor = MaterialTheme.colorScheme.onSurface,
-        disabledTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-        disabledLeadingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-        disabledTrailingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-    )
-
-    /**
-     * Themed AlertDialog that uses correct theme colors.
-     *
-     * AlertDialog in Material3 uses surfaceContainerHigh by default, which doesn't follow
-     * custom theme colors. This wrapper overrides the color scheme to use the proper
-     * surface color from the theme, ensuring dialogs match the application's theme.
-     *
-     * Usage:
-     * ```kotlin
-     * ComponentColors.themedAlertDialog(
-     *     onDismissRequest = { showDialog = false },
-     *     title = { Text("Title") },
-     *     text = { Text("Content") },
-     *     confirmButton = { Button(...) { Text("OK") } }
-     * )
-     * ```
-     */
-    @Composable
-    fun themedAlertDialog(
+    fun alertDialog(
         onDismissRequest: () -> Unit,
         confirmButton: @Composable () -> Unit,
         modifier: Modifier = Modifier,
@@ -427,7 +257,7 @@ object ComponentColors {
                 surfaceContainerHigh = MaterialTheme.colorScheme.surface,
             ),
         ) {
-            AlertDialog(
+            androidx.compose.material3.AlertDialog(
                 onDismissRequest = onDismissRequest,
                 confirmButton = confirmButton,
                 modifier = modifier,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/FontSettings.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/FontSettings.kt
@@ -3,21 +3,69 @@
  * Copyright (c) 2025 Hai Nguyen
  */
 package io.askimo.ui.common.theme
+
+import androidx.compose.material3.Typography
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.text.font.FontFamily
 
 val LocalFontScale = compositionLocalOf { 1f }
 
 data class FontSettings(
     val fontFamily: String = "System Default",
-    val fontSize: io.askimo.ui.common.theme.FontSize = _root_ide_package_.io.askimo.ui.common.theme.FontSize.MEDIUM,
+    val fontSize: FontSize = FontSize.MEDIUM,
 ) {
     companion object {
         const val SYSTEM_DEFAULT = "System Default"
     }
 }
+
 enum class FontSize(val displayName: String, val scale: Float) {
     SMALL("Small", 0.85f),
     MEDIUM("Medium", 1.0f),
     LARGE("Large", 1.15f),
     EXTRA_LARGE("Extra Large", 1.35f),
+}
+
+/**
+ * Maps font family names to predefined [FontFamily] types.
+ */
+fun loadFontFamily(fontName: String): FontFamily = when (fontName.lowercase()) {
+    "monospace", "courier", "courier new", "consolas", "monaco", "menlo",
+    "dejavu sans mono", "lucida console",
+    -> FontFamily.Monospace
+    "serif", "times", "times new roman", "georgia", "palatino",
+    "garamond", "baskerville", "book antiqua",
+    -> FontFamily.Serif
+    "cursive", "comic sans ms", "apple chancery", "brush script mt" -> FontFamily.Cursive
+    else -> FontFamily.SansSerif
+}
+
+/**
+ * Creates a [Typography] scaled and set to the font in [fontSettings].
+ */
+fun createCustomTypography(fontSettings: FontSettings): Typography {
+    val fontFamily = if (fontSettings.fontFamily == FontSettings.SYSTEM_DEFAULT) {
+        FontFamily.Default
+    } else {
+        loadFontFamily(fontSettings.fontFamily)
+    }
+    val scale = fontSettings.fontSize.scale
+    val base = Typography()
+    return Typography(
+        displayLarge = base.displayLarge.copy(fontFamily = fontFamily, fontSize = base.displayLarge.fontSize * scale),
+        displayMedium = base.displayMedium.copy(fontFamily = fontFamily, fontSize = base.displayMedium.fontSize * scale),
+        displaySmall = base.displaySmall.copy(fontFamily = fontFamily, fontSize = base.displaySmall.fontSize * scale),
+        headlineLarge = base.headlineLarge.copy(fontFamily = fontFamily, fontSize = base.headlineLarge.fontSize * scale),
+        headlineMedium = base.headlineMedium.copy(fontFamily = fontFamily, fontSize = base.headlineMedium.fontSize * scale),
+        headlineSmall = base.headlineSmall.copy(fontFamily = fontFamily, fontSize = base.headlineSmall.fontSize * scale),
+        titleLarge = base.titleLarge.copy(fontFamily = fontFamily, fontSize = base.titleLarge.fontSize * scale),
+        titleMedium = base.titleMedium.copy(fontFamily = fontFamily, fontSize = base.titleMedium.fontSize * scale),
+        titleSmall = base.titleSmall.copy(fontFamily = fontFamily, fontSize = base.titleSmall.fontSize * scale),
+        bodyLarge = base.bodyLarge.copy(fontFamily = fontFamily, fontSize = base.bodyLarge.fontSize * scale),
+        bodyMedium = base.bodyMedium.copy(fontFamily = fontFamily, fontSize = base.bodyMedium.fontSize * scale),
+        bodySmall = base.bodySmall.copy(fontFamily = fontFamily, fontSize = base.bodySmall.fontSize * scale),
+        labelLarge = base.labelLarge.copy(fontFamily = fontFamily, fontSize = base.labelLarge.fontSize * scale),
+        labelMedium = base.labelMedium.copy(fontFamily = fontFamily, fontSize = base.labelMedium.fontSize * scale),
+        labelSmall = base.labelSmall.copy(fontFamily = fontFamily, fontSize = base.labelSmall.fontSize * scale),
+    )
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/Spacing.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/Spacing.kt
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.ui.common.theme
+
+import androidx.compose.ui.unit.dp
+
+/**
+ * Standardized spacing system following Material Design 3 guidelines.
+ *
+ * - [extraSmall] 4.dp  — tight spacing within small components
+ * - [small]      8.dp  — standard spacing between related items
+ * - [medium]     12.dp — spacing between component groups within a card
+ * - [large]      16.dp — card/panel padding and spacing between cards
+ * - [extraLarge] 24.dp — major section spacing
+ */
+object Spacing {
+    val extraSmall = 4.dp
+    val small = 8.dp
+    val medium = 12.dp
+    val large = 16.dp
+    val extraLarge = 24.dp
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/Theme.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/Theme.kt
@@ -5,40 +5,9 @@
 package io.askimo.ui.common.theme
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
-
-/**
- * Standardized spacing system following Material Design 3 guidelines.
- * Use these constants throughout the application for consistent spacing.
- *
- * Guidelines:
- * - extraSmall (4.dp): Tight spacing within small components (e.g., label + description pairs)
- * - small (8.dp): Standard spacing between related items within a component
- * - medium (12.dp): Spacing between component groups within a card
- * - large (16.dp): Spacing between cards/panels and padding inside cards
- * - extraLarge (24.dp): Major section spacing
- */
-object Spacing {
-    /** 4.dp - Tight spacing for closely related elements (label + description) */
-    val extraSmall = 4.dp
-
-    /** 8.dp - Standard spacing between related items within a component */
-    val small = 8.dp
-
-    /** 12.dp - Spacing between component groups within a card */
-    val medium = 12.dp
-
-    /** 16.dp - Card/panel padding and spacing between cards */
-    val large = 16.dp
-
-    /** 24.dp - Major section spacing */
-    val extraLarge = 24.dp
-}
 
 // Light Theme Colors
 private val md_theme_light_primary = Color(0xFF006C4C)
@@ -103,74 +72,74 @@ private val md_theme_dark_outlineVariant = Color(0xFF565E59)
 private val md_theme_dark_scrim = Color(0xFF000000)
 
 val LightColorScheme = lightColorScheme(
-    primary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_primary,
-    onPrimary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onPrimary,
-    primaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_primaryContainer,
-    onPrimaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onPrimaryContainer,
-    secondary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_secondary,
-    onSecondary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onSecondary,
-    secondaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_secondaryContainer,
-    onSecondaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onSecondaryContainer,
-    tertiary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_tertiary,
-    onTertiary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onTertiary,
-    tertiaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_tertiaryContainer,
-    onTertiaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onTertiaryContainer,
-    error = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_error,
-    errorContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_errorContainer,
-    onError = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onError,
-    onErrorContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onErrorContainer,
-    background = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_background,
-    onBackground = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onBackground,
-    surface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_surface,
-    onSurface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onSurface,
-    surfaceVariant = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_surfaceVariant,
-    onSurfaceVariant = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_onSurfaceVariant,
-    outline = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_outline,
-    inverseOnSurface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_inverseOnSurface,
-    inverseSurface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_inverseSurface,
-    inversePrimary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_inversePrimary,
-    surfaceTint = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_surfaceTint,
-    outlineVariant = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_outlineVariant,
-    scrim = _root_ide_package_.io.askimo.ui.common.theme.md_theme_light_scrim,
+    primary = md_theme_light_primary,
+    onPrimary = md_theme_light_onPrimary,
+    primaryContainer = md_theme_light_primaryContainer,
+    onPrimaryContainer = md_theme_light_onPrimaryContainer,
+    secondary = md_theme_light_secondary,
+    onSecondary = md_theme_light_onSecondary,
+    secondaryContainer = md_theme_light_secondaryContainer,
+    onSecondaryContainer = md_theme_light_onSecondaryContainer,
+    tertiary = md_theme_light_tertiary,
+    onTertiary = md_theme_light_onTertiary,
+    tertiaryContainer = md_theme_light_tertiaryContainer,
+    onTertiaryContainer = md_theme_light_onTertiaryContainer,
+    error = md_theme_light_error,
+    errorContainer = md_theme_light_errorContainer,
+    onError = md_theme_light_onError,
+    onErrorContainer = md_theme_light_onErrorContainer,
+    background = md_theme_light_background,
+    onBackground = md_theme_light_onBackground,
+    surface = md_theme_light_surface,
+    onSurface = md_theme_light_onSurface,
+    surfaceVariant = md_theme_light_surfaceVariant,
+    onSurfaceVariant = md_theme_light_onSurfaceVariant,
+    outline = md_theme_light_outline,
+    inverseOnSurface = md_theme_light_inverseOnSurface,
+    inverseSurface = md_theme_light_inverseSurface,
+    inversePrimary = md_theme_light_inversePrimary,
+    surfaceTint = md_theme_light_surfaceTint,
+    outlineVariant = md_theme_light_outlineVariant,
+    scrim = md_theme_light_scrim,
 )
 
 val DarkColorScheme = darkColorScheme(
-    primary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_primary,
-    onPrimary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onPrimary,
-    primaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_primaryContainer,
-    onPrimaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onPrimaryContainer,
-    secondary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_secondary,
-    onSecondary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onSecondary,
-    secondaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_secondaryContainer,
-    onSecondaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onSecondaryContainer,
-    tertiary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_tertiary,
-    onTertiary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onTertiary,
-    tertiaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_tertiaryContainer,
-    onTertiaryContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onTertiaryContainer,
-    error = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_error,
-    errorContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_errorContainer,
-    onError = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onError,
-    onErrorContainer = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onErrorContainer,
-    background = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_background,
-    onBackground = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onBackground,
-    surface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_surface,
-    onSurface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onSurface,
-    surfaceVariant = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_surfaceVariant,
-    onSurfaceVariant = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_onSurfaceVariant,
-    outline = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_outline,
-    inverseOnSurface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_inverseOnSurface,
-    inverseSurface = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_inverseSurface,
-    inversePrimary = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_inversePrimary,
-    surfaceTint = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_surfaceTint,
-    outlineVariant = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_outlineVariant,
-    scrim = _root_ide_package_.io.askimo.ui.common.theme.md_theme_dark_scrim,
+    primary = md_theme_dark_primary,
+    onPrimary = md_theme_dark_onPrimary,
+    primaryContainer = md_theme_dark_primaryContainer,
+    onPrimaryContainer = md_theme_dark_onPrimaryContainer,
+    secondary = md_theme_dark_secondary,
+    onSecondary = md_theme_dark_onSecondary,
+    secondaryContainer = md_theme_dark_secondaryContainer,
+    onSecondaryContainer = md_theme_dark_onSecondaryContainer,
+    tertiary = md_theme_dark_tertiary,
+    onTertiary = md_theme_dark_onTertiary,
+    tertiaryContainer = md_theme_dark_tertiaryContainer,
+    onTertiaryContainer = md_theme_dark_onTertiaryContainer,
+    error = md_theme_dark_error,
+    errorContainer = md_theme_dark_errorContainer,
+    onError = md_theme_dark_onError,
+    onErrorContainer = md_theme_dark_onErrorContainer,
+    background = md_theme_dark_background,
+    onBackground = md_theme_dark_onBackground,
+    surface = md_theme_dark_surface,
+    onSurface = md_theme_dark_onSurface,
+    surfaceVariant = md_theme_dark_surfaceVariant,
+    onSurfaceVariant = md_theme_dark_onSurfaceVariant,
+    outline = md_theme_dark_outline,
+    inverseOnSurface = md_theme_dark_inverseOnSurface,
+    inverseSurface = md_theme_dark_inverseSurface,
+    inversePrimary = md_theme_dark_inversePrimary,
+    surfaceTint = md_theme_dark_surfaceTint,
+    outlineVariant = md_theme_dark_outlineVariant,
+    scrim = md_theme_dark_scrim,
 )
 
 /**
  * Creates a light color scheme with the specified accent color
  */
-fun getLightColorScheme(accentColor: io.askimo.ui.common.theme.AccentColor): ColorScheme {
-    val baseScheme = _root_ide_package_.io.askimo.ui.common.theme.LightColorScheme
+fun getLightColorScheme(accentColor: AccentColor): ColorScheme {
+    val baseScheme = LightColorScheme
     return baseScheme.copy(
         // Keep primary as accent color for backgrounds/highlights
         primary = accentColor.lightColor,
@@ -196,8 +165,8 @@ fun getLightColorScheme(accentColor: io.askimo.ui.common.theme.AccentColor): Col
 /**
  * Creates a dark color scheme with the specified accent color
  */
-fun getDarkColorScheme(accentColor: io.askimo.ui.common.theme.AccentColor): ColorScheme {
-    val baseScheme = _root_ide_package_.io.askimo.ui.common.theme.DarkColorScheme
+fun getDarkColorScheme(accentColor: AccentColor): ColorScheme {
+    val baseScheme = DarkColorScheme
     return baseScheme.copy(
         // Keep primary as accent color for backgrounds/highlights
         primary = accentColor.darkColor,
@@ -217,104 +186,5 @@ fun getDarkColorScheme(accentColor: io.askimo.ui.common.theme.AccentColor): Colo
         onSurface = Color.White,
         onBackground = Color.White,
         onSurfaceVariant = Color(0xFFE0E0E0), // Slightly darker white for secondary text
-    )
-}
-
-/**
- * Maps font family names to predefined FontFamily types
- * This provides basic font customization without requiring font file loading
- */
-private fun loadFontFamily(fontName: String): FontFamily = when (fontName.lowercase()) {
-    // Monospace fonts
-    "monospace", "courier", "courier new", "consolas", "monaco", "menlo",
-    "dejavu sans mono", "lucida console",
-    -> FontFamily.Monospace
-
-    // Serif fonts
-    "serif", "times", "times new roman", "georgia", "palatino",
-    "garamond", "baskerville", "book antiqua",
-    -> FontFamily.Serif
-
-    // Cursive fonts
-    "cursive", "comic sans ms", "apple chancery", "brush script mt" -> FontFamily.Cursive
-
-    // Default to SansSerif for all other fonts (Arial, Helvetica, Roboto, etc.)
-    else -> FontFamily.SansSerif
-}
-
-/**
- * Creates a custom Typography based on font settings
- */
-fun createCustomTypography(fontSettings: io.askimo.ui.common.theme.FontSettings): Typography {
-    val fontFamily = if (fontSettings.fontFamily == _root_ide_package_.io.askimo.ui.common.theme.FontSettings.SYSTEM_DEFAULT) {
-        FontFamily.Default
-    } else {
-        _root_ide_package_.io.askimo.ui.common.theme.loadFontFamily(fontSettings.fontFamily)
-    }
-
-    val scale = fontSettings.fontSize.scale
-    val baseTypography = Typography()
-
-    return Typography(
-        displayLarge = baseTypography.displayLarge.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.displayLarge.fontSize * scale,
-        ),
-        displayMedium = baseTypography.displayMedium.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.displayMedium.fontSize * scale,
-        ),
-        displaySmall = baseTypography.displaySmall.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.displaySmall.fontSize * scale,
-        ),
-        headlineLarge = baseTypography.headlineLarge.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.headlineLarge.fontSize * scale,
-        ),
-        headlineMedium = baseTypography.headlineMedium.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.headlineMedium.fontSize * scale,
-        ),
-        headlineSmall = baseTypography.headlineSmall.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.headlineSmall.fontSize * scale,
-        ),
-        titleLarge = baseTypography.titleLarge.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.titleLarge.fontSize * scale,
-        ),
-        titleMedium = baseTypography.titleMedium.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.titleMedium.fontSize * scale,
-        ),
-        titleSmall = baseTypography.titleSmall.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.titleSmall.fontSize * scale,
-        ),
-        bodyLarge = baseTypography.bodyLarge.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.bodyLarge.fontSize * scale,
-        ),
-        bodyMedium = baseTypography.bodyMedium.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.bodyMedium.fontSize * scale,
-        ),
-        bodySmall = baseTypography.bodySmall.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.bodySmall.fontSize * scale,
-        ),
-        labelLarge = baseTypography.labelLarge.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.labelLarge.fontSize * scale,
-        ),
-        labelMedium = baseTypography.labelMedium.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.labelMedium.fontSize * scale,
-        ),
-        labelSmall = baseTypography.labelSmall.copy(
-            fontFamily = fontFamily,
-            fontSize = baseTypography.labelSmall.fontSize * scale,
-        ),
     )
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/ThemePreferences.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/ThemePreferences.kt
@@ -33,20 +33,19 @@ object ThemePreferences {
     private const val WINDOW_X_KEY = "window_x"
     private const val WINDOW_Y_KEY = "window_y"
     private const val WINDOW_IS_MAXIMIZED_KEY = "window_is_maximized"
-    private const val USER_AVATAR_PATH_KEY = "user_avatar_path"
     private const val AI_AVATAR_PATH_KEY = "ai_avatar_path"
     private const val MAIN_SIDEBAR_WIDTH_FRACTION_KEY = "main_sidebar_width_fraction"
     private const val SETTINGS_SIDEBAR_WIDTH_FRACTION_KEY = "settings_sidebar_width_fraction"
     private val prefs = Preferences.userNodeForPackage(ThemePreferences::class.java)
 
     private val _themeMode = MutableStateFlow(loadThemeMode())
-    val themeMode: StateFlow<io.askimo.ui.common.theme.ThemeMode> = _themeMode.asStateFlow()
+    val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
 
     private val _accentColor = MutableStateFlow(loadAccentColor())
-    val accentColor: StateFlow<io.askimo.ui.common.theme.AccentColor> = _accentColor.asStateFlow()
+    val accentColor: StateFlow<AccentColor> = _accentColor.asStateFlow()
 
     private val _fontSettings = MutableStateFlow(loadFontSettings())
-    val fontSettings: StateFlow<io.askimo.ui.common.theme.FontSettings> = _fontSettings.asStateFlow()
+    val fontSettings: StateFlow<FontSettings> = _fontSettings.asStateFlow()
 
     private val _locale = MutableStateFlow(loadLocale())
     val locale: StateFlow<Locale> = _locale.asStateFlow()
@@ -54,33 +53,33 @@ object ThemePreferences {
     private val _logLevel = MutableStateFlow(loadLogLevel())
     val logLevel: StateFlow<LogLevel> = _logLevel.asStateFlow()
 
-    private fun loadThemeMode(): io.askimo.ui.common.theme.ThemeMode {
-        val themeName = prefs.get(THEME_MODE_KEY, _root_ide_package_.io.askimo.ui.common.theme.ThemeMode.SYSTEM.name)
+    private fun loadThemeMode(): ThemeMode {
+        val themeName = prefs.get(THEME_MODE_KEY, ThemeMode.SYSTEM.name)
         return try {
-            _root_ide_package_.io.askimo.ui.common.theme.ThemeMode.valueOf(themeName)
-        } catch (e: IllegalArgumentException) {
-            _root_ide_package_.io.askimo.ui.common.theme.ThemeMode.SYSTEM
+            ThemeMode.valueOf(themeName)
+        } catch (_: IllegalArgumentException) {
+            ThemeMode.SYSTEM
         }
     }
 
-    private fun loadAccentColor(): io.askimo.ui.common.theme.AccentColor {
-        val colorName = prefs.get(ACCENT_COLOR_KEY, _root_ide_package_.io.askimo.ui.common.theme.AccentColor.MODERN_GRAY.name)
+    private fun loadAccentColor(): AccentColor {
+        val colorName = prefs.get(ACCENT_COLOR_KEY, AccentColor.MODERN_GRAY.name)
         return try {
-            _root_ide_package_.io.askimo.ui.common.theme.AccentColor.valueOf(colorName)
-        } catch (e: IllegalArgumentException) {
-            _root_ide_package_.io.askimo.ui.common.theme.AccentColor.MODERN_GRAY
+            AccentColor.valueOf(colorName)
+        } catch (_: IllegalArgumentException) {
+            AccentColor.MODERN_GRAY
         }
     }
 
-    private fun loadFontSettings(): io.askimo.ui.common.theme.FontSettings {
-        val fontFamily = prefs.get(FONT_FAMILY_KEY, _root_ide_package_.io.askimo.ui.common.theme.FontSettings.SYSTEM_DEFAULT)
-        val fontSizeName = prefs.get(FONT_SIZE_KEY, _root_ide_package_.io.askimo.ui.common.theme.FontSize.MEDIUM.name)
+    private fun loadFontSettings(): FontSettings {
+        val fontFamily = prefs.get(FONT_FAMILY_KEY, FontSettings.SYSTEM_DEFAULT)
+        val fontSizeName = prefs.get(FONT_SIZE_KEY, FontSize.MEDIUM.name)
         val fontSize = try {
-            _root_ide_package_.io.askimo.ui.common.theme.FontSize.valueOf(fontSizeName)
+            FontSize.valueOf(fontSizeName)
         } catch (e: IllegalArgumentException) {
-            _root_ide_package_.io.askimo.ui.common.theme.FontSize.MEDIUM
+            FontSize.MEDIUM
         }
-        return _root_ide_package_.io.askimo.ui.common.theme.FontSettings(fontFamily, fontSize)
+        return FontSettings(fontFamily, fontSize)
     }
 
     private fun loadLocale(): Locale {
@@ -91,7 +90,7 @@ object ThemePreferences {
             // User has explicitly set a locale, use it
             return try {
                 Locale.forLanguageTag(savedLocaleTag)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 Locale.ENGLISH
             }
         }
@@ -117,12 +116,12 @@ object ThemePreferences {
         val levelName = prefs.get(LOG_LEVEL_KEY, LogLevel.INFO.name)
         val level = try {
             LogLevel.valueOf(levelName)
-        } catch (e: IllegalArgumentException) {
+        } catch (_: IllegalArgumentException) {
             LogLevel.INFO
         }
 
         // Apply saved log level on startup
-        LoggingService.updateLogLevel(LogLevel.DEBUG)
+        LoggingService.updateLogLevel(level)
 
         return level
     }
@@ -160,7 +159,7 @@ object ThemePreferences {
     fun getAvailableSystemFonts(): List<String> {
         val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
         val fonts = ge.availableFontFamilyNames.toList()
-        return listOf(_root_ide_package_.io.askimo.ui.common.theme.FontSettings.SYSTEM_DEFAULT) + fonts.sorted()
+        return listOf(FontSettings.SYSTEM_DEFAULT) + fonts.sorted()
     }
 
     // Window state management
@@ -176,19 +175,10 @@ object ThemePreferences {
     fun getWindowHeight(): Int = prefs.getInt(WINDOW_HEIGHT_KEY, -1)
     fun getWindowX(): Int = prefs.getInt(WINDOW_X_KEY, -1)
     fun getWindowY(): Int = prefs.getInt(WINDOW_Y_KEY, -1)
-    fun isWindowMaximized(): Boolean = prefs.getBoolean(WINDOW_IS_MAXIMIZED_KEY, true) // Default to maximized
+    fun isWindowMaximized(): Boolean = prefs.getBoolean(WINDOW_IS_MAXIMIZED_KEY, true)
 
     // Avatar management
-    fun getUserAvatarPath(): String? = prefs.get(USER_AVATAR_PATH_KEY, null)
     fun getAIAvatarPath(): String? = prefs.get(AI_AVATAR_PATH_KEY, null)
-
-    fun setUserAvatarPath(path: String?) {
-        if (path != null) {
-            prefs.put(USER_AVATAR_PATH_KEY, path)
-        } else {
-            prefs.remove(USER_AVATAR_PATH_KEY)
-        }
-    }
 
     fun setAIAvatarPath(path: String?) {
         if (path != null) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/AsyncImage.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/AsyncImage.kt
@@ -45,10 +45,10 @@ fun asyncImage(
                 val bytes = file.readBytes()
                 imageBitmap = Image.makeFromEncoded(bytes).toComposeImageBitmap()
             } else {
-                _root_ide_package_.io.askimo.ui.common.ui.log.error("Avatar file does not exist: $imagePath")
+                log.error("Avatar file does not exist: $imagePath")
             }
         } catch (e: Exception) {
-            _root_ide_package_.io.askimo.ui.common.ui.log.error("Failed to load avatar: ${e.message}", e)
+            log.error("Failed to load avatar: ${e.message}", e)
         }
     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/LatexRenderer.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/LatexRenderer.kt
@@ -45,7 +45,7 @@ fun latexFormula(
     val textColor = LocalContentColor.current
 
     val formulaImage = remember(latex, fontSize, textColor) {
-        _root_ide_package_.io.askimo.ui.common.ui.renderLatexToImage(latex, fontSize, textColor)
+        renderLatexToImage(latex, fontSize, textColor)
     }
 
     if (formulaImage != null) {
@@ -78,7 +78,7 @@ private fun renderLatexToImage(
     latex: String,
     fontSize: Float,
     textColor: Color,
-): ImageBitmap? = synchronized(_root_ide_package_.io.askimo.ui.common.ui.renderLock) {
+): ImageBitmap? = synchronized(renderLock) {
     try {
         val red = (textColor.red * 255).toInt().coerceIn(0, 255)
         val green = (textColor.green * 255).toInt().coerceIn(0, 255)
@@ -97,14 +97,14 @@ private fun renderLatexToImage(
             setColorMethod.isAccessible = true
             setColorMethod.invoke(formula, awtColor)
         } catch (e: Exception) {
-            _root_ide_package_.io.askimo.ui.common.ui.log.warn("Could not use setColor method: ${e.message}")
+            log.warn("Could not use setColor method: ${e.message}")
         }
 
         val icon = formula.createTeXIcon(TeXConstants.STYLE_DISPLAY, fontSize)
 
         // Ensure icon has valid dimensions
         if (icon.iconWidth <= 0 || icon.iconHeight <= 0) {
-            _root_ide_package_.io.askimo.ui.common.ui.log.error("Invalid icon dimensions: ${icon.iconWidth}x${icon.iconHeight} for latex: $normalizedLatex")
+            log.error("Invalid icon dimensions: ${icon.iconWidth}x${icon.iconHeight} for latex: $normalizedLatex")
             return@synchronized null
         }
 
@@ -150,20 +150,20 @@ private fun renderLatexToImage(
         val writeSuccess = ImageIO.write(bufferedImage, "PNG", outputStream)
 
         if (!writeSuccess) {
-            _root_ide_package_.io.askimo.ui.common.ui.log.error("Failed to write PNG for latex: $normalizedLatex")
+            log.error("Failed to write PNG for latex: $normalizedLatex")
             return@synchronized null
         }
 
         val bytes = outputStream.toByteArray()
 
         if (bytes.isEmpty()) {
-            _root_ide_package_.io.askimo.ui.common.ui.log.error("Empty PNG bytes for latex: $normalizedLatex")
+            log.error("Empty PNG bytes for latex: $normalizedLatex")
             return@synchronized null
         }
 
         Image.makeFromEncoded(bytes).toComposeImageBitmap()
     } catch (e: Exception) {
-        _root_ide_package_.io.askimo.ui.common.ui.log.error("Failed to render LaTeX: $latex - ${e.message}", e)
+        log.error("Failed to render LaTeX: $latex - ${e.message}", e)
         null
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
@@ -48,14 +48,12 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -84,7 +82,7 @@ import io.askimo.core.logging.currentFileLogger
 import io.askimo.core.util.JsonUtils.json
 import io.askimo.tools.chart.MermaidChartData
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -143,7 +141,7 @@ fun markdownText(
     val document = parser.parse(markdown)
 
     Column(modifier = modifier) {
-        _root_ide_package_.io.askimo.ui.common.ui.renderNode(document, viewportTopY, onRunRequest)
+        renderNode(document, viewportTopY, onRunRequest)
     }
 }
 
@@ -153,33 +151,33 @@ private fun renderNode(node: Node, viewportTopY: Float? = null, onRunRequest: ((
     while (child != null) {
         when (child) {
             is Paragraph -> {
-                val videoUrl = _root_ide_package_.io.askimo.ui.common.ui.extractVideoUrl(child)
+                val videoUrl = extractVideoUrl(child)
                 if (videoUrl != null) {
-                    _root_ide_package_.io.askimo.ui.common.ui.renderVideo(videoUrl)
+                    renderVideo(videoUrl)
                 } else {
-                    _root_ide_package_.io.askimo.ui.common.ui.renderParagraph(child)
+                    renderParagraph(child)
                 }
             }
-            is Heading -> _root_ide_package_.io.askimo.ui.common.ui.renderHeading(child)
-            is BulletList -> _root_ide_package_.io.askimo.ui.common.ui.renderBulletList(child)
-            is OrderedList -> _root_ide_package_.io.askimo.ui.common.ui.renderOrderedList(child)
-            is FencedCodeBlock -> _root_ide_package_.io.askimo.ui.common.ui.renderCodeBlock(
+            is Heading -> renderHeading(child)
+            is BulletList -> renderBulletList(child)
+            is OrderedList -> renderOrderedList(child)
+            is FencedCodeBlock -> renderCodeBlock(
                 child,
                 viewportTopY,
                 onRunRequest,
             )
-            is BlockQuote -> _root_ide_package_.io.askimo.ui.common.ui.renderBlockQuote(
+            is BlockQuote -> renderBlockQuote(
                 child,
                 viewportTopY,
                 onRunRequest,
             )
-            is TableBlock -> _root_ide_package_.io.askimo.ui.common.ui.renderTable(child)
+            is TableBlock -> renderTable(child)
             is Image -> {
                 val destination = child.destination
-                if (_root_ide_package_.io.askimo.ui.common.ui.isVideoUrl(destination)) {
-                    _root_ide_package_.io.askimo.ui.common.ui.renderVideo(destination)
+                if (isVideoUrl(destination)) {
+                    renderVideo(destination)
                 } else {
-                    _root_ide_package_.io.askimo.ui.common.ui.renderImage(child)
+                    renderImage(child)
                 }
             }
             else -> renderNode(child, viewportTopY, onRunRequest)
@@ -195,10 +193,10 @@ private fun renderParagraph(paragraph: Paragraph) {
     if (firstChild is Image && firstChild.next == null) {
         // Paragraph contains only an image - render as block image
         val destination = firstChild.destination
-        if (_root_ide_package_.io.askimo.ui.common.ui.isVideoUrl(destination)) {
-            _root_ide_package_.io.askimo.ui.common.ui.renderVideo(destination)
+        if (isVideoUrl(destination)) {
+            renderVideo(destination)
         } else {
-            _root_ide_package_.io.askimo.ui.common.ui.renderImage(firstChild)
+            renderImage(firstChild)
         }
         return
     }
@@ -207,7 +205,7 @@ private fun renderParagraph(paragraph: Paragraph) {
     val linkColor = MaterialTheme.colorScheme.tertiary
 
     // Extract raw text to check for LaTeX
-    val rawText = _root_ide_package_.io.askimo.ui.common.ui.extractTextContent(paragraph)
+    val rawText = extractTextContent(paragraph)
 
     // Check if this paragraph contains LaTeX formulas with \[ \] or [ ]
     val latexMatches = mutableListOf<Triple<Int, Int, String>>() // (start, end, content)
@@ -235,7 +233,7 @@ private fun renderParagraph(paragraph: Paragraph) {
                     if (content.isNotBlank() && isMathContent) {
                         val endIndex = if (hasEndBackslash) j + 2 else j + 1
                         // Fix markdown-mangled LaTeX content
-                        val fixedContent = _root_ide_package_.io.askimo.ui.common.ui.fixMarkdownMangledLatex(content)
+                        val fixedContent = fixMarkdownMangledLatex(content)
                         latexMatches.add(Triple(start, endIndex, fixedContent))
                         i = endIndex
                         break
@@ -276,7 +274,7 @@ private fun renderParagraph(paragraph: Paragraph) {
                         if (!overlaps) {
                             // Fix markdown-mangled LaTeX content
                             val fixedContent =
-                                _root_ide_package_.io.askimo.ui.common.ui.fixMarkdownMangledLatex(content)
+                                fixMarkdownMangledLatex(content)
                             latexMatches.add(Triple(start, j + 2, fixedContent))
                             foundEnd = true
                         }
@@ -319,7 +317,7 @@ private fun renderParagraph(paragraph: Paragraph) {
                 }
 
                 // Render LaTeX formula as image
-                _root_ide_package_.io.askimo.ui.common.ui.latexFormula(
+                latexFormula(
                     latex = latexContent.trim(),
                     fontSize = 32f,
                 )
@@ -365,7 +363,7 @@ private fun renderParagraph(paragraph: Paragraph) {
                         }
 
                         // Render LaTeX formula
-                        _root_ide_package_.io.askimo.ui.common.ui.latexFormula(
+                        latexFormula(
                             latex = match.groupValues[1].trim(),
                             fontSize = 28f,
                         )
@@ -390,7 +388,7 @@ private fun renderParagraph(paragraph: Paragraph) {
 
         // No LaTeX at all, render normally with full markdown support
         val annotatedText =
-            _root_ide_package_.io.askimo.ui.common.ui.buildInlineContent(paragraph, inlineCodeBg, linkColor)
+            buildInlineContent(paragraph, inlineCodeBg, linkColor)
         Text(
             text = annotatedText,
             style = MaterialTheme.typography.bodyMedium,
@@ -455,7 +453,7 @@ private fun renderHeading(heading: Heading) {
     }
 
     Text(
-        text = _root_ide_package_.io.askimo.ui.common.ui.buildInlineContent(heading, inlineCodeBg, linkColor),
+        text = buildInlineContent(heading, inlineCodeBg, linkColor),
         style = style,
         fontWeight = FontWeight.Bold,
         modifier = Modifier
@@ -472,7 +470,7 @@ private fun renderBulletList(list: BulletList) {
         var item = list.firstChild
         while (item != null) {
             if (item is ListItem) {
-                _root_ide_package_.io.askimo.ui.common.ui.renderListItem(item, "• ", inlineCodeBg)
+                renderListItem(item, "• ", inlineCodeBg)
             }
             item = item.next
         }
@@ -489,7 +487,7 @@ private fun renderOrderedList(list: OrderedList) {
         var index = list.markerStartNumber
         while (item != null) {
             if (item is ListItem) {
-                _root_ide_package_.io.askimo.ui.common.ui.renderListItem(item, "$index. ", inlineCodeBg)
+                renderListItem(item, "$index. ", inlineCodeBg)
                 index++
             }
             item = item.next
@@ -525,7 +523,7 @@ private fun renderListItem(
                 append(marker)
                 inlineContent.forEach { node ->
                     append(
-                        _root_ide_package_.io.askimo.ui.common.ui.buildInlineContentForNode(
+                        buildInlineContentForNode(
                             node,
                             inlineCodeBg,
                             linkColor,
@@ -543,8 +541,8 @@ private fun renderListItem(
         // Render nested lists
         nestedBlocks.forEach { block ->
             when (block) {
-                is BulletList -> _root_ide_package_.io.askimo.ui.common.ui.renderBulletList(block)
-                is OrderedList -> _root_ide_package_.io.askimo.ui.common.ui.renderOrderedList(block)
+                is BulletList -> renderBulletList(block)
+                is OrderedList -> renderOrderedList(block)
             }
         }
     }
@@ -561,7 +559,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
 
     // Check if this "code block" is actually just prose text
     // (AI sometimes wraps regular text in code fences by mistake)
-    if (language == null && _root_ide_package_.io.askimo.ui.common.ui.isProbablyProse(code)) {
+    if (language == null && isProbablyProse(code)) {
         // Render as a regular paragraph instead
         Text(
             text = code.trim(),
@@ -575,7 +573,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
 
     // Try to parse as chart data before rendering
     val chartData = remember(code, language) {
-        _root_ide_package_.io.askimo.ui.common.ui.parseChartData(code, language)
+        parseChartData(code, language)
     }
 
     // If we successfully parsed chart data, render it as a chart
@@ -596,7 +594,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
             ),
             elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         ) {
-            _root_ide_package_.io.askimo.ui.common.ui.mermaidChart(
+            mermaidChart(
                 data = chartData,
                 modifier = Modifier.padding(16.dp),
             )
@@ -605,18 +603,17 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
     }
 
     // Render as regular code block
-    val backgroundColor = _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.codeBlockBackground()
-    val isDark = _root_ide_package_.io.askimo.ui.common.theme.ComponentColors.isCodeBlockDark()
+    val backgroundColor = AppComponents.codeBlockBackground()
+    val isDark = AppComponents.isCodeBlockDark()
     val clipboardManager = LocalClipboardManager.current
     val density = LocalDensity.current
     var isHovered by remember { mutableStateOf(false) }
     var showCopyFeedback by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
-    var codeBlockBounds by remember { mutableStateOf<Rect?>(null) }
     var codeBlockPositionInRoot by remember { mutableStateOf<Offset?>(null) }
 
-    val theme = if (isDark) _root_ide_package_.io.askimo.ui.common.ui.CodeHighlighter.darkTheme() else _root_ide_package_.io.askimo.ui.common.ui.CodeHighlighter.lightTheme()
-    val highlightedCode = _root_ide_package_.io.askimo.ui.common.ui.CodeHighlighter.highlight(
+    val theme = if (isDark) CodeHighlighter.darkTheme() else CodeHighlighter.lightTheme()
+    val highlightedCode = CodeHighlighter.highlight(
         code = code,
         language = language,
         theme = theme,
@@ -647,7 +644,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
             .padding(vertical = 4.dp)
             .border(
                 width = 1.dp,
-                color = ComponentColors.codeBlockBorderColor(),
+                color = AppComponents.codeBlockBorderColor(),
                 shape = codeBlockShape,
             )
             .clip(codeBlockShape)
@@ -657,7 +654,6 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
             .onPointerEvent(PointerEventType.Exit) { isHovered = false }
             .onGloballyPositioned { coordinates ->
                 if (coordinates.isAttached) {
-                    codeBlockBounds = coordinates.boundsInWindow()
                     codeBlockPositionInRoot = coordinates.positionInRoot()
                 }
             },
@@ -668,15 +664,15 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
             if (it.lastOrNull()?.isEmpty() == true) it.dropLast(1) else it
         }
         val lineCount = lines.size
-        val lineNumberColor = ComponentColors.codeBlockContentColor().copy(alpha = 0.4f)
+        val lineNumberColor = AppComponents.codeBlockContentColor().copy(alpha = 0.4f)
         val lineNumberWidth = when {
             lineCount >= 1000 -> 52.dp
             lineCount >= 100 -> 42.dp
             else -> 32.dp
         }
         // Gutter background: slightly darker/lighter than the code area depending on theme
-        val gutterBackground = ComponentColors.codeBlockBackground().let { base ->
-            if (ComponentColors.isCodeBlockDark()) {
+        val gutterBackground = AppComponents.codeBlockBackground().let { base ->
+            if (AppComponents.isCodeBlockDark()) {
                 base.copy(
                     red = (base.red * 0.80f).coerceIn(0f, 1f),
                     green = (base.green * 0.80f).coerceIn(0f, 1f),
@@ -730,7 +726,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
                         text = highlightedCode,
                         style = MaterialTheme.typography.bodyMedium,
                         fontFamily = FontFamily.Monospace,
-                        color = ComponentColors.codeBlockContentColor(),
+                        color = AppComponents.codeBlockContentColor(),
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 12.dp, bottom = 20.dp, start = 12.dp, end = 12.dp)

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddMcpIntegrationDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddMcpIntegrationDialog.kt
@@ -70,7 +70,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -202,7 +202,7 @@ fun addMcpIntegrationDialog(
                             }
                         }
 
-                        ComponentColors.themedDropdownMenu(
+                        AppComponents.dropdownMenu(
                             expanded = showServerDropdown,
                             onDismissRequest = { showServerDropdown = false },
                         ) {
@@ -260,7 +260,7 @@ fun addMcpIntegrationDialog(
                                 placeholder = { Text(stringResource("mcp.integrations.instance.name.placeholder")) },
                                 modifier = Modifier.fillMaxWidth(),
                                 singleLine = true,
-                                colors = ComponentColors.outlinedTextFieldColors(),
+                                colors = AppComponents.outlinedTextFieldColors(),
                             )
 
                             // Variables from templates
@@ -341,7 +341,7 @@ fun addMcpIntegrationDialog(
                                             } else {
                                                 null
                                             },
-                                            colors = ComponentColors.outlinedTextFieldColors(),
+                                            colors = AppComponents.outlinedTextFieldColors(),
                                         )
 
                                         Spacer(modifier = Modifier.height(Spacing.small))
@@ -378,7 +378,7 @@ fun addMcpIntegrationDialog(
                                 modifier = Modifier.fillMaxWidth(),
                                 minLines = 2,
                                 maxLines = 5,
-                                colors = ComponentColors.outlinedTextFieldColors(),
+                                colors = AppComponents.outlinedTextFieldColors(),
                             )
 
                             // Tools Section
@@ -841,7 +841,7 @@ private fun parameterField(
                         )
                     }
                 },
-                colors = ComponentColors.outlinedTextFieldColors(),
+                colors = AppComponents.outlinedTextFieldColors(),
             )
         }
 
@@ -865,7 +865,7 @@ private fun parameterField(
                 supportingText = { parameter.description?.let { Text(it) } },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
-                colors = ComponentColors.outlinedTextFieldColors(),
+                colors = AppComponents.outlinedTextFieldColors(),
             )
         }
     }
@@ -924,7 +924,7 @@ private fun toolConfigurationRow(
                     )
                 }
 
-                ComponentColors.themedDropdownMenu(
+                AppComponents.dropdownMenu(
                     expanded = showCategoryDropdown,
                     onDismissRequest = { showCategoryDropdown = false },
                 ) {
@@ -976,7 +976,7 @@ private fun toolConfigurationRow(
                     )
                 }
 
-                ComponentColors.themedDropdownMenu(
+                AppComponents.dropdownMenu(
                     expanded = showStrategyDropdown,
                     onDismissRequest = { showStrategyDropdown = false },
                 ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddReferenceMaterialDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddReferenceMaterialDialog.kt
@@ -36,7 +36,7 @@ import io.askimo.core.event.internal.ProjectRefreshEvent
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import java.util.UUID
 import kotlin.collections.plus
 
@@ -113,7 +113,7 @@ fun addReferenceMaterialDialog(
                         Text(stringResource("projects.sources.add.button"))
                     }
 
-                    ComponentColors.themedDropdownMenu(
+                    AppComponents.dropdownMenu(
                         expanded = showAddSourceMenu,
                         onDismissRequest = { showAddSourceMenu = false },
                     ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/EditProjectDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/EditProjectDialog.kt
@@ -59,7 +59,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.UUID
@@ -282,7 +282,7 @@ private fun editProjectForm(
                     modifier = Modifier
                         .fillMaxWidth()
                         .focusRequester(focusRequester),
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                 )
 
@@ -294,7 +294,7 @@ private fun editProjectForm(
                     minLines = 3,
                     maxLines = 5,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                 )
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/McpToolsDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/McpToolsDialog.kt
@@ -61,7 +61,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -126,7 +126,7 @@ fun mcpToolsDialog(
         }
     }
 
-    ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
@@ -154,7 +154,7 @@ fun mcpToolsDialog(
                     // ── Instance info card ─────────────────────────────────
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.secondaryCardColors(),
+                        colors = AppComponents.secondaryCardColors(),
                     ) {
                         Column(
                             modifier = Modifier
@@ -285,7 +285,7 @@ fun mcpToolsDialog(
                             placeholder = { Text(stringResource("mcp.tools.dialog.search.placeholder")) },
                             modifier = Modifier.fillMaxWidth(),
                             singleLine = true,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
                     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
@@ -51,7 +51,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.util.FileDialogUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -275,7 +275,7 @@ fun newProjectDialog(
                         supportingText = nameError?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
                         singleLine = true,
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     )
 
@@ -288,7 +288,7 @@ fun newProjectDialog(
                         minLines = 3,
                         maxLines = 5,
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                         keyboardActions = KeyboardActions(onDone = { handleCreate() }),
                     )
@@ -323,7 +323,7 @@ fun newProjectDialog(
                                 Icon(Icons.Default.ArrowDropDown, contentDescription = null)
                             }
 
-                            ComponentColors.themedDropdownMenu(
+                            AppComponents.dropdownMenu(
                                 expanded = showAddSourceMenu,
                                 onDismissRequest = { showAddSourceMenu = false },
                             ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
@@ -85,7 +85,7 @@ import io.askimo.ui.chat.chatInputField
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.clickableCard
 import io.askimo.ui.common.ui.themedTooltip
@@ -199,7 +199,7 @@ fun projectView(
                                 }
                             }
 
-                            ComponentColors.themedDropdownMenu(
+                            AppComponents.dropdownMenu(
                                 expanded = showProjectMenu,
                                 onDismissRequest = { showProjectMenu = false },
                             ) {
@@ -474,7 +474,7 @@ private fun sessionCard(
                     )
                 }
 
-                ComponentColors.themedDropdownMenu(
+                AppComponents.dropdownMenu(
                     expanded = showMenu,
                     onDismissRequest = { showMenu = false },
                 ) {
@@ -545,7 +545,7 @@ private fun knowledgeSourcesPanel(
 
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -809,7 +809,7 @@ private fun mcpIntegrationsPanel(
 
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -1052,7 +1052,7 @@ private fun mcpIntegrationsPanel(
 
     // Show error dialog if there's an error
     errorMessage?.let { message ->
-        ComponentColors.themedAlertDialog(
+        AppComponents.alertDialog(
             onDismissRequest = { errorMessage = null },
             title = { Text(stringResource("mcp.integrations.error.title")) },
             text = { Text(message) },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectsView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectsView.kt
@@ -66,7 +66,7 @@ import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.domain.UrlKnowledgeSourceConfig
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.ThemePreferences
 
 @Composable
@@ -285,7 +285,7 @@ private fun projectCard(
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -355,7 +355,7 @@ private fun projectCard(
                         )
                     }
 
-                    ComponentColors.themedDropdownMenu(
+                    AppComponents.dropdownMenu(
                         expanded = showMenu,
                         onDismissRequest = { showMenu = false },
                     ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/UrlInputDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/UrlInputDialog.kt
@@ -36,7 +36,7 @@ import io.askimo.core.logging.logger
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -177,7 +177,7 @@ fun urlInputDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .focusRequester(focusRequester),
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { handleAdd() }),
                 )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
@@ -55,7 +55,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.export.ExportFormat
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import java.io.File
 import javax.swing.JFileChooser
 
@@ -207,7 +207,7 @@ fun exportSessionDialog(
                         label = { Text(stringResource("session.export.file.path")) },
                         modifier = Modifier.weight(1f),
                         singleLine = true,
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                     )
 
                     IconButton(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
@@ -48,7 +48,7 @@ import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -124,7 +124,7 @@ fun manageDirectivesDialog(
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
                                 colors = CardDefaults.cardColors(
-                                    containerColor = ComponentColors.sidebarSurfaceColor(),
+                                    containerColor = AppComponents.sidebarSurfaceColor(),
                                 ),
                             ) {
                                 Column(
@@ -193,7 +193,7 @@ fun manageDirectivesDialog(
                                                 placeholder = { Text(stringResource("directive.edit.name.placeholder")) },
                                                 singleLine = true,
                                                 isError = editError != null && editName.isBlank(),
-                                                colors = ComponentColors.outlinedTextFieldColors(),
+                                                colors = AppComponents.outlinedTextFieldColors(),
                                             )
                                             OutlinedTextField(
                                                 value = editContent,
@@ -209,7 +209,7 @@ fun manageDirectivesDialog(
                                                 maxLines = 10,
                                                 isError = editError != null,
                                                 supportingText = editError?.let { { Text(it) } },
-                                                colors = ComponentColors.outlinedTextFieldColors(),
+                                                colors = AppComponents.outlinedTextFieldColors(),
                                             )
 
                                             // Action buttons for edit mode

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/MoveToProjectMenu.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/MoveToProjectMenu.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import io.askimo.core.chat.domain.Project
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 
 /**
  * Reusable component for "Move to Project" menu with popup submenu.
@@ -91,7 +91,7 @@ fun moveToProjectMenuItem(
             Box(
                 modifier = Modifier.offset(x = itemWidth, y = (-8).dp),
             ) {
-                ComponentColors.themedDropdownMenu(
+                AppComponents.dropdownMenu(
                     expanded = showSubmenu,
                     onDismissRequest = { showSubmenu = false },
                 ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.window.Dialog
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 
 @Composable
 fun newDirectiveDialog(
@@ -85,7 +85,7 @@ fun newDirectiveDialog(
                     singleLine = true,
                     isError = nameError != null,
                     supportingText = nameError?.let { { Text(it) } },
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                 )
 
                 // Content field
@@ -103,7 +103,7 @@ fun newDirectiveDialog(
                     maxLines = 8,
                     isError = contentError != null,
                     supportingText = contentError?.let { { Text(it) } },
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                 )
 
                 // Apply to current session checkbox

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/RenameSessionDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/RenameSessionDialog.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.window.Dialog
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 
 /**
  * A styled dialog for renaming a chat session.
@@ -101,7 +101,7 @@ fun renameSessionDialog(
                     singleLine = true,
                     isError = error != null,
                     supportingText = error?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { performRename() }),
                 )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionActionsMenu.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionActionsMenu.kt
@@ -29,7 +29,7 @@ import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ProjectsRefreshEvent
 import io.askimo.core.event.internal.SessionsRefreshEvent
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.project.newProjectDialog
 import io.askimo.ui.shell.DeveloperModePreferences
 
@@ -91,7 +91,7 @@ fun sessionActionsMenu(
             )
         }
 
-        ComponentColors.themedDropdownMenu(
+        AppComponents.dropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
@@ -45,7 +45,7 @@ import io.askimo.core.util.JsonUtils
 import io.askimo.core.util.JsonUtils.prettyJson
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
@@ -98,7 +98,7 @@ fun sessionMemoryDialog(
                 if (isLoading) {
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.surfaceVariantCardColors(),
+                        colors = AppComponents.surfaceVariantCardColors(),
                     ) {
                         Text(
                             text = stringResource("developer.session.memory.loading"),
@@ -110,7 +110,7 @@ fun sessionMemoryDialog(
                 } else if (sessionMemory == null) {
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.surfaceVariantCardColors(),
+                        colors = AppComponents.surfaceVariantCardColors(),
                     ) {
                         Text(
                             text = stringResource("developer.session.memory.not.found"),
@@ -152,7 +152,7 @@ fun sessionMemoryDialog(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .heightIn(max = 200.dp),
-                            colors = ComponentColors.surfaceVariantCardColors(),
+                            colors = AppComponents.surfaceVariantCardColors(),
                         ) {
                             Box(
                                 modifier = Modifier.fillMaxWidth(),
@@ -281,7 +281,7 @@ fun sessionMemoryDialog(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .height(300.dp),
-                            colors = ComponentColors.surfaceVariantCardColors(),
+                            colors = AppComponents.surfaceVariantCardColors(),
                         ) {
                             Box(
                                 modifier = Modifier.fillMaxWidth(),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsView.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.ThemePreferences
 
 @Composable
@@ -260,7 +260,7 @@ private fun sessionCard(
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Row(
             modifier = Modifier
@@ -318,7 +318,7 @@ private fun sessionCard(
                     )
                 }
 
-                ComponentColors.themedDropdownMenu(
+                AppComponents.dropdownMenu(
                     expanded = showMenu,
                     onDismissRequest = { showMenu = false },
                 ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/GeneralSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/GeneralSettingsSection.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.config.AppConfig
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.FontSettings
 import io.askimo.ui.common.theme.FontSize
 import io.askimo.ui.common.theme.Spacing
@@ -115,7 +115,7 @@ private fun languageSelectionCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -157,7 +157,7 @@ private fun languageSelectionCard() {
                     }
                 }
 
-                ComponentColors.themedDropdownMenu(
+                AppComponents.dropdownMenu(
                     expanded = languageDropdownExpanded,
                     onDismissRequest = { languageDropdownExpanded = false },
                 ) {
@@ -263,7 +263,7 @@ private fun preferredAIResponseLanguageField(availableLanguages: Map<Locale, Str
                 }
             }
 
-            ComponentColors.themedDropdownMenu(
+            AppComponents.dropdownMenu(
                 expanded = aiLanguageDropdownExpanded,
                 onDismissRequest = { aiLanguageDropdownExpanded = false },
             ) {
@@ -332,7 +332,7 @@ private fun fontSettingsCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -376,7 +376,7 @@ private fun fontSettingsCard() {
                         }
                     }
 
-                    ComponentColors.themedDropdownMenu(
+                    AppComponents.dropdownMenu(
                         expanded = fontDropdownExpanded,
                         onDismissRequest = { fontDropdownExpanded = false },
                         modifier = Modifier.fillMaxWidth(0.5f),
@@ -467,7 +467,7 @@ private fun fontSettingsCard() {
                         }
                     }
 
-                    ComponentColors.themedDropdownMenu(
+                    AppComponents.dropdownMenu(
                         expanded = fontSizeDropdownExpanded,
                         onDismissRequest = { fontSizeDropdownExpanded = false },
                     ) {
@@ -509,7 +509,7 @@ private fun fontSettingsCard() {
 private fun samplingSettingsCard() {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/ShortcutsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/ShortcutsSettingsSection.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 
@@ -80,7 +80,7 @@ fun shortcutsSettingsSection() {
                 shortcutsByCategory.forEach { (category, shortcuts) ->
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.bannerCardColors(),
+                        colors = AppComponents.bannerCardColors(),
                     ) {
                         Column(
                             modifier = Modifier
@@ -114,7 +114,7 @@ fun shortcutsSettingsSection() {
                                     )
 
                                     Card(
-                                        colors = ComponentColors.surfaceVariantCardColors(),
+                                        colors = AppComponents.surfaceVariantCardColors(),
                                     ) {
                                         Text(
                                             text = keyBinding,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/GlobalSearchDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/GlobalSearchDialog.kt
@@ -71,7 +71,7 @@ import io.askimo.core.search.SortBy
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -268,7 +268,7 @@ fun globalSearchDialog(
                             }
                         },
                     singleLine = true,
-                    colors = ComponentColors.outlinedTextFieldColors(),
+                    colors = AppComponents.outlinedTextFieldColors(),
                 )
 
                 // Filters Row
@@ -292,7 +292,7 @@ fun globalSearchDialog(
                                 .fillMaxWidth()
                                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                                 .pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))),
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
                         ExposedDropdownMenu(
                             expanded = dateFilterExpanded,
@@ -327,7 +327,7 @@ fun globalSearchDialog(
                                 .fillMaxWidth()
                                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                                 .pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR))),
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
                         ExposedDropdownMenu(
                             expanded = sortByExpanded,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/terminal/TerminalPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/terminal/TerminalPanel.kt
@@ -635,7 +635,7 @@ private fun applyThemeToScrollBar(panel: JComponent, bgColor: Color, fgColor: Co
             }
         }
 
-        // Calculate outline/border color (similar to ComponentColors.outlineVariant)
+        // Calculate outline/border color (similar to AppComponents.outlineVariant)
         val outlineColor = Color(
             (fgColor.red * 0.15 + bgColor.red * 0.85).toInt(),
             (fgColor.green * 0.15 + bgColor.green * 0.85).toInt(),

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -103,7 +103,7 @@ import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.KeyMapManager.AppShortcut
 import io.askimo.ui.common.preferences.ApplicationPreferences
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.LocalFontScale
 import io.askimo.ui.common.theme.ThemeMode
 import io.askimo.ui.common.theme.ThemePreferences
@@ -1006,7 +1006,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
                 // Quit confirmation dialog
                 if (showQuitDialog) {
-                    ComponentColors.themedAlertDialog(
+                    AppComponents.alertDialog(
                         onDismissRequest = { showQuitDialog = false },
                         title = { Text(stringResource("menu.quit") + "?") },
                         text = { Text(stringResource("session.delete.confirm")) },
@@ -1032,7 +1032,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
                 // Invalidate cache confirmation dialog
                 if (showInvalidateCacheDialog) {
-                    ComponentColors.themedAlertDialog(
+                    AppComponents.alertDialog(
                         onDismissRequest = { showInvalidateCacheDialog = false },
                         title = { Text(stringResource("menu.invalidate.caches.title")) },
                         text = { Text(stringResource("menu.invalidate.caches.message")) },
@@ -1061,7 +1061,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
                 // Cache deleted success dialog
                 if (showCacheDeletedDialog) {
-                    ComponentColors.themedAlertDialog(
+                    AppComponents.alertDialog(
                         onDismissRequest = { showCacheDeletedDialog = false },
                         title = { Text(stringResource("menu.invalidate.caches.success.title")) },
                         text = { Text(stringResource("menu.invalidate.caches.success.message")) },
@@ -1077,7 +1077,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
                 // Import backup confirmation dialog
                 if (showImportBackupConfirm) {
-                    ComponentColors.themedAlertDialog(
+                    AppComponents.alertDialog(
                         onDismissRequest = {
                             showImportBackupConfirm = false
                             pendingImportBackupPath = null
@@ -1132,7 +1132,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
                 // Provider setup required dialog
                 if (showProviderSetupDialog) {
-                    ComponentColors.themedAlertDialog(
+                    AppComponents.alertDialog(
                         onDismissRequest = { },
                         title = {
                             Text(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
@@ -51,7 +51,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import kotlinx.coroutines.Dispatchers
@@ -87,7 +87,7 @@ fun aiProviderSettingsSection(viewModel: SettingsViewModel) {
                 // Chat Configuration Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier
@@ -237,7 +237,7 @@ private fun providerModelConfigCard(provider: ModelProvider) {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -512,7 +512,7 @@ private fun specialModelSelectionDialog(
         }
     }
 
-    ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
@@ -529,7 +529,7 @@ private fun specialModelSelectionDialog(
                 if (currentValue.isNotBlank()) {
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.bannerCardColors(),
+                        colors = AppComponents.bannerCardColors(),
                     ) {
                         Column(
                             modifier = Modifier
@@ -575,7 +575,7 @@ private fun specialModelSelectionDialog(
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                             errorHelp?.let { helpText ->
-                                Card(colors = ComponentColors.surfaceVariantCardColors()) {
+                                Card(colors = AppComponents.surfaceVariantCardColors()) {
                                     Text(
                                         text = helpText,
                                         style = MaterialTheme.typography.bodySmall,
@@ -601,7 +601,7 @@ private fun specialModelSelectionDialog(
                         if (selectedModel != null && selectedModel != currentValue) {
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
-                                colors = ComponentColors.primaryCardColors(),
+                                colors = AppComponents.primaryCardColors(),
                             ) {
                                 Row(
                                     modifier = Modifier
@@ -639,7 +639,7 @@ private fun specialModelSelectionDialog(
                             placeholder = { Text(stringResource("settings.model.search.placeholder")) },
                             label = { Text(stringResource("settings.model.search")) },
                             singleLine = true,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
 
                         // Filtered models list

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.VersionInfo
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import java.awt.Desktop
@@ -76,7 +76,7 @@ fun aboutSettingsSection() {
                 // Application Info Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier
@@ -146,7 +146,7 @@ fun aboutSettingsSection() {
                 // Description Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier
@@ -170,7 +170,7 @@ fun aboutSettingsSection() {
                 // License Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier
@@ -201,7 +201,7 @@ fun aboutSettingsSection() {
                 // Runtime Information Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier
@@ -234,7 +234,7 @@ fun aboutSettingsSection() {
                 // Links Section
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutView.kt
@@ -21,7 +21,7 @@ import io.askimo.core.VersionInfo
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import java.awt.Desktop
 import java.net.URI
@@ -31,7 +31,7 @@ import java.time.Year
 fun aboutDialog(
     onDismiss: () -> Unit,
 ) {
-    ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
@@ -49,7 +49,7 @@ fun aboutDialog(
                 // Version Info
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),
@@ -90,7 +90,7 @@ fun aboutDialog(
                 // Description
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),
@@ -112,7 +112,7 @@ fun aboutDialog(
                 // License
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AddGlobalMcpInstanceDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AddGlobalMcpInstanceDialog.kt
@@ -53,7 +53,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -340,7 +340,7 @@ fun addGlobalMcpInstanceDialog(
                             placeholder = { Text(stringResource("mcp.integrations.instance.name.placeholder")) },
                             modifier = Modifier.fillMaxWidth(),
                             singleLine = true,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
 
                         // Description (optional)
@@ -352,7 +352,7 @@ fun addGlobalMcpInstanceDialog(
                             modifier = Modifier.fillMaxWidth(),
                             minLines = 2,
                             maxLines = 3,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
 
                         HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.small))
@@ -413,7 +413,7 @@ fun addGlobalMcpInstanceDialog(
                                     supportingText = { Text(stringResource("mcp.template.field.command.hint")) },
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
 
                                 OutlinedTextField(
@@ -424,7 +424,7 @@ fun addGlobalMcpInstanceDialog(
                                     supportingText = { Text(stringResource("mcp.global.instance.field.args.hint")) },
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
 
                                 OutlinedTextField(
@@ -435,7 +435,7 @@ fun addGlobalMcpInstanceDialog(
                                     supportingText = { Text(stringResource("mcp.global.instance.field.workingdir.hint")) },
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
 
                                 OutlinedTextField(
@@ -447,7 +447,7 @@ fun addGlobalMcpInstanceDialog(
                                     modifier = Modifier.fillMaxWidth(),
                                     minLines = 3,
                                     maxLines = 5,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
                             }
                         }
@@ -463,7 +463,7 @@ fun addGlobalMcpInstanceDialog(
                                     supportingText = { Text(stringResource("mcp.template.http.url.hint")) },
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
 
                                 OutlinedTextField(
@@ -475,7 +475,7 @@ fun addGlobalMcpInstanceDialog(
                                     modifier = Modifier.fillMaxWidth(),
                                     minLines = 3,
                                     maxLines = 5,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
 
                                 OutlinedTextField(
@@ -486,7 +486,7 @@ fun addGlobalMcpInstanceDialog(
                                     supportingText = { Text(stringResource("mcp.template.http.timeout.hint")) },
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
                             }
                         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
@@ -57,7 +57,7 @@ import io.askimo.core.logging.currentFileLogger
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.clickableCard
@@ -148,7 +148,7 @@ private fun logLevelCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -198,7 +198,7 @@ private fun logLevelCard() {
                     }
                 }
 
-                ComponentColors.themedDropdownMenu(
+                AppComponents.dropdownMenu(
                     expanded = logLevelDropdownExpanded,
                     onDismissRequest = { logLevelDropdownExpanded = false },
                 ) {
@@ -247,7 +247,7 @@ private fun logViewerCard(
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -355,7 +355,7 @@ private fun developerModeSection() {
     // Developer Mode Card
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -397,7 +397,7 @@ private fun developerModeSection() {
 private fun ragConfigurationSection() {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -629,7 +629,7 @@ private fun ragIntField(
                     )
                 }
             },
-            colors = ComponentColors.outlinedTextFieldColors(),
+            colors = AppComponents.outlinedTextFieldColors(),
         )
         Text(
             text = hint,
@@ -709,7 +709,7 @@ private fun ragDoubleField(
                     )
                 }
             },
-            colors = ComponentColors.outlinedTextFieldColors(),
+            colors = AppComponents.outlinedTextFieldColors(),
         )
         Text(
             text = hint,
@@ -793,7 +793,7 @@ private fun ragOptionalIntField(
                     )
                 }
             },
-            colors = ComponentColors.outlinedTextFieldColors(),
+            colors = AppComponents.outlinedTextFieldColors(),
         )
         Text(
             text = hint,

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AppearanceSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AppearanceSettingsSection.kt
@@ -49,7 +49,7 @@ import io.askimo.ui.common.components.dangerButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AccentColor
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemeMode
 import io.askimo.ui.common.theme.ThemePreferences
@@ -183,9 +183,9 @@ private fun themeOption(
             .fillMaxWidth()
             .clickableCard(onClick = onClick),
         colors = if (selected) {
-            ComponentColors.primaryCardColors()
+            AppComponents.primaryCardColors()
         } else {
-            ComponentColors.surfaceVariantCardColors()
+            AppComponents.surfaceVariantCardColors()
         },
     ) {
         Row(
@@ -287,7 +287,7 @@ private fun avatarSetting(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.surfaceVariantCardColors(),
+        colors = AppComponents.surfaceVariantCardColors(),
     ) {
         Row(
             modifier = Modifier
@@ -390,9 +390,9 @@ private fun accentColorOption(
             .fillMaxWidth()
             .clickableCard(onClick = onClick),
         colors = if (selected) {
-            ComponentColors.primaryCardColors()
+            AppComponents.primaryCardColors()
         } else {
-            ComponentColors.surfaceVariantCardColors()
+            AppComponents.surfaceVariantCardColors()
         },
     ) {
         Row(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.clickableCard
 
 /**
@@ -69,9 +69,9 @@ fun groupedModelListAsCards(
                     .padding(bottom = 8.dp)
                     .clickableCard { onModelClick(dto.modelId) },
                 colors = if (isSelected) {
-                    ComponentColors.primaryCardColors()
+                    AppComponents.primaryCardColors()
                 } else {
-                    ComponentColors.surfaceVariantCardColors()
+                    AppComponents.surfaceVariantCardColors()
                 },
             ) {
                 Row(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
@@ -65,7 +65,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.clickableCard
@@ -157,7 +157,7 @@ fun mcpServerTemplatesSection() {
                                 Text(stringResource("mcp.servers.add"))
                             }
 
-                            ComponentColors.themedDropdownMenu(
+                            AppComponents.dropdownMenu(
                                 expanded = showAddDropdown,
                                 onDismissRequest = { showAddDropdown = false },
                             ) {
@@ -249,7 +249,7 @@ fun mcpServerTemplatesSection() {
                     // Templates list
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.bannerCardColors(),
+                        colors = AppComponents.bannerCardColors(),
                     ) {
                         if (servers.isEmpty()) {
                             Box(
@@ -304,7 +304,7 @@ fun mcpServerTemplatesSection() {
 
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.bannerCardColors(),
+                        colors = AppComponents.bannerCardColors(),
                     ) {
                         if (globalInstances.isEmpty()) {
                             Box(
@@ -421,7 +421,7 @@ fun mcpServerTemplatesSection() {
 
     // Delete Template Confirmation
     deletingServer?.let { server ->
-        ComponentColors.themedAlertDialog(
+        AppComponents.alertDialog(
             onDismissRequest = { deletingServer = null },
             title = { Text(stringResource("mcp.servers.delete.confirm.title")) },
             text = { Text(stringResource("mcp.servers.delete.confirm.message", server.name)) },
@@ -446,7 +446,7 @@ fun mcpServerTemplatesSection() {
 
     // Delete Global Instance Confirmation
     deletingGlobalInstance?.let { instance ->
-        ComponentColors.themedAlertDialog(
+        AppComponents.alertDialog(
             onDismissRequest = { deletingGlobalInstance = null },
             title = { Text(stringResource("mcp.global.instance.delete.confirm.title")) },
             text = { Text(stringResource("mcp.global.instance.delete.confirm.message", instance.name)) },
@@ -473,7 +473,7 @@ fun mcpServerTemplatesSection() {
 
     // Reset Templates Confirmation
     if (showResetConfirm) {
-        ComponentColors.themedAlertDialog(
+        AppComponents.alertDialog(
             onDismissRequest = { showResetConfirm = false },
             title = { Text(stringResource("mcp.servers.reset.confirm.title")) },
             text = { Text(stringResource("mcp.servers.reset.confirm.message")) },

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerTemplateDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerTemplateDialog.kt
@@ -50,7 +50,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 
 private val log = currentFileLogger()
@@ -147,7 +147,7 @@ fun mcpServerTemplateDialog(
                             modifier = Modifier.fillMaxWidth(),
                             singleLine = true,
                             enabled = !isEditMode,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
                         OutlinedTextField(
                             value = name,
@@ -156,7 +156,7 @@ fun mcpServerTemplateDialog(
                             placeholder = { Text(stringResource("mcp.template.field.name.placeholder")) },
                             modifier = Modifier.fillMaxWidth(),
                             singleLine = true,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
                         OutlinedTextField(
                             value = description,
@@ -166,7 +166,7 @@ fun mcpServerTemplateDialog(
                             modifier = Modifier.fillMaxWidth(),
                             minLines = 2,
                             maxLines = 3,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
 
                         HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.small))
@@ -234,7 +234,7 @@ fun mcpServerTemplateDialog(
                                     },
                                     modifier = Modifier.fillMaxWidth(),
                                     minLines = 2,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
                                 OutlinedTextField(
                                     value = envTemplate,
@@ -249,7 +249,7 @@ fun mcpServerTemplateDialog(
                                     },
                                     modifier = Modifier.fillMaxWidth(),
                                     minLines = 2,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
                             }
                         }
@@ -270,7 +270,7 @@ fun mcpServerTemplateDialog(
                                     },
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
                                 OutlinedTextField(
                                     value = headersTemplate,
@@ -285,7 +285,7 @@ fun mcpServerTemplateDialog(
                                     },
                                     modifier = Modifier.fillMaxWidth(),
                                     minLines = 2,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
 
                                 OutlinedTextField(
@@ -300,7 +300,7 @@ fun mcpServerTemplateDialog(
                                     },
                                     modifier = Modifier.fillMaxWidth(),
                                     singleLine = true,
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
                             }
                         }
@@ -319,7 +319,7 @@ fun mcpServerTemplateDialog(
                             },
                             modifier = Modifier.fillMaxWidth(),
                             singleLine = true,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
                     } // end scrollable Column
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ModelSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ModelSelectionDialog.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 
 @Composable
@@ -57,7 +57,7 @@ fun modelSelectionDialog(
         }
     }
 
-    ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
@@ -74,7 +74,7 @@ fun modelSelectionDialog(
                 if (viewModel.model.isNotBlank()) {
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.bannerCardColors(),
+                        colors = AppComponents.bannerCardColors(),
                     ) {
                         Column(
                             modifier = Modifier
@@ -120,7 +120,7 @@ fun modelSelectionDialog(
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                             viewModel.modelErrorHelp?.let { helpText ->
-                                Card(colors = ComponentColors.surfaceVariantCardColors()) {
+                                Card(colors = AppComponents.surfaceVariantCardColors()) {
                                     Text(
                                         text = helpText,
                                         style = MaterialTheme.typography.bodySmall,
@@ -146,7 +146,7 @@ fun modelSelectionDialog(
                         if (selectedModel != null && selectedModel != viewModel.model) {
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
-                                colors = ComponentColors.primaryCardColors(),
+                                colors = AppComponents.primaryCardColors(),
                             ) {
                                 Row(
                                     modifier = Modifier
@@ -184,7 +184,7 @@ fun modelSelectionDialog(
                             placeholder = { Text(stringResource("settings.model.search.placeholder")) },
                             label = { Text(stringResource("settings.model.search")) },
                             singleLine = true,
-                            colors = ComponentColors.outlinedTextFieldColors(),
+                            colors = AppComponents.outlinedTextFieldColors(),
                         )
 
                         // Filtered models list

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
@@ -43,7 +43,7 @@ import io.askimo.core.config.AppConfig
 import io.askimo.core.config.ProxyType
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.clickableCard
@@ -114,7 +114,7 @@ private fun proxyConfigurationCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -207,7 +207,7 @@ private fun proxyConfigurationCard() {
                         }
                     }
 
-                    ComponentColors.themedDropdownMenu(
+                    AppComponents.dropdownMenu(
                         expanded = proxyTypeDropdownExpanded,
                         onDismissRequest = { proxyTypeDropdownExpanded = false },
                     ) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
@@ -50,7 +50,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.ui.clickableCard
 import java.awt.Desktop
@@ -62,7 +62,7 @@ fun providerSelectionDialog(
     onDismiss: () -> Unit,
     onSave: () -> Unit,
 ) {
-    ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
@@ -119,7 +119,7 @@ fun providerSelectionDialog(
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
                                 viewModel.modelErrorHelp?.let { helpText ->
-                                    Card(colors = ComponentColors.surfaceVariantCardColors()) {
+                                    Card(colors = AppComponents.surfaceVariantCardColors()) {
                                         Text(
                                             text = helpText,
                                             style = MaterialTheme.typography.bodySmall,
@@ -145,7 +145,7 @@ fun providerSelectionDialog(
                             if (viewModel.pendingModelForNewProvider != null) {
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),
-                                    colors = ComponentColors.surfaceVariantCardColors(),
+                                    colors = AppComponents.surfaceVariantCardColors(),
                                 ) {
                                     Row(
                                         modifier = Modifier
@@ -177,7 +177,7 @@ fun providerSelectionDialog(
                                 placeholder = { Text(stringResource("settings.model.search.placeholder")) },
                                 label = { Text(stringResource("settings.model.search")) },
                                 singleLine = true,
-                                colors = ComponentColors.outlinedTextFieldColors(),
+                                colors = AppComponents.outlinedTextFieldColors(),
                             )
 
                             // Filtered models list
@@ -224,7 +224,7 @@ fun providerSelectionDialog(
 
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier
@@ -271,7 +271,7 @@ fun providerSelectionDialog(
                                     }
                                 }
 
-                                ComponentColors.themedDropdownMenu(
+                                AppComponents.dropdownMenu(
                                     expanded = providerDropdownExpanded,
                                     onDismissRequest = { providerDropdownExpanded = false },
                                 ) {
@@ -387,7 +387,7 @@ fun providerSelectionDialog(
                                                         Icon(Icons.Default.Lock, contentDescription = "Password")
                                                     }
                                                 },
-                                                colors = ComponentColors.outlinedTextFieldColors(),
+                                                colors = AppComponents.outlinedTextFieldColors(),
                                             )
 
                                             // Security assurance message
@@ -437,7 +437,7 @@ fun providerSelectionDialog(
                                                 modifier = Modifier.fillMaxWidth(),
                                                 singleLine = true,
                                                 placeholder = { Text(stringResource("settings.placeholder.baseurl")) },
-                                                colors = ComponentColors.outlinedTextFieldColors(),
+                                                colors = AppComponents.outlinedTextFieldColors(),
                                             )
                                         }
                                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsConfigDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsConfigDialog.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import io.askimo.core.providers.SettingField
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,7 +41,7 @@ fun settingsConfigDialog(
     viewModel: SettingsViewModel,
     onDismiss: () -> Unit,
 ) {
-    ComponentColors.themedAlertDialog(
+    AppComponents.alertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
@@ -71,7 +71,7 @@ fun settingsConfigDialog(
                                 } else {
                                     VisualTransformation.None
                                 },
-                                colors = ComponentColors.outlinedTextFieldColors(),
+                                colors = AppComponents.outlinedTextFieldColors(),
                             )
                         }
                         is SettingField.EnumField -> {
@@ -90,7 +90,7 @@ fun settingsConfigDialog(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                                    colors = ComponentColors.outlinedTextFieldColors(),
+                                    colors = AppComponents.outlinedTextFieldColors(),
                                 )
                                 ExposedDropdownMenu(
                                     expanded = expanded,

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.settings.generalSettingsSection
 import io.askimo.ui.settings.shortcutsSettingsSection
@@ -90,7 +90,7 @@ fun settingsViewWithSidebar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(ComponentColors.sidebarHeaderColor())
+                .background(AppComponents.sidebarHeaderColor())
                 .padding(16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
@@ -163,7 +163,7 @@ fun settingsViewWithSidebar(
                     modifier = Modifier
                         .width(calculatedWidth)
                         .fillMaxHeight()
-                        .background(ComponentColors.sidebarSurfaceColor()),
+                        .background(AppComponents.sidebarSurfaceColor()),
                 ) {
                     settingsSidebarItem(
                         title = stringResource("settings.general"),

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
@@ -82,7 +82,7 @@ import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.util.TimeUtil.formatInstantDisplay
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.monitoring.SystemResourceMonitor
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.clickableCard
 import io.askimo.ui.common.ui.themedTooltip
 import kotlinx.coroutines.CoroutineScope
@@ -249,7 +249,7 @@ private fun modelDropdown(
             }
         }
 
-        ComponentColors.themedDropdownMenu(
+        AppComponents.dropdownMenu(
             expanded = expanded,
             onDismissRequest = {
                 expanded = false
@@ -313,7 +313,7 @@ private fun modelDropdown(
                             )
                         },
                         textStyle = MaterialTheme.typography.bodySmall,
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                     )
 
                     HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
@@ -437,7 +437,7 @@ fun footerBar(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(ComponentColors.sidebarSurfaceColor()),
+            .background(AppComponents.sidebarSurfaceColor()),
     ) {
         // Top border
         HorizontalDivider()
@@ -795,7 +795,7 @@ private fun eventItem(
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.surfaceVariantCardColors(),
+        colors = AppComponents.surfaceVariantCardColors(),
     ) {
         Column(
             modifier = Modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -74,7 +74,7 @@ import io.askimo.core.event.internal.SessionsRefreshEvent
 import io.askimo.core.user.domain.UserProfile
 import io.askimo.desktop.View
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.LocalFontScale
 import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.project.ProjectsViewModel
@@ -205,13 +205,13 @@ private fun expandedNavigationSidebar(
         modifier = Modifier
             .width(animatedWidth)
             .fillMaxHeight()
-            .background(ComponentColors.sidebarSurfaceColor()),
+            .background(AppComponents.sidebarSurfaceColor()),
     ) {
         // Header with logo and collapse button
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(ComponentColors.sidebarHeaderColor())
+                .background(AppComponents.sidebarHeaderColor())
                 .padding((16 * fontScale).dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
@@ -276,7 +276,7 @@ private fun expandedNavigationSidebar(
                     modifier = Modifier
                         .padding(horizontal = (12 * fontScale).dp)
                         .pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.navigationDrawerItemColors(),
+                    colors = AppComponents.navigationDrawerItemColors(),
                 )
             }
 
@@ -303,7 +303,7 @@ private fun expandedNavigationSidebar(
                 modifier = Modifier
                     .padding(horizontal = (12 * fontScale).dp)
                     .pointerHoverIcon(PointerIcon.Hand),
-                colors = ComponentColors.navigationDrawerItemColors(),
+                colors = AppComponents.navigationDrawerItemColors(),
             )
             // Projects list (collapsible content)
             if (isProjectsExpanded) {
@@ -338,7 +338,7 @@ private fun expandedNavigationSidebar(
                 modifier = Modifier
                     .padding(horizontal = (12 * fontScale).dp)
                     .pointerHoverIcon(PointerIcon.Hand),
-                colors = ComponentColors.navigationDrawerItemColors(),
+                colors = AppComponents.navigationDrawerItemColors(),
             )
 
             // Sessions list (collapsible content)
@@ -391,7 +391,7 @@ private fun collapsedNavigationSidebar(
         modifier = Modifier
             .width(animatedWidth)
             .fillMaxHeight()
-            .background(ComponentColors.sidebarSurfaceColor())
+            .background(AppComponents.sidebarSurfaceColor())
             .border(
                 width = 1.dp,
                 color = MaterialTheme.colorScheme.outlineVariant,
@@ -417,7 +417,7 @@ private fun collapsedNavigationSidebar(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(ComponentColors.sidebarHeaderColor())
+                    .background(AppComponents.sidebarHeaderColor())
                     .padding(vertical = (16 * fontScale).dp)
                     .hoverable(headerInteractionSource)
                     .clickable(
@@ -464,7 +464,7 @@ private fun collapsedNavigationSidebar(
                     selected = false,
                     onClick = onNewChat,
                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.navigationRailItemColors(),
+                    colors = AppComponents.navigationRailItemColors(),
                 )
             }
 
@@ -478,7 +478,7 @@ private fun collapsedNavigationSidebar(
                     selected = currentView == View.SESSIONS,
                     onClick = onNavigateToSessions,
                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.navigationRailItemColors(),
+                    colors = AppComponents.navigationRailItemColors(),
                 )
             }
         }
@@ -519,12 +519,12 @@ private fun collapsedNavigationSidebar(
                     modifier = Modifier
                         .padding(vertical = (8 * fontScale).dp)
                         .pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.navigationRailItemColors(),
+                    colors = AppComponents.navigationRailItemColors(),
                 )
             }
 
             // User menu dropdown
-            ComponentColors.themedDropdownMenu(
+            AppComponents.dropdownMenu(
                 expanded = showUserMenu,
                 onDismissRequest = { showUserMenu = false },
             ) {
@@ -591,7 +591,7 @@ private fun projectsList(
             modifier = Modifier
                 .padding(vertical = (2 * fontScale).dp)
                 .pointerHoverIcon(PointerIcon.Hand),
-            colors = ComponentColors.navigationDrawerItemColors(),
+            colors = AppComponents.navigationDrawerItemColors(),
         )
 
         if (projectsViewModel.projects.isEmpty()) {
@@ -710,14 +710,14 @@ private fun projectItemWithMenu(
                 modifier = Modifier
                     .fillMaxWidth()
                     .pointerHoverIcon(PointerIcon.Hand),
-                colors = ComponentColors.navigationDrawerItemColors(),
+                colors = AppComponents.navigationDrawerItemColors(),
             )
         }
 
         Box(
             modifier = Modifier.align(Alignment.CenterEnd).padding(end = 8.dp),
         ) {
-            ComponentColors.themedDropdownMenu(
+            AppComponents.dropdownMenu(
                 expanded = showMenu,
                 onDismissRequest = { showMenu = false },
             ) {
@@ -812,7 +812,7 @@ private fun sessionsList(
                     modifier = Modifier
                         .padding(vertical = (2 * fontScale).dp)
                         .pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.navigationDrawerItemColors(),
+                    colors = AppComponents.navigationDrawerItemColors(),
                 )
 
                 // Starred sessions list
@@ -882,7 +882,7 @@ private fun sessionsList(
                     modifier = Modifier
                         .padding(vertical = (2 * fontScale).dp)
                         .pointerHoverIcon(PointerIcon.Hand),
-                    colors = ComponentColors.navigationDrawerItemColors(),
+                    colors = AppComponents.navigationDrawerItemColors(),
                 )
             }
         }
@@ -929,14 +929,14 @@ private fun sessionItemWithMenu(
                 modifier = Modifier
                     .fillMaxWidth()
                     .pointerHoverIcon(PointerIcon.Hand),
-                colors = ComponentColors.navigationDrawerItemColors(),
+                colors = AppComponents.navigationDrawerItemColors(),
             )
         }
 
         Box(
             modifier = Modifier.align(Alignment.CenterEnd).padding(end = 8.dp),
         ) {
-            ComponentColors.themedDropdownMenu(
+            AppComponents.dropdownMenu(
                 expanded = showMenu,
                 onDismissRequest = { showMenu = false },
             ) {
@@ -1124,7 +1124,7 @@ private fun userProfileSection(
         }
 
         // Dropdown Menu
-        ComponentColors.themedDropdownMenu(
+        AppComponents.dropdownMenu(
             expanded = showMenu,
             onDismissRequest = { showMenu = false },
         ) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/tutorial/LanguageSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/tutorial/LanguageSelectionDialog.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.window.Dialog
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.ui.clickableCard
 import java.util.Locale
@@ -83,7 +83,7 @@ fun languageSelectionDialog(
                 // Language Selection Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ComponentColors.bannerCardColors(),
+                    colors = AppComponents.bannerCardColors(),
                 ) {
                     Column(
                         modifier = Modifier
@@ -126,7 +126,7 @@ fun languageSelectionDialog(
                                 }
                             }
 
-                            ComponentColors.themedDropdownMenu(
+                            AppComponents.dropdownMenu(
                                 expanded = languageDropdownExpanded,
                                 onDismissRequest = { languageDropdownExpanded = false },
                             ) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/tutorial/TutorialWizardDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/tutorial/TutorialWizardDialog.kt
@@ -49,7 +49,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 
 /**
@@ -307,7 +307,7 @@ private fun tutorialStepNextSteps() {
 
         Card(
             modifier = Modifier.fillMaxWidth(),
-            colors = ComponentColors.bannerCardColors(),
+            colors = AppComponents.bannerCardColors(),
         ) {
             Column(
                 modifier = Modifier
@@ -345,7 +345,7 @@ private fun tutorialFeatureCard(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = ComponentColors.bannerCardColors(),
+        colors = AppComponents.bannerCardColors(),
     ) {
         Column(
             modifier = Modifier
@@ -378,7 +378,7 @@ private fun tutorialLinkItem(
         modifier = Modifier
             .fillMaxWidth()
             .pointerHoverIcon(PointerIcon.Hand),
-        colors = ComponentColors.primaryTextButtonColors(),
+        colors = AppComponents.primaryTextButtonColors(),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
@@ -55,7 +55,7 @@ import io.askimo.core.util.AskimoHome
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
@@ -267,7 +267,7 @@ fun userProfileDialog(
                         value = name,
                         onValueChange = { name = it },
                         label = { Text(stringResource("user.profile.name")) },
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                     )
@@ -276,7 +276,7 @@ fun userProfileDialog(
                         value = email,
                         onValueChange = { email = it },
                         label = { Text(stringResource("user.profile.email")) },
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         placeholder = { Text(stringResource("user.profile.email.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
@@ -286,7 +286,7 @@ fun userProfileDialog(
                         value = occupation,
                         onValueChange = { occupation = it },
                         label = { Text(stringResource("user.profile.occupation")) },
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         placeholder = { Text(stringResource("user.profile.occupation.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
@@ -296,7 +296,7 @@ fun userProfileDialog(
                         value = location,
                         onValueChange = { location = it },
                         label = { Text(stringResource("user.profile.location")) },
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         placeholder = { Text(stringResource("user.profile.location.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
@@ -306,7 +306,7 @@ fun userProfileDialog(
                         value = bio,
                         onValueChange = { bio = it },
                         label = { Text(stringResource("user.profile.bio")) },
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         placeholder = { Text(stringResource("user.profile.bio.placeholder")) },
                         modifier = Modifier.fillMaxWidth().height(100.dp),
                         maxLines = 4,
@@ -354,7 +354,7 @@ fun userProfileDialog(
                         value = customInterests,
                         onValueChange = { customInterests = it },
                         label = { Text(stringResource("user.profile.interests.custom")) },
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         placeholder = { Text(stringResource("user.profile.interests.custom.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
                         supportingText = {

--- a/desktop/src/main/kotlin/io/askimo/desktop/user/WelcomeProfileDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/user/WelcomeProfileDialog.kt
@@ -52,7 +52,7 @@ import io.askimo.core.util.AskimoHome
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.ComponentColors
+import io.askimo.ui.common.theme.AppComponents
 import java.awt.FileDialog
 import java.awt.Frame
 import java.nio.file.Files
@@ -208,7 +208,7 @@ fun welcomeProfileDialog(
                         },
                         placeholder = { Text(stringResource("welcome.name.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         singleLine = true,
                     )
 
@@ -219,7 +219,7 @@ fun welcomeProfileDialog(
                         label = { Text(stringResource("welcome.occupation")) },
                         placeholder = { Text(stringResource("welcome.occupation.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ComponentColors.outlinedTextFieldColors(),
+                        colors = AppComponents.outlinedTextFieldColors(),
                         singleLine = true,
                     )
 


### PR DESCRIPTION
- consolidate shared UI theming helpers under a broader AppComponents API
- update dialogs, dropdowns, cards, text fields, and navigation to use the new theme entry points
- extract spacing tokens and typography scaling helpers to simplify theme organization
- remove obsolete theme preference avatar storage and related dead code
- clean up generated fully qualified references to improve readability and maintenance
- keep behavior consistent while reducing theme duplication across shared and desktop UI