### PR TITLE
chore: update CI workflows, UI imports and desktop build settings

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up GraalVM (JDK 21)
         uses: graalvm/setup-graalvm@v1
@@ -36,7 +36,7 @@ jobs:
           echo "GRADLE_USER_HOME=$env:RUNNER_TEMP\gradle" >> $env:GITHUB_ENV
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-report-${{ github.job }}-${{ runner.os }}-attempt${{ github.run_attempt }}
           path: cli/build/reports/tests/test
@@ -129,7 +129,7 @@ jobs:
           }
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-${{ matrix.os }}
           path: ${{ steps.paths.outputs.bin }}
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up GraalVM (JDK 21)
         uses: graalvm/setup-graalvm@v1
@@ -153,7 +153,7 @@ jobs:
           distribution: 'graalvm-community'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Generate Graal metadata (arm64)
         env:
@@ -192,7 +192,7 @@ jobs:
           fi
 
       - name: Upload arm64 artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-ubuntu-24.04-arm
           path: ${{ steps.arm_paths.outputs.bin }}
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
 
@@ -271,367 +271,7 @@ jobs:
         with:
           files: ${{ steps.pkg.outputs.files }}
           generate_release_notes: true
-          draft: false
+          draft: true
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Publish CLI Homebrew formula to separate tap repository
-  homebrew:
-    name: Publish Homebrew tap (separate repo)
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [ release ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Install jq
-        # curl & awk available by default; install jq explicitly
-        run: sudo apt-get update && sudo apt-get install -y jq
-
-      - name: Collect release assets & checksums
-        id: meta
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"                # e.g. v0.4.0
-          VERSION_PLAIN="${TAG#v}"                # e.g. 0.4.0
-          API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
-          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
-
-          ARM_NAME="askimo-darwin-arm64.tar.gz"
-          AMD_NAME="askimo-darwin-amd64.tar.gz"
-
-          ARM_URL="$(echo "$JSON" | jq -r --arg N "$ARM_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
-          AMD_URL="$(echo "$JSON" | jq -r --arg N "$AMD_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
-          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
-
-          if [ -z "${SHA_URL:-}" ] || [ -z "${ARM_URL:-}" ]; then
-            echo "Release missing SHA256SUMS.txt or macOS arm64 tarball." >&2
-            echo "Assets present:" >&2
-            echo "$JSON" | jq -r '.assets[]?.name' >&2
-            exit 1
-          fi
-
-          curl -sSL -o SHA256SUMS.txt "$SHA_URL"
-
-          # Quote/escape dots in grep pattern to avoid partial matches
-          ARM_SHA="$(grep -E "  ${ARM_NAME//./\\.}$" SHA256SUMS.txt | awk '{print $1}')"
-          AMD_SHA=""
-          if [ -n "${AMD_URL:-}" ]; then
-            AMD_SHA="$(grep -E "  ${AMD_NAME//./\\.}$" SHA256SUMS.txt | awk '{print $1}')"
-          fi
-
-          if [ -z "${ARM_SHA:-}" ]; then
-            echo "Could not find ARM sha in SHA256SUMS.txt" >&2
-            exit 1
-          fi
-
-          {
-            echo "tag=$TAG"
-            echo "version_plain=$VERSION_PLAIN"
-            echo "arm_url=$ARM_URL"
-            echo "arm_sha=$ARM_SHA"
-            echo "amd_url=$AMD_URL"
-            echo "amd_sha=$AMD_SHA"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Checkout tap repo
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ vars.TAP_REPO || 'haiphucnguyen/homebrew-askimo' }}
-          token: ${{ secrets.TAP_PUSH_TOKEN }}
-          path: tap
-          fetch-depth: 0
-
-      - name: Write formula into tap
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p tap/Formula
-          
-          VERSION="${{ steps.meta.outputs.version_plain }}"
-          ARM_URL="${{ steps.meta.outputs.arm_url }}"
-          ARM_SHA="${{ steps.meta.outputs.arm_sha }}"
-          AMD_URL="${{ steps.meta.outputs.amd_url }}"
-          AMD_SHA="${{ steps.meta.outputs.amd_sha }}"
-          
-          # 1) Header
-          cat > tap/Formula/askimo.rb <<'RUBY'
-          # typed: false
-          # frozen_string_literal: true
-
-          class Askimo < Formula
-            desc "AI-powered terminal assistant for multiple LLM providers"
-            homepage "https://github.com/haiphucnguyen/askimo"
-            license "AGPLv3"
-            
-            on_macos do
-          RUBY
-          
-          # 2) ARM stanza (required)
-          cat >> tap/Formula/askimo.rb <<RUBY
-              on_arm do
-                version "${VERSION}"
-                url "${ARM_URL}"
-                sha256 "${ARM_SHA}"
-              end
-          RUBY
-          
-          # 3) Optional Intel stanza
-          if [ -n "${AMD_URL}" ] && [ -n "${AMD_SHA}" ]; then
-          cat >> tap/Formula/askimo.rb <<RUBY
-              
-              on_intel do
-                version "${VERSION}"
-                url "${AMD_URL}"
-                sha256 "${AMD_SHA}"
-              end
-          RUBY
-          fi
-          
-          # 4) Footer (ALWAYS append this block)
-          cat >> tap/Formula/askimo.rb <<'RUBY'
-            end
-            
-            def install
-              # Expect the tarball to contain a single binary named "askimo"
-              bin.install "askimo"
-            end
-            
-            test do
-              output = shell_output("#{bin}/askimo --version")
-              assert_match "askimo", output.downcase
-            end
-          end
-          RUBY
-          
-          echo "==== tap/Formula/askimo.rb ===="
-          nl -ba tap/Formula/askimo.rb
-          
-          # 5) Catch structure errors early (like missing 'end')
-          ruby -c tap/Formula/askimo.rb
-      - name: Commit & push to tap repo
-        working-directory: tap
-        env:
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
-        shell: bash
-        run: |
-          set -euo pipefail
-          git add Formula/askimo.rb
-          if git diff --cached --quiet; then
-            echo "No changes to commit."
-          else
-            git commit -m "askimo ${{ steps.meta.outputs.version_plain }}: update formula for ${{ steps.meta.outputs.tag }}"
-            # Push to the current branch (usually main)
-            git push
-          fi
-
-  # Publish CLI Scoop manifest for Windows package manager
-  scoop:
-    name: Publish Scoop manifest (Windows)
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [ release ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read   # reads current repo; pushes to bucket via PAT
-
-    steps:
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
-      - name: Collect release assets & checksums
-        id: meta
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"              # e.g. v0.1.013
-          VERSION_PLAIN="${TAG#v}"
-          API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
-          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
-
-          WIN_NAME="askimo-windows-x64.zip"
-          WIN_URL="$(echo "$JSON" | jq -r --arg N "$WIN_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
-          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
-
-          if [ -z "$WIN_URL" ] || [ -z "$SHA_URL" ]; then
-            echo "Windows zip or SHA256SUMS.txt not found in the release." >&2
-            echo "Assets:" >&2
-            echo "$JSON" | jq -r '.assets[]?.name' >&2
-            exit 1
-          fi
-
-          curl -sSL -o SHA256SUMS.txt "$SHA_URL"
-          WIN_SHA="$(grep "  $WIN_NAME" SHA256SUMS.txt | awk '{print $1}')"
-          if [ -z "$WIN_SHA" ]; then
-            echo "SHA256 for $WIN_NAME not in SHA256SUMS.txt" >&2
-            exit 1
-          fi
-
-          echo "version=$VERSION_PLAIN" >> $GITHUB_OUTPUT
-          echo "win_url=$WIN_URL"       >> $GITHUB_OUTPUT
-          echo "win_sha=$WIN_SHA"       >> $GITHUB_OUTPUT
-
-      - name: Checkout scoop bucket
-        uses: actions/checkout@v4
-        with:
-          repository: haiphucnguyen/scoop-askimo
-          token: ${{ secrets.TAP_PUSH_TOKEN }}   # <-- use your existing PAT
-          ref: main
-          path: bucket
-          fetch-depth: 0
-
-      - name: Write askimo manifest
-        run: |
-          set -euo pipefail
-          mkdir -p bucket/bucket
-          printf '%s\n' \
-            '{' \
-            '  "version": "VERSION_PLACEHOLDER",' \
-            '  "description": "AI-powered terminal assistant for multiple LLM providers",' \
-            '  "homepage": "https://github.com/haiphucnguyen/askimo",' \
-            '  "license": "AGPLv3",' \
-            '  "architecture": {' \
-            '    "64bit": {' \
-            '      "url": "WIN_URL_PLACEHOLDER",' \
-            '      "hash": "WIN_SHA_PLACEHOLDER",' \
-            '      "bin": "askimo.exe"' \
-            '    }' \
-            '  }' \
-            '}' \
-            > bucket/bucket/askimo.json
-          sed -i "s|VERSION_PLACEHOLDER|${{ steps.meta.outputs.version }}|g" bucket/bucket/askimo.json
-          sed -i "s|WIN_URL_PLACEHOLDER|${{ steps.meta.outputs.win_url }}|g" bucket/bucket/askimo.json
-          sed -i "s|WIN_SHA_PLACEHOLDER|${{ steps.meta.outputs.win_sha }}|g" bucket/bucket/askimo.json
-          cat bucket/bucket/askimo.json
-
-      - name: Commit & push to bucket
-        working-directory: bucket
-        env:
-          TOKEN: ${{ secrets.TAP_PUSH_TOKEN }}
-        run: |
-          set -euo pipefail
-          # set identity LOCALLY (not global)
-          git config user.name  "github-actions"
-          git config user.email "actions@users.noreply.github.com"
-
-          git add bucket/askimo.json
-          if ! git diff --cached --quiet; then
-            git commit -m "askimo ${GITHUB_REF_NAME}"
-            # ensure remote uses PAT
-            git remote set-url origin "https://x-access-token:${TOKEN}@github.com/haiphucnguyen/scoop-askimo.git"
-            git push origin HEAD:main
-          else
-            echo "No changes to commit."
-          fi
-
-  # Build and push multi-arch Docker images containing CLI binaries
-  docker:
-    name: Build & Push Docker (native, multi-arch)
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [ release, native, native-arm ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Download Linux amd64 artifact from the matrix 'native' job
-      - name: Download amd64 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.event.repository.name }}-ubuntu-latest
-          path: dist-amd64
-
-      - name: Normalize amd64 binary
-        shell: bash
-        run: |
-          set -euo pipefail
-          AMD="$(ls dist-amd64/* | head -n1)"
-          chmod +x "$AMD"
-          mkdir -p out
-          cp "$AMD" out/askimo-amd64
-
-      # Download Linux arm64 artifact from 'native-arm' job
-      - name: Download arm64 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ github.event.repository.name }}-ubuntu-24.04-arm
-          path: dist-arm64
-
-      - name: Normalize arm64 binary
-        shell: bash
-        run: |
-          set -euo pipefail
-          ARM="$(ls dist-arm64/* | head -n1)"
-          chmod +x "$ARM"
-          mkdir -p out
-          cp "$ARM" out/askimo-arm64
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute tags
-        id: meta
-        shell: bash
-        run: |
-          set -euo pipefail
-          REPO="ghcr.io/${GITHUB_REPOSITORY_OWNER}/askimo"
-          V="${GITHUB_REF_NAME}"   # e.g. v1.2.3
-          echo "base=$REPO"                                   >> $GITHUB_OUTPUT
-          echo "tags=$REPO:latest,$REPO:${V},$REPO:${V#v}"    >> $GITHUB_OUTPUT
-
-      # Build & push per-arch images (no QEMU; runtime-only copy)
-      - name: Build amd64 image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.runtime
-          build-args: BIN=out/askimo-amd64
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.base }}:amd64-temp
-          provenance: false
-          sbom: false
-
-      - name: Build arm64 image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.runtime
-          build-args: BIN=out/askimo-arm64
-          platforms: linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.base }}:arm64-temp
-          provenance: false
-          sbom: false
-
-      - name: Create & push multi-arch manifests
-        shell: bash
-        run: |
-          set -euo pipefail
-          I="${{ steps.meta.outputs.base }}"
-          IFS=',' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
-          for T in "${TAGS[@]}"; do
-            docker manifest create "$T" \
-              --amend "$I:amd64-temp" \
-              --amend "$I:arm64-temp"
-            docker manifest push "$T"
-          done
-          docker rmi "$I:amd64-temp" "$I:arm64-temp" || true
-

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -2,12 +2,12 @@ name: Desktop
 
 on:
   push:
-    tags: [ "v*" ]  # Trigger on version tags (e.g., v0.3.0)
-  pull_request:  # Build on every PR
-  workflow_dispatch:  # Allow manual trigger
+    tags: [ "v*" ]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  # Build desktop application for each platform (runs on PRs and releases)
+  # ── Build (PRs + releases) ────────────────────────────────────────────────
   desktop-build:
     name: desktop-build-${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -28,16 +28,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
@@ -51,7 +51,7 @@ jobs:
         run: .\gradlew.bat --no-daemon "-Dorg.gradle.jvmargs=-Xmx4g" desktop:build
 
 
-  # Package desktop installers for each platform (runs only on release tags)
+  # ── Package + notarize installers (release tags only) ────────────────────
   desktop-package:
     name: desktop-package-${{ matrix.name }}
     if: startsWith(github.ref, 'refs/tags/v')
@@ -90,441 +90,387 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
-      # Install Apple intermediate certificates (macOS only)
-      - name: Install Apple Intermediate Certificates
-        if: runner.os == 'macOS'
-        run: |
-          echo "Installing Apple intermediate certificates..."
-          
-          # Download Apple intermediate certificates
-          curl -s -o /tmp/DeveloperIDG2.cer "https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer"
-          curl -s -o /tmp/AppleRootCA-G3.cer "https://www.apple.com/certificateauthority/AppleRootCA-G3.cer"
-          curl -s -o /tmp/AppleWWDRCAG3.cer "https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer"
-          
-          # Install to system keychain as trusted
-          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/DeveloperIDG2.cer
-          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/AppleRootCA-G3.cer
-          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/AppleWWDRCAG3.cer
-          
-          echo "✅ Apple intermediate certificates installed"
-
-      # Import Apple Developer ID certificate for code signing (macOS only)
-      - name: Import Code Signing Certificate
-        if: runner.os == 'macOS'
+      # Runs build + sign + notarize + staple in one Gradle task chain.
+      # On macOS the chain is: build → signMacApp → notarizeApp → createSignedDmg → customNotarizeDmg → customNotarizeMacApp
+      - name: Package and notarize installer (Linux/macOS)
+        if: runner.os != 'Windows'
         env:
           MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-        run: |
-          echo "Setting up code signing certificate..."
-          
-          # Decode certificate from base64
-          echo "$MACOS_CERTIFICATE_BASE64" | base64 --decode > certificate.p12
-          
-          # Create temporary keychain
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-          
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          
-          # Import certificate to keychain with proper ACLs
-          security import certificate.p12 \
-            -P "$MACOS_CERTIFICATE_PASSWORD" \
-            -k "$KEYCHAIN_PATH" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/productbuild \
-            -A
-          
-          # Import Apple intermediate certificates to build keychain too
-          security import /tmp/DeveloperIDG2.cer -k "$KEYCHAIN_PATH" -T /usr/bin/codesign -A
-          security import /tmp/AppleRootCA-G3.cer -k "$KEYCHAIN_PATH" -T /usr/bin/codesign -A
-          
-          # Set keychain to be used by codesign
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-          security default-keychain -s "$KEYCHAIN_PATH"
-          
-          # Set partition list to allow codesign access without prompts
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          
-          # Find and export certificate identity
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | \
-            grep "Developer ID Application" | \
-            head -1 | \
-            sed 's/.*"\(.*\)".*/\1/')
-          
-          if [ -z "$IDENTITY" ]; then
-            echo "❌ Error: Could not find Developer ID Application certificate"
-            security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-            exit 1
-          fi
-          
-          echo "MACOS_IDENTITY=$IDENTITY" >> $GITHUB_ENV
-          echo "✅ Code signing certificate configured: $IDENTITY"
-          
-          # Verify the setup
-          echo "Testing code signing..."
-          echo "test" > /tmp/test-sign.txt
-          if codesign --sign "$IDENTITY" /tmp/test-sign.txt 2>&1; then
-            echo "✅ Code signing test successful"
-          else
-            echo "❌ Code signing test failed"
-            exit 1
-          fi
-          
-          # Clean up
-          rm -f certificate.p12 /tmp/test-sign.txt /tmp/*.cer
-
-      - name: Build desktop application (Linux/macOS)
-        if: runner.os != 'Windows'
-        run: ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx4g" desktop:build
-
-      - name: Build desktop application (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: .\gradlew.bat --no-daemon "-Dorg.gradle.jvmargs=-Xmx4g" desktop:build
-
-      - name: Package desktop installer (Linux/macOS)
-        if: runner.os != 'Windows'
-        env:
-          MACOS_IDENTITY: ${{ runner.os == 'macOS' && env.MACOS_IDENTITY || '' }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-        run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
-            # For macOS: Build, sign, and notarize using custom Gradle task
-            # Redirect output to a log file so we can upload it on failure
-            ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx4g" desktop:customNotarizeMacApp \
-              2>&1 | tee /tmp/notarize.log
-            # Preserve the exit code from gradlew (tee always exits 0)
-            exit "${PIPESTATUS[0]}"
-          else
-            # For Linux: Just package
-            ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx4g" desktop:${{ matrix.task }}
-          fi
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx4g" desktop:${{ matrix.task }}
 
-      - name: Package desktop installer (Windows)
+      - name: Package installer (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: .\gradlew.bat --no-daemon "-Dorg.gradle.jvmargs=-Xmx4g" desktop:${{ matrix.task }}
 
+      # ── CHECKPOINT 1: verify DMG is properly signed + stapled before upload ──
+      # If this fails the whole pipeline stops — no point uploading a broken artifact.
+      - name: "[macOS] Verify DMG signature and staple ticket before upload"
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          DMG="${{ matrix.artifact-pattern }}"
+
+          echo "══════════════════════════════════════════════════════════════"
+          echo "CHECKPOINT 1 — DMG before upload to artifact store"
+          echo "══════════════════════════════════════════════════════════════"
+
+          if [ ! -f "$DMG" ]; then
+            echo "❌ DMG not found: $DMG"
+            echo "Contents of desktop/build/compose/notarized/:"
+            ls -la desktop/build/compose/notarized/ || true
+            exit 1
+          fi
+
+          echo "── File ────────────────────────────────────────────────────"
+          ls -lh "$DMG"
+          shasum -a 256 "$DMG"
+
+          echo "── Code signature ──────────────────────────────────────────"
+          codesign --verify --verbose=2 "$DMG" 2>&1 || { echo "❌ codesign verify failed"; exit 1; }
+          codesign --display --verbose=4 "$DMG" 2>&1 | grep -E "CDHash|TeamIdentifier|Identifier|Authority" || true
+
+          echo "── Staple ticket ───────────────────────────────────────────"
+          xcrun stapler validate "$DMG" 2>&1 || { echo "❌ STAPLE TICKET MISSING — Gradle task failed to staple"; exit 1; }
+          echo "✅ Staple ticket present"
+
+          echo "── Gatekeeper assessment ───────────────────────────────────"
+          spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG" 2>&1 \
+            || { echo "❌ Gatekeeper rejected DMG"; exit 1; }
+          echo "✅ Gatekeeper accepts DMG"
+          echo "══════════════════════════════════════════════════════════════"
 
       - name: Build uber JAR (Linux/macOS)
         if: runner.os != 'Windows'
         run: ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx4g" desktop:packageUberJarForCurrentOS
-
-      - name: Verify macOS Notarization
-        if: runner.os == 'macOS'
-        run: |
-          DMG="desktop/build/compose/notarized/Askimo-signed.dmg"
-          
-          echo "🔍 Verifying notarized DMG..."
-          
-          # Check if DMG exists
-          if [ ! -f "$DMG" ]; then
-            echo "❌ DMG not found at: $DMG"
-            exit 1
-          fi
-          
-          echo "✅ DMG exists: $DMG"
-          
-          # Check code signature
-          echo ""
-          echo "📝 Code signature:"
-          codesign -dvv "$DMG" 2>&1 | grep -E "Signature|Authority|Timestamp" | head -5
-          
-          # Verify signature
-          if codesign --verify --verbose "$DMG" 2>&1; then
-            echo "✅ Code signature is valid"
-          else
-            echo "❌ Code signature verification failed"
-            exit 1
-          fi
-          
-          # Check for notarization ticket
-          echo ""
-          echo "🎫 Checking notarization ticket:"
-          if xattr -l "$DMG" | grep -q "com.apple.stapler"; then
-            echo "✅ Notarization ticket is attached"
-          else
-            echo "⚠️  No stapler ticket found (may not be accessible in CI)"
-          fi
-          
-          # Check with spctl (Gatekeeper)
-          echo ""
-          echo "🔐 Gatekeeper assessment:"
-          if spctl -a -t open --context context:primary-signature -v "$DMG" 2>&1; then
-            echo "✅ Gatekeeper accepts the DMG"
-          else
-            echo "⚠️  Gatekeeper assessment unavailable in CI (this is normal)"
-          fi
-          
-          echo ""
-          echo "✅ Notarization verification complete"
 
       - name: Build uber JAR (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: .\gradlew.bat --no-daemon "-Dorg.gradle.jvmargs=-Xmx4g" desktop:packageUberJarForCurrentOS
 
-      - name: Find installer package
-        id: package
+      - name: Locate artifacts
+        id: locate
         shell: bash
         run: |
           set -euo pipefail
           PATTERN="${{ matrix.artifact-pattern }}"
-          
-          # For macOS notarized DMG, the path is specific
+
           if [ "$RUNNER_OS" == "macOS" ]; then
             PKG="$PATTERN"
             if [ ! -f "$PKG" ]; then
-              echo "Error: Notarized DMG not found at: $PKG" >&2
-              echo "Listing desktop/build/compose/notarized/:"
+              echo "❌ Installer not found at: $PKG" >&2
               ls -la desktop/build/compose/notarized/ || true
               exit 1
             fi
           else
-            # Use compgen if available (bash), otherwise use ls with wildcard
-            if compgen -G "$PATTERN" > /dev/null 2>&1; then
-              PKG="$(compgen -G "$PATTERN" | head -n1)"
-            else
-              PKG="$(ls $PATTERN 2>/dev/null | head -n1)" || true
-            fi
-            
+            PKG="$(compgen -G "$PATTERN" 2>/dev/null | head -n1 || ls $PATTERN 2>/dev/null | head -n1 || true)"
             if [ -z "$PKG" ]; then
-              echo "Error: No installer found matching pattern: $PATTERN" >&2
+              echo "❌ No installer found matching: $PATTERN" >&2
               exit 1
             fi
           fi
-          
-          echo "package=$PKG" >> $GITHUB_OUTPUT
-          echo "Found installer: $PKG"
 
-      - name: Find uber JAR
-        id: jar
-        shell: bash
-        run: |
-          set -euo pipefail
-          JAR=$(find desktop/build/compose/jars -name "*.jar" -type f | head -n1)
-          
+          JAR=$(find desktop/build/compose/jars -name "*.jar" -type f 2>/dev/null | head -n1 || true)
           if [ -z "$JAR" ]; then
-            echo "Error: No uber JAR found" >&2
+            echo "❌ No uber JAR found in desktop/build/compose/jars/" >&2
             exit 1
           fi
-          
-          echo "jar=$JAR" >> $GITHUB_OUTPUT
-          echo "Found uber JAR: $JAR"
+
+          echo "package=$PKG" >> $GITHUB_OUTPUT
+          echo "jar=$JAR"     >> $GITHUB_OUTPUT
+          echo "✓ Installer : $PKG"
+          echo "✓ Uber JAR  : $JAR"
 
       - name: Upload installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: askimo-desktop-installer-${{ matrix.artifact-suffix }}
-          path: ${{ steps.package.outputs.package }}
+          path: ${{ steps.locate.outputs.package }}
           if-no-files-found: error
           retention-days: 14
 
       - name: Upload uber JAR artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: askimo-desktop-jar-${{ matrix.artifact-suffix }}
-          path: ${{ steps.jar.outputs.jar }}
+          path: ${{ steps.locate.outputs.jar }}
           if-no-files-found: error
           retention-days: 14
 
       - name: Upload notarization log on failure
         if: failure() && runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: notarize-log-${{ matrix.name }}-attempt${{ github.run_attempt }}
-          path: /tmp/notarize.log
+          path: ~/Library/Logs/notarytool/
           if-no-files-found: warn
           retention-days: 7
 
-  # Create GitHub release with all desktop installers and JARs
+
+  # ── Create GitHub release ─────────────────────────────────────────────────
   release:
     name: Create Desktop Release
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [ desktop-package ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: write
 
     steps:
       - name: Download all installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
 
-      - name: List downloaded artifacts
-        shell: bash
-        run: |
-          echo "Downloaded artifacts:"
-          ls -lhR dist/
-
-      - name: Prepare release assets
-        id: assets
+      # ── CHECKPOINT 2: confirm what arrived after upload-artifact round-trip ──
+      # upload-artifact zips the file; that zip round-trip may strip the staple
+      # ticket xattr. We re-staple from Apple CDN and HARD FAIL if it doesn't work.
+      - name: "[macOS] Re-staple DMGs after artifact download"
         shell: bash
         run: |
           set -euo pipefail
-          
+          echo "══════════════════════════════════════════════════════════════"
+          echo "CHECKPOINT 2 — DMGs after download-artifact"
+          echo "══════════════════════════════════════════════════════════════"
+          echo "Full artifact tree received:"
+          ls -lhR dist/
+          echo ""
+
+          FAILED=0
+          for platform in macos-arm64 macos-intel; do
+            echo "──────────────────────────────────────────────────────────"
+            echo "Platform: $platform"
+            DMG=$(find "dist/askimo-desktop-installer-${platform}" -name "*.dmg" -type f 2>/dev/null | head -n1 || true)
+            if [ -z "$DMG" ]; then
+              echo "⚠️  No DMG found for $platform — skipping (matrix may have failed)"
+              continue
+            fi
+
+            echo "   File    : $DMG"
+            ls -lh "$DMG"
+            echo "   SHA-256 : $(shasum -a 256 "$DMG")"
+
+            echo "   Code signature:"
+            codesign --verify --verbose=2 "$DMG" 2>&1 \
+              && echo "   ✅ Signature OK" \
+              || { echo "   ❌ SIGNATURE INVALID"; FAILED=1; continue; }
+            codesign --display --verbose=4 "$DMG" 2>&1 | grep -E "CDHash|TeamIdentifier|Identifier|Authority|Signed Time" || true
+
+            echo "   Staple ticket before re-staple:"
+            xcrun stapler validate "$DMG" 2>&1 \
+              && echo "   ℹ️  Ticket still present (survived zip)" \
+              || echo "   ℹ️  Ticket stripped by upload-artifact zip (expected — will re-staple)"
+
+            echo "   📎 Re-stapling from Apple CDN..."
+            set +e
+            xcrun stapler staple "$DMG" 2>&1
+            STAPLE_EXIT=$?
+            set -e
+            if [ $STAPLE_EXIT -ne 0 ]; then
+              echo "   ❌ RE-STAPLE FAILED (exit $STAPLE_EXIT) for $platform"
+              echo "   This means Apple CDN does not have a ticket for this DMG."
+              echo "   The notarization step may have succeeded but the DMG was"
+              echo "   re-created/modified after stapling — the hashes won't match."
+              FAILED=1
+              continue
+            fi
+
+            echo "   Staple ticket after re-staple:"
+            xcrun stapler validate "$DMG" 2>&1 \
+              && echo "   ✅ Re-staple verified" \
+              || { echo "   ❌ VALIDATE FAILED after re-staple"; FAILED=1; }
+
+            echo "   SHA-256 after re-staple: $(shasum -a 256 "$DMG")"
+            echo ""
+          done
+
+          echo "══════════════════════════════════════════════════════════════"
+          if [ "$FAILED" -ne 0 ]; then
+            echo "❌ CHECKPOINT 2 FAILED — one or more DMGs are not properly notarized."
+            echo "   Do NOT release. Fix the notarization pipeline and re-run."
+            exit 1
+          fi
+          echo "✅ CHECKPOINT 2 PASSED — all DMGs re-stapled successfully"
+
+      - name: Prepare release assets
+        shell: bash
+        run: |
+          set -euo pipefail
           mkdir -p release
-          files=()
 
-          # macOS DMG (ARM64)
+          echo "══════════════════════════════════════════════════════════════"
+          echo "Prepare release assets"
+          echo "══════════════════════════════════════════════════════════════"
+
+          # ── macOS ARM64 DMG ──────────────────────────────────────────────
           if [ -d "dist/askimo-desktop-installer-macos-arm64" ]; then
-            DMG=$(find dist/askimo-desktop-installer-macos-arm64 -name "*.dmg" -type f | head -n1)
-            if [ -n "$DMG" ]; then
-              DEST="release/Askimo-Desktop-macos-arm64.dmg"
-              cp "$DMG" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged macOS ARM64 DMG: $DEST"
+            SRC=$(find dist/askimo-desktop-installer-macos-arm64 -name "*.dmg" -type f | head -n1)
+            if [ -z "$SRC" ]; then
+              echo "❌ ARM64 DMG not found in dist/askimo-desktop-installer-macos-arm64/" >&2; exit 1
             fi
+            DEST="release/Askimo-Desktop-macos-arm64.dmg"
+            # cp preserves the embedded staple ticket (it's in the DMG code signature,
+            # not a filesystem xattr, so a plain copy is sufficient)
+            cp "$SRC" "$DEST"
+            echo "✓ Copied ARM64 DMG  : $DEST  ($(du -sh "$DEST" | cut -f1))"
+            # Verify ticket survived the copy
+            xcrun stapler validate "$DEST" 2>&1 \
+              && echo "  ✅ Staple ticket intact after copy" \
+              || { echo "  ❌ Staple ticket LOST after cp — aborting"; exit 1; }
           fi
 
-          # macOS DMG (Intel)
+          # ── macOS Intel DMG ──────────────────────────────────────────────
           if [ -d "dist/askimo-desktop-installer-macos-intel" ]; then
-            DMG=$(find dist/askimo-desktop-installer-macos-intel -name "*.dmg" -type f | head -n1)
-            if [ -n "$DMG" ]; then
-              DEST="release/Askimo-Desktop-macos-x64.dmg"
-              cp "$DMG" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged macOS x64 DMG: $DEST"
+            SRC=$(find dist/askimo-desktop-installer-macos-intel -name "*.dmg" -type f | head -n1)
+            if [ -z "$SRC" ]; then
+              echo "❌ Intel DMG not found in dist/askimo-desktop-installer-macos-intel/" >&2; exit 1
             fi
+            DEST="release/Askimo-Desktop-macos-x64.dmg"
+            cp "$SRC" "$DEST"
+            echo "✓ Copied Intel DMG  : $DEST  ($(du -sh "$DEST" | cut -f1))"
+            xcrun stapler validate "$DEST" 2>&1 \
+              && echo "  ✅ Staple ticket intact after copy" \
+              || { echo "  ❌ Staple ticket LOST after cp — aborting"; exit 1; }
           fi
 
-          # Windows MSI
+          # ── Windows MSI ──────────────────────────────────────────────────
           if [ -d "dist/askimo-desktop-installer-windows" ]; then
             MSI=$(find dist/askimo-desktop-installer-windows -name "*.msi" -type f | head -n1)
             if [ -n "$MSI" ]; then
-              DEST="release/Askimo-Desktop-windows-x64.msi"
-              cp "$MSI" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged Windows x64 MSI: $DEST"
+              cp "$MSI" "release/Askimo-Desktop-windows-x64.msi"
+              echo "✓ Copied Windows MSI: release/Askimo-Desktop-windows-x64.msi"
             fi
           fi
 
-          # Linux DEB (x64)
+          # ── Linux x64 DEB ────────────────────────────────────────────────
           if [ -d "dist/askimo-desktop-installer-linux" ]; then
             DEB=$(find dist/askimo-desktop-installer-linux -name "*.deb" -type f | head -n1)
             if [ -n "$DEB" ]; then
-              DEST="release/Askimo-Desktop-linux-x64.deb"
-              cp "$DEB" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged Linux x64 DEB: $DEST"
+              cp "$DEB" "release/Askimo-Desktop-linux-x64.deb"
+              echo "✓ Copied Linux x64  : release/Askimo-Desktop-linux-x64.deb"
             fi
           fi
 
-          # Linux DEB (ARM64)
+          # ── Linux ARM64 DEB ──────────────────────────────────────────────
           if [ -d "dist/askimo-desktop-installer-linux-arm64" ]; then
             DEB=$(find dist/askimo-desktop-installer-linux-arm64 -name "*.deb" -type f | head -n1)
             if [ -n "$DEB" ]; then
-              DEST="release/Askimo-Desktop-linux-arm64.deb"
-              cp "$DEB" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged Linux ARM64 DEB: $DEST"
+              cp "$DEB" "release/Askimo-Desktop-linux-arm64.deb"
+              echo "✓ Copied Linux ARM64: release/Askimo-Desktop-linux-arm64.deb"
             fi
           fi
 
-          # macOS uber JAR (ARM64)
-          if [ -d "dist/askimo-desktop-jar-macos-arm64" ]; then
-            JAR=$(find dist/askimo-desktop-jar-macos-arm64 -name "*.jar" -type f | head -n1)
-            if [ -n "$JAR" ]; then
-              DEST="release/askimo-desktop-macos-arm64.jar"
-              cp "$JAR" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged macOS ARM64 uber JAR: $DEST"
+          # ── Uber JARs ────────────────────────────────────────────────────
+          for entry in \
+            "askimo-desktop-jar-macos-arm64:askimo-desktop-macos-arm64.jar" \
+            "askimo-desktop-jar-macos-intel:askimo-desktop-macos-x64.jar" \
+            "askimo-desktop-jar-windows:askimo-desktop-windows-x64.jar" \
+            "askimo-desktop-jar-linux:askimo-desktop-linux-x64.jar" \
+            "askimo-desktop-jar-linux-arm64:askimo-desktop-linux-arm64.jar"; do
+            artifact="${entry%%:*}"
+            destname="${entry##*:}"
+            if [ -d "dist/$artifact" ]; then
+              JAR=$(find "dist/$artifact" -name "*.jar" -type f | head -n1)
+              if [ -n "$JAR" ]; then
+                cp "$JAR" "release/$destname"
+                echo "✓ Copied JAR        : release/$destname"
+              fi
             fi
-          fi
+          done
 
-          # macOS uber JAR (Intel)
-          if [ -d "dist/askimo-desktop-jar-macos-intel" ]; then
-            JAR=$(find dist/askimo-desktop-jar-macos-intel -name "*.jar" -type f | head -n1)
-            if [ -n "$JAR" ]; then
-              DEST="release/askimo-desktop-macos-x64.jar"
-              cp "$JAR" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged macOS x64 uber JAR: $DEST"
-            fi
-          fi
-
-          # Windows uber JAR
-          if [ -d "dist/askimo-desktop-jar-windows" ]; then
-            JAR=$(find dist/askimo-desktop-jar-windows -name "*.jar" -type f | head -n1)
-            if [ -n "$JAR" ]; then
-              DEST="release/askimo-desktop-windows-x64.jar"
-              cp "$JAR" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged Windows x64 uber JAR: $DEST"
-            fi
-          fi
-
-          # Linux uber JAR (x64)
-          if [ -d "dist/askimo-desktop-jar-linux" ]; then
-            JAR=$(find dist/askimo-desktop-jar-linux -name "*.jar" -type f | head -n1)
-            if [ -n "$JAR" ]; then
-              DEST="release/askimo-desktop-linux-x64.jar"
-              cp "$JAR" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged Linux x64 uber JAR: $DEST"
-            fi
-          fi
-
-          # Linux uber JAR (ARM64)
-          if [ -d "dist/askimo-desktop-jar-linux-arm64" ]; then
-            JAR=$(find dist/askimo-desktop-jar-linux-arm64 -name "*.jar" -type f | head -n1)
-            if [ -n "$JAR" ]; then
-              DEST="release/askimo-desktop-linux-arm64.jar"
-              cp "$JAR" "$DEST"
-              files+=("$DEST")
-              echo "✓ Packaged Linux ARM64 uber JAR: $DEST"
-            fi
-          fi
-
-          # Generate checksums
-          if (( ${#files[@]} > 0 )); then
-            cd release
-            shasum -a 256 * 2>/dev/null | grep -v SHA256SUMS.txt > SHA256SUMS.txt || true
-            cd ..
-            files+=("release/SHA256SUMS.txt")
-          else
-            echo "Error: No installer packages found" >&2
+          echo ""
+          if [ -z "$(ls release/ 2>/dev/null)" ]; then
+            echo "❌ No release files found in release/ — aborting" >&2
             exit 1
           fi
 
-          # Output files for release upload
-          {
-            echo "files<<EOF"
-            printf 'release/%s\n' "$(basename "${files[@]}")"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "Computing checksums..."
+          cd release && shasum -a 256 * > SHA256SUMS.txt && cd ..
 
           echo ""
           echo "Release files prepared:"
           ls -lh release/
-      - name: Upload Desktop Binaries to Existing Release
+          echo "══════════════════════════════════════════════════════════════"
+
+      # ── CHECKPOINT 3: final gate before upload to GitHub Releases ────────
+      # Hard fail if staple ticket or Gatekeeper check is missing.
+      # This is the LAST line of defence before files reach users.
+      - name: "[macOS] Final validation of release DMGs before GitHub upload"
+        shell: bash
+        run: |
+          set -euo pipefail
+          FAILED=0
+
+          echo "══════════════════════════════════════════════════════════════"
+          echo "CHECKPOINT 3 — Final gate before GitHub Releases upload"
+          echo "══════════════════════════════════════════════════════════════"
+
+          shopt -s nullglob
+          DMGS=(release/Askimo-Desktop-macos-*.dmg)
+          if [ ${#DMGS[@]} -eq 0 ]; then
+            echo "⚠️  No macOS DMGs found in release/ — skipping macOS validation"
+          fi
+
+          for DMG in "${DMGS[@]}"; do
+            echo "──────────────────────────────────────────────────────────"
+            echo "Validating: $DMG"
+            ls -lh "$DMG"
+            echo "SHA-256: $(shasum -a 256 "$DMG")"
+
+            echo "Code signature:"
+            codesign --verify --verbose=2 "$DMG" 2>&1 \
+              && echo "✅ Signature OK" \
+              || { echo "❌ SIGNATURE INVALID — DO NOT RELEASE"; FAILED=1; }
+            codesign --display --verbose=4 "$DMG" 2>&1 | grep -E "CDHash|TeamIdentifier|Identifier|Authority|Signed Time" || true
+
+            echo "Staple ticket:"
+            xcrun stapler validate "$DMG" 2>&1 \
+              && echo "✅ Staple ticket present" \
+              || { echo "❌ STAPLE TICKET MISSING — DO NOT RELEASE"; FAILED=1; }
+
+            echo "Gatekeeper assessment:"
+            spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG" 2>&1 \
+              && echo "✅ Gatekeeper accepts" \
+              || { echo "❌ Gatekeeper REJECTS — DO NOT RELEASE"; FAILED=1; }
+            echo ""
+          done
+
+          echo "══════════════════════════════════════════════════════════════"
+          if [ "$FAILED" -ne 0 ]; then
+            echo "❌ CHECKPOINT 3 FAILED — one or more DMGs did not pass validation."
+            echo "   Aborting release. Check the output above for details."
+            exit 1
+          fi
+          echo "✅ CHECKPOINT 3 PASSED — all DMGs are safe to upload to GitHub Releases"
+
+      - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             release/*
           append_body: false
           fail_on_unmatched_files: true
-          prerelease: true
-          draft: false
+          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
+          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -19,13 +19,13 @@ jobs:
         run: git fetch origin ${{ github.base_ref }}
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: true
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,415 @@
+# Triggered ONLY when a GitHub Release is explicitly published (un-drafted in the UI).
+# This ensures homebrew/scoop/docker are never updated by test or draft builds.
+#
+# Flow:
+#   Push tag → cli-release.yml builds binaries → creates DRAFT release
+#   You review the draft → click "Publish release"
+#   ↓ this workflow fires ↓
+#   homebrew tap + scoop bucket + docker images are updated
+name: Publish Packages
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  # ── Homebrew tap ────────────────────────────────────────────────────────────
+  homebrew:
+    name: Publish Homebrew tap
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Collect release assets & checksums
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"   # e.g. v0.4.0
+          VERSION_PLAIN="${TAG#v}"                      # e.g. 0.4.0
+          API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
+          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
+
+          echo "Release : $TAG"
+          echo "Draft   : ${{ github.event.release.draft }}"
+          echo "Pre     : ${{ github.event.release.prerelease }}"
+          echo "Assets  :"
+          echo "$JSON" | jq -r '.assets[].name'
+          echo ""
+
+          ARM_NAME="askimo-darwin-arm64.tar.gz"
+          AMD_NAME="askimo-darwin-amd64.tar.gz"
+
+          ARM_URL="$(echo "$JSON" | jq -r --arg N "$ARM_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
+          AMD_URL="$(echo "$JSON" | jq -r --arg N "$AMD_NAME" '.assets[] | select(.name==$N) | .browser_download_url // empty')"
+          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
+
+          # If no macOS CLI binary is present this is a desktop-only release — skip silently
+          if [ -z "${ARM_URL:-}" ] || [ -z "${SHA_URL:-}" ]; then
+            echo "⚠️  No CLI macOS assets found — skipping homebrew (desktop-only release?)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          curl -sSL -o SHA256SUMS.txt "$SHA_URL"
+
+          ARM_SHA="$(grep -E "  ${ARM_NAME//./\\.}$" SHA256SUMS.txt | awk '{print $1}')"
+          AMD_SHA=""
+          if [ -n "${AMD_URL:-}" ]; then
+            AMD_SHA="$(grep -E "  ${AMD_NAME//./\\.}$" SHA256SUMS.txt | awk '{print $1}')" || true
+          fi
+
+          if [ -z "${ARM_SHA:-}" ]; then
+            echo "❌ Could not find ARM sha in SHA256SUMS.txt" >&2; exit 1
+          fi
+
+          {
+            echo "skip=false"
+            echo "tag=$TAG"
+            echo "version_plain=$VERSION_PLAIN"
+            echo "arm_url=$ARM_URL"
+            echo "arm_sha=$ARM_SHA"
+            echo "amd_url=${AMD_URL:-}"
+            echo "amd_sha=${AMD_SHA:-}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tap repo
+        if: steps.meta.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ vars.TAP_REPO || 'haiphucnguyen/homebrew-askimo' }}
+          token: ${{ secrets.TAP_PUSH_TOKEN }}
+          path: tap
+          fetch-depth: 0
+
+      - name: Write formula into tap
+        if: steps.meta.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Formula
+
+          VERSION="${{ steps.meta.outputs.version_plain }}"
+          ARM_URL="${{ steps.meta.outputs.arm_url }}"
+          ARM_SHA="${{ steps.meta.outputs.arm_sha }}"
+          AMD_URL="${{ steps.meta.outputs.amd_url }}"
+          AMD_SHA="${{ steps.meta.outputs.amd_sha }}"
+
+          # 1) Header
+          cat > tap/Formula/askimo.rb <<'RUBY'
+          # typed: false
+          # frozen_string_literal: true
+
+          class Askimo < Formula
+            desc "AI-powered terminal assistant for multiple LLM providers"
+            homepage "https://github.com/haiphucnguyen/askimo"
+            license "AGPLv3"
+
+            on_macos do
+          RUBY
+
+          # 2) ARM stanza (required)
+          cat >> tap/Formula/askimo.rb <<RUBY
+              on_arm do
+                version "${VERSION}"
+                url "${ARM_URL}"
+                sha256 "${ARM_SHA}"
+              end
+          RUBY
+
+          # 3) Optional Intel stanza
+          if [ -n "${AMD_URL}" ] && [ -n "${AMD_SHA}" ]; then
+          cat >> tap/Formula/askimo.rb <<RUBY
+
+              on_intel do
+                version "${VERSION}"
+                url "${AMD_URL}"
+                sha256 "${AMD_SHA}"
+              end
+          RUBY
+          fi
+
+          # 4) Footer
+          cat >> tap/Formula/askimo.rb <<'RUBY'
+            end
+
+            def install
+              bin.install "askimo"
+            end
+
+            test do
+              output = shell_output("#{bin}/askimo --version")
+              assert_match "askimo", output.downcase
+            end
+          end
+          RUBY
+
+          echo "==== tap/Formula/askimo.rb ===="
+          nl -ba tap/Formula/askimo.rb
+
+          # Catch structure errors early
+          ruby -c tap/Formula/askimo.rb
+
+      - name: Commit & push to tap repo
+        if: steps.meta.outputs.skip != 'true'
+        working-directory: tap
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+        shell: bash
+        run: |
+          set -euo pipefail
+          git add Formula/askimo.rb
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "askimo ${{ steps.meta.outputs.version_plain }}: update formula for ${{ steps.meta.outputs.tag }}"
+            git push
+          fi
+
+  # ── Scoop bucket ────────────────────────────────────────────────────────────
+  scoop:
+    name: Publish Scoop manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Collect release assets & checksums
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION_PLAIN="${TAG#v}"
+          API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
+          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
+
+          echo "Release : $TAG"
+          echo "Assets  :"
+          echo "$JSON" | jq -r '.assets[].name'
+          echo ""
+
+          WIN_NAME="askimo-windows-x64.zip"
+          WIN_URL="$(echo "$JSON" | jq -r --arg N "$WIN_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
+          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
+
+          if [ -z "${WIN_URL:-}" ] || [ -z "${SHA_URL:-}" ]; then
+            echo "⚠️  No CLI Windows assets found — skipping scoop (desktop-only release?)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          curl -sSL -o SHA256SUMS.txt "$SHA_URL"
+          WIN_SHA="$(grep "  $WIN_NAME" SHA256SUMS.txt | awk '{print $1}')"
+          if [ -z "$WIN_SHA" ]; then
+            echo "❌ SHA256 for $WIN_NAME not in SHA256SUMS.txt" >&2; exit 1
+          fi
+
+          {
+            echo "skip=false"
+            echo "tag=$TAG"
+            echo "version=$VERSION_PLAIN"
+            echo "win_url=$WIN_URL"
+            echo "win_sha=$WIN_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout scoop bucket
+        if: steps.meta.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: haiphucnguyen/scoop-askimo
+          token: ${{ secrets.TAP_PUSH_TOKEN }}
+          ref: main
+          path: bucket
+          fetch-depth: 0
+
+      - name: Write askimo manifest
+        if: steps.meta.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p bucket/bucket
+          cat > bucket/bucket/askimo.json <<EOF
+          {
+            "version": "${{ steps.meta.outputs.version }}",
+            "description": "AI-powered terminal assistant for multiple LLM providers",
+            "homepage": "https://github.com/haiphucnguyen/askimo",
+            "license": "AGPLv3",
+            "architecture": {
+              "64bit": {
+                "url": "${{ steps.meta.outputs.win_url }}",
+                "hash": "${{ steps.meta.outputs.win_sha }}",
+                "bin": "askimo.exe"
+              }
+            }
+          }
+          EOF
+          cat bucket/bucket/askimo.json
+
+      - name: Commit & push to bucket
+        if: steps.meta.outputs.skip != 'true'
+        working-directory: bucket
+        env:
+          TOKEN: ${{ secrets.TAP_PUSH_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git add bucket/askimo.json
+          if ! git diff --cached --quiet; then
+            git commit -m "askimo ${{ steps.meta.outputs.tag }}"
+            git remote set-url origin "https://x-access-token:${TOKEN}@github.com/haiphucnguyen/scoop-askimo.git"
+            git push origin HEAD:main
+          else
+            echo "No changes to commit."
+          fi
+
+  # ── Docker multi-arch images ────────────────────────────────────────────────
+  docker:
+    name: Build & Push Docker (native, multi-arch)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Check for CLI Linux assets
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
+          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
+
+          AMD_NAME="askimo-linux-x64.tar.gz"
+          AMD_URL="$(echo "$JSON" | jq -r --arg N "$AMD_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
+
+          if [ -z "${AMD_URL:-}" ]; then
+            echo "⚠️  No CLI Linux x64 asset found — skipping docker (desktop-only release?)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
+          ARM_NAME="askimo-linux-arm64.tar.gz"
+          ARM_URL="$(echo "$JSON" | jq -r --arg N "$ARM_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
+
+          curl -sSL -o SHA256SUMS.txt "$SHA_URL"
+
+          {
+            echo "skip=false"
+            echo "amd_url=$AMD_URL"
+            echo "arm_url=${ARM_URL:-}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download & extract amd64 binary
+        if: steps.check.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          curl -sSL "${{ steps.check.outputs.amd_url }}" | tar -xz -C out/
+          mv out/askimo out/askimo-amd64
+          chmod +x out/askimo-amd64
+          echo "✅ amd64: $(out/askimo-amd64 --version 2>&1 || true)"
+
+      - name: Download & extract arm64 binary
+        if: steps.check.outputs.skip != 'true' && steps.check.outputs.arm_url != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          curl -sSL "${{ steps.check.outputs.arm_url }}" | tar -xz -C out/
+          mv out/askimo out/askimo-arm64
+          chmod +x out/askimo-arm64
+          echo "✅ arm64 binary ready"
+
+      - name: Set up Buildx
+        if: steps.check.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        if: steps.check.outputs.skip != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        if: steps.check.outputs.skip != 'true'
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/${GITHUB_REPOSITORY_OWNER}/askimo"
+          V="${{ github.event.release.tag_name }}"
+          echo "base=$REPO"                                   >> $GITHUB_OUTPUT
+          echo "tags=$REPO:latest,$REPO:${V},$REPO:${V#v}"    >> $GITHUB_OUTPUT
+
+      - name: Build & push amd64 image
+        if: steps.check.outputs.skip != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.runtime
+          build-args: BIN=out/askimo-amd64
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.base }}:amd64-temp
+          provenance: false
+          sbom: false
+
+      - name: Build & push arm64 image
+        if: steps.check.outputs.skip != 'true' && steps.check.outputs.arm_url != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.runtime
+          build-args: BIN=out/askimo-arm64
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.base }}:arm64-temp
+          provenance: false
+          sbom: false
+
+      - name: Create & push multi-arch manifests
+        if: steps.check.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          I="${{ steps.tags.outputs.base }}"
+          IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.tags }}"
+          AMENDS="--amend $I:amd64-temp"
+          if [ -n "${{ steps.check.outputs.arm_url }}" ]; then
+            AMENDS="$AMENDS --amend $I:arm64-temp"
+          fi
+          for T in "${TAGS[@]}"; do
+            docker manifest create "$T" $AMENDS
+            docker manifest push "$T"
+          done
+          docker rmi "$I:amd64-temp" "$I:arm64-temp" 2>/dev/null || true
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,16 +12,16 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Publish to GitHub Packages
         run: ./gradlew :shared:publish :desktop-shared:publish

--- a/.github/workflows/shared-tests.yml
+++ b/.github/workflows/shared-tests.yml
@@ -11,16 +11,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: true
 
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: shared-test-report-attempt${{ github.run_attempt }}
           path: shared/build/reports/tests/test

--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -760,8 +760,7 @@
     "name": "com.github.dockerjava.api.model.PeerNode",
     "allDeclaredFields": true,
     "queryAllDeclaredMethods": true,
-    "queryAllDeclaredConstructors": true,
-    "methods": [{ "name": "<init>", "parameterTypes": [] }]
+    "queryAllDeclaredConstructors": true
   },
   {
     "name": "com.github.dockerjava.api.model.Ports",
@@ -4952,7 +4951,7 @@
     ]
   },
   {
-    "name": "io.askimo.core.providers.ChatClient$MockitoMock$VRRMpwO4",
+    "name": "io.askimo.core.providers.ChatClient$MockitoMock$TJ5euPwO",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },
@@ -7339,7 +7338,7 @@
     ]
   },
   {
-    "name": "org.jline.reader.ParsedLine$MockitoMock$S6nuyYvP",
+    "name": "org.jline.reader.ParsedLine$MockitoMock$TfaM2s4g",
     "queryAllDeclaredConstructors": true,
     "methods": [{ "name": "<init>", "parameterTypes": [] }]
   },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ProjectSidePanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ProjectSidePanel.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -120,6 +121,7 @@ fun projectSidePanel(
         modifier = modifier
             .width(animatedWidth)
             .fillMaxHeight(),
+        shape = RectangleShape,
         colors = CardDefaults.cardColors(
             containerColor = AppComponents.sidebarSurfaceColor(),
             contentColor = MaterialTheme.colorScheme.onSurface,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/service/BackgroundImageService.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/service/BackgroundImageService.kt
@@ -95,19 +95,4 @@ object BackgroundImageService {
             log.error("Failed to remove custom background", e)
         }
     }
-
-    /**
-     * Returns the absolute path of the currently stored custom background file,
-     * or `null` if none exists.
-     *
-     * Useful for validating on startup that the stored preference path still
-     * points to an existing file inside the managed directory.
-     */
-    fun getStoredCustomBackgroundPath(): String? = backgroundsDir.listFiles()
-        ?.firstOrNull {
-            it.isFile &&
-                it.nameWithoutExtension == STORED_NAME &&
-                it.extension.lowercase() in VALID_EXTENSIONS
-        }
-        ?.absolutePath
 }

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.time.Year
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.util.Base64
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -129,7 +130,7 @@ compose.desktop {
             includeAllModules = true
 
             macOS {
-                bundleID = "io.askimo.desktop"
+                bundleID = "io.askimo.askimo-personal"
                 iconFile.set(project.file("src/main/resources/images/askimo.icns"))
 
                 // Disable automatic signing - we do custom signing with entitlements in signMacApp task
@@ -525,17 +526,19 @@ tasks.register("detectUnusedLocalizations") {
 
                     // Pattern 4: Keys with variable interpolation
                     // Matches: stringResource("log.level.${variable}"), stringResource("prefix.${var}.suffix")
-                    Regex("""stringResource\s*\(\s*"([a-z][a-z0-9._-]*)\$\{[^}]+\}([a-z0-9._-]*)"""").findAll(content).forEach { match ->
-                        val prefix = match.groupValues[1]
-                        val suffix = match.groupValues[2]
-                        // Find all keys that start with the prefix and end with the suffix
-                        allKeys.keys.forEach { key ->
-                            if (key.startsWith(prefix) && (suffix.isEmpty() || key.endsWith(suffix))) {
-                                usedKeys.add(key)
-                                keyUsageMap.getOrPut(key) { mutableListOf() }.add(relativePath)
+                    Regex("""stringResource\s*\(\s*"([a-z][a-z0-9._-]*)\$\{[^}]+\}([a-z0-9._-]*)"""")
+                        .findAll(content)
+                        .forEach { match ->
+                            val prefix = match.groupValues[1]
+                            val suffix = match.groupValues[2]
+                            // Find all keys that start with the prefix and end with the suffix
+                            allKeys.keys.forEach { key ->
+                                if (key.startsWith(prefix) && (suffix.isEmpty() || key.endsWith(suffix))) {
+                                    usedKeys.add(key)
+                                    keyUsageMap.getOrPut(key) { mutableListOf() }.add(relativePath)
+                                }
                             }
                         }
-                    }
 
                     // Pattern 5: LocalizationManager.getString with interpolation
                     Regex(
@@ -672,7 +675,392 @@ tasks.register("detectUnusedLocalizations") {
 
 // =============================================================================
 // macOS Code Signing and Notarization Tasks
+//
+// All certificate/keychain setup lives here — portable across local and CI.
+//
+// Environment variables (pass via .env or command line):
+//
+//   ── Signing ──────────────────────────────────────────────────────────────
+//   KEYCHAIN_PASSWORD          Required always.
+//                              Local dev : your macOS login password.
+//                              CI        : any random string (ephemeral keychain).
+//
+//   MACOS_CERTIFICATE_BASE64   Optional.  base64-encoded .p12 file.
+//                              Set this in CI where the cert is not pre-installed.
+//                              If absent the login keychain is used as-is.
+//
+//   MACOS_CERTIFICATE_PASSWORD Optional.  Password for the .p12 (default: "").
+//
+//   MACOS_IDENTITY             Optional.  "Developer ID Application: Name (TEAM)".
+//                              Auto-detected from the keychain when not set.
+//
+//   ── Notarization ─────────────────────────────────────────────────────────
+//   APPLE_ID                   Required.  Your Apple ID email.
+//   APPLE_PASSWORD             Required.  App-specific password.
+//   APPLE_TEAM_ID              Required.  10-character team ID.
+//
+// Usage (local and CI are identical):
+//   ./gradlew customNotarizeMacApp
 // =============================================================================
+
+// -----------------------------------------------------------------------------
+// Shared helpers
+// -----------------------------------------------------------------------------
+
+/**
+ * Prepares the macOS Keychain so codesign can access the Developer ID private key.
+ *
+ * CI mode   (MACOS_CERTIFICATE_BASE64 set):
+ *   Decodes the base64 .p12, creates a short-lived keychain, imports the cert,
+ *   grants codesign partition-list access, and puts the keychain first in the
+ *   search list.  No Apple intermediate cert download is needed — codesign
+ *   fetches them automatically via the --timestamp server.
+ *
+ * Local dev (MACOS_CERTIFICATE_BASE64 absent):
+ *   Just unlocks the existing login keychain with KEYCHAIN_PASSWORD and raises
+ *   the auto-lock timeout so it stays open for the whole build.
+ *
+ * After this call use [resolveIdentity] to get the signing identity string.
+ */
+fun prepareSigningKeychain() {
+    val keychainPassword =
+        getEnvOrProperty("KEYCHAIN_PASSWORD")
+            ?: throw GradleException(
+                "KEYCHAIN_PASSWORD is required.\n" +
+                    "  Local dev: set it to your macOS login password.\n" +
+                    "  CI: set it to any random string (the ephemeral keychain password).",
+            )
+    val certBase64 = getEnvOrProperty("MACOS_CERTIFICATE_BASE64")
+    val certPassword = getEnvOrProperty("MACOS_CERTIFICATE_PASSWORD") ?: ""
+
+    if (certBase64 != null) {
+        // ── CI mode: import the .p12 into an ephemeral keychain ──────────────
+        logger.lifecycle("🔑 CI mode: creating ephemeral keychain and importing certificate...")
+
+        val tmpDir = File(System.getProperty("java.io.tmpdir"))
+        val keychainPath = File(tmpDir, "askimo-signing.keychain-db")
+        val p12File = File(tmpDir, "askimo-cert.p12")
+
+        try {
+            // Write decoded certificate
+            p12File.writeBytes(Base64.getDecoder().decode(certBase64.trim()))
+
+            // Delete any leftover keychain from a previous run
+            execOps.exec {
+                commandLine("security", "delete-keychain", keychainPath.absolutePath)
+                isIgnoreExitValue = true
+            }
+
+            // Create keychain, unlock it, extend auto-lock timeout to 6 hours
+            execOps.exec { commandLine("security", "create-keychain", "-p", keychainPassword, keychainPath.absolutePath) }
+            execOps.exec { commandLine("security", "unlock-keychain", "-p", keychainPassword, keychainPath.absolutePath) }
+            execOps.exec { commandLine("security", "set-keychain-settings", "-lut", "21600", keychainPath.absolutePath) }
+
+            // Import certificate — grant codesign access without prompts (-A = all apps, -T = specific tool)
+            execOps.exec {
+                commandLine(
+                    "security",
+                    "import",
+                    p12File.absolutePath,
+                    "-P",
+                    certPassword,
+                    "-k",
+                    keychainPath.absolutePath,
+                    "-T",
+                    "/usr/bin/codesign",
+                    "-A",
+                )
+            }
+
+            // Allow codesign to access the key without a UI password prompt
+            execOps.exec {
+                commandLine(
+                    "security",
+                    "set-key-partition-list",
+                    "-S",
+                    "apple-tool:,apple:,codesign:",
+                    "-s",
+                    "-k",
+                    keychainPassword,
+                    keychainPath.absolutePath,
+                )
+            }
+
+            // Put our keychain first so codesign finds the identity
+            execOps.exec {
+                commandLine(
+                    "security",
+                    "list-keychains",
+                    "-d",
+                    "user",
+                    "-s",
+                    keychainPath.absolutePath,
+                    "login.keychain-db",
+                )
+            }
+
+            logger.lifecycle("✅ Ephemeral keychain ready: ${keychainPath.absolutePath}")
+        } finally {
+            p12File.delete()
+        }
+
+        resolveAndCacheIdentity(keychainPath.absolutePath)
+    } else {
+        // ── Local dev mode: unlock the login keychain ─────────────────────────
+        // Resolve the actual login keychain path dynamically — on some macOS
+        // versions or after upgrades the path may differ from the default.
+        val home = System.getProperty("user.home")
+
+        // Candidate paths in priority order
+        val keychainCandidates =
+            listOf(
+                "$home/Library/Keychains/login.keychain-db", // modern macOS
+                "$home/Library/Keychains/login.keychain", // legacy path
+            )
+        val loginKeychain =
+            keychainCandidates.firstOrNull { File(it).exists() }
+                ?: run {
+                    // Last resort: ask the system which keychains are in the list
+                    val out = ByteArrayOutputStream()
+                    execOps.exec {
+                        commandLine("security", "list-keychains", "-d", "user")
+                        standardOutput = out
+                        isIgnoreExitValue = true
+                    }
+                    out
+                        .toString()
+                        .lines()
+                        .map { it.trim().removeSurrounding("\"") }
+                        .firstOrNull { it.contains("login") && File(it).exists() }
+                        ?: throw GradleException(
+                            "Cannot find login keychain. Set KEYCHAIN_PASSWORD and ensure " +
+                                "your Developer ID certificate is in the login keychain.",
+                        )
+                }
+
+        logger.lifecycle("🔓 Local mode: unlocking $loginKeychain")
+
+        // Unlock — Gradle commandLine does NOT go through a shell, so passwords
+        // with special characters are passed safely as raw process arguments.
+        execOps.exec {
+            commandLine("security", "unlock-keychain", "-p", keychainPassword, loginKeychain)
+        }
+
+        // Prevent auto-lock for 1 hour during the build
+        execOps.exec {
+            commandLine("security", "set-keychain-settings", "-t", "3600", "-u", loginKeychain)
+            isIgnoreExitValue = true
+        }
+
+        // Grant codesign access without interactive UI prompts
+        execOps.exec {
+            commandLine(
+                "security",
+                "set-key-partition-list",
+                "-S",
+                "apple-tool:,apple:,codesign:",
+                "-s",
+                "-k",
+                keychainPassword,
+                loginKeychain,
+            )
+            isIgnoreExitValue = true
+        }
+
+        // Ensure the login keychain is at the top of the search list
+        execOps.exec {
+            commandLine("security", "list-keychains", "-d", "user", "-s", loginKeychain)
+            isIgnoreExitValue = true
+        }
+
+        logger.lifecycle("✅ Login keychain unlocked: $loginKeychain")
+
+        resolveAndCacheIdentity(loginKeychain)
+    }
+}
+
+/**
+ * Finds the first "Developer ID Application" identity in [keychainPath]
+ * (or the default search list when null) and caches it in a project extra
+ * property so [resolveIdentity] can return it cheaply.
+ *
+ * MACOS_IDENTITY env var takes precedence if set.
+ */
+fun resolveAndCacheIdentity(keychainPath: String?) {
+    val explicit = getEnvOrProperty("MACOS_IDENTITY")
+
+    // Determine which keychain actually holds the signing identity.
+    // In CI mode the identity is always in the ephemeral keychain we just created,
+    // so we can use keychainPath directly.
+    // In local-dev mode the cert may live in System.keychain (or any other keychain
+    // in the search list), NOT necessarily in login.keychain-db.  Passing the wrong
+    // --keychain path to codesign causes errSecInternalComponent even when the
+    // keychain is unlocked, so we probe for the real keychain here.
+    val effectiveKeychainPath: String? =
+        run {
+            if (keychainPath == null) return@run null
+
+            // Check whether the identity is actually present in keychainPath.
+            val probeOut = ByteArrayOutputStream()
+            execOps.exec {
+                commandLine("security", "find-identity", "-v", "-p", "codesigning", keychainPath)
+                standardOutput = probeOut
+                isIgnoreExitValue = true
+            }
+            val identityName = explicit?.takeIf { it.isNotBlank() } ?: "Developer ID Application"
+            if (probeOut.toString().contains(identityName)) {
+                // Identity lives in the supplied keychain — use it.
+                keychainPath
+            } else {
+                // Identity is NOT in keychainPath (e.g. it lives in System.keychain).
+                // Find the actual keychain by asking security for the certificate.
+                val certOut = ByteArrayOutputStream()
+                execOps.exec {
+                    commandLine(
+                        "security",
+                        "find-certificate",
+                        "-c",
+                        if (!explicit.isNullOrBlank()) {
+                            explicit.substringAfter(": ").substringBefore(" (")
+                        } else {
+                            "Developer ID Application"
+                        },
+                    )
+                    standardOutput = certOut
+                    isIgnoreExitValue = true
+                }
+                val match = Regex("""keychain:\s*"([^"]+)"""").find(certOut.toString())
+                val foundKeychain = match?.groupValues?.get(1)
+                if (foundKeychain != null) {
+                    logger.lifecycle("🔑 Identity found in keychain: $foundKeychain (not in $keychainPath)")
+                    // Do NOT pass --keychain for System.keychain: codesign can reach it via the
+                    // default search list, and explicitly passing System.keychain with
+                    // set-key-partition-list would require sudo (causing errSecInternalComponent).
+                    if (foundKeychain == "/Library/Keychains/System.keychain") {
+                        logger.lifecycle(
+                            "ℹ️  Identity is in System.keychain — omitting --" +
+                                "keychain from codesign (uses default search list)",
+                        )
+                        null
+                    } else {
+                        foundKeychain
+                    }
+                } else {
+                    // Cannot determine keychain — let codesign use the default search list.
+                    logger.lifecycle("⚠️  Could not determine keychain for identity; omitting --keychain from codesign")
+                    null
+                }
+            }
+        }
+
+    if (effectiveKeychainPath != null) {
+        project.extra["macosKeychainPath"] = effectiveKeychainPath
+    }
+
+    if (!explicit.isNullOrBlank()) {
+        project.extra["macosIdentityResolved"] = explicit
+        logger.lifecycle("🔑 Using provided identity: $explicit")
+        return
+    }
+
+    val output = ByteArrayOutputStream()
+    val args =
+        buildList {
+            add("security")
+            add("find-identity")
+            add("-v")
+            add("-p")
+            add("codesigning")
+            if (effectiveKeychainPath != null) {
+                add(effectiveKeychainPath)
+            }
+        }
+    execOps.exec {
+        commandLine(args)
+        standardOutput = output
+        isIgnoreExitValue = true
+    }
+
+    val identity =
+        output
+            .toString()
+            .lines()
+            .firstOrNull { it.contains("Developer ID Application") }
+            ?.let { Regex(""""([^"]+)"""").find(it)?.groupValues?.get(1) }
+            ?: throw GradleException(
+                "❌ No 'Developer ID Application' certificate found.\n" +
+                    "  Local: make sure your cert is in the login keychain.\n" +
+                    "  CI: verify MACOS_CERTIFICATE_BASE64 is correct.",
+            )
+
+    project.extra["macosIdentityResolved"] = identity
+    logger.lifecycle("🔑 Resolved identity: $identity")
+}
+
+/** Returns the signing identity resolved by [prepareSigningKeychain]. */
+fun resolveIdentity(): String =
+    (project.extra.get("macosIdentityResolved") as? String)
+        ?: throw GradleException("prepareSigningKeychain() must run before resolveIdentity()")
+
+/**
+ * Returns the keychain path cached by [prepareSigningKeychain], or null when
+ * not available (falls back to the system default keychain search list).
+ */
+fun resolveKeychainPath(): String? = project.extra.properties["macosKeychainPath"] as? String
+
+/**
+ * Staples the notarization ticket to [target] with up to [maxAttempts] retries,
+ * waiting [waitSeconds] between attempts.
+ *
+ * Apple's CDN can take several minutes to publish the ticket after "Accepted"
+ * (Error 65 = "Record not found" = CDN lag, safe to retry).
+ */
+fun stapleWithRetry(
+    target: File,
+    maxAttempts: Int = 5,
+    waitSeconds: Long = 60,
+) {
+    var stapled = false
+    for (attempt in 1..maxAttempts) {
+        logger.lifecycle("⏳ Waiting ${waitSeconds}s for ticket CDN propagation (attempt $attempt/$maxAttempts)...")
+        Thread.sleep(waitSeconds * 1000)
+
+        logger.lifecycle("📎 Stapling: ${target.name} ...")
+        val out = ByteArrayOutputStream()
+        val err = ByteArrayOutputStream()
+        val result =
+            execOps.exec {
+                commandLine("xcrun", "stapler", "staple", "-v", target.absolutePath)
+                isIgnoreExitValue = true
+                standardOutput = out
+                errorOutput = err
+            }
+
+        if (result.exitValue == 0) {
+            logger.lifecycle("✅ Stapled successfully on attempt $attempt")
+            stapled = true
+            break
+        }
+
+        val combined = out.toString() + err.toString()
+        logger.lifecycle("⚠️  Attempt $attempt failed (exit ${result.exitValue}):\n$combined")
+
+        if (!combined.contains("Error 65") && !combined.contains("Record not found")) {
+            throw GradleException("❌ Stapler failed with unexpected error:\n$combined")
+        }
+    }
+    if (!stapled) {
+        throw GradleException(
+            "❌ Stapler failed after $maxAttempts attempts (${maxAttempts * waitSeconds}s).\n" +
+                "Run manually when the ticket propagates:\n" +
+                "  xcrun stapler staple -v \"${target.absolutePath}\"",
+        )
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Task: createEntitlements
+// -----------------------------------------------------------------------------
 
 /**
  * Create entitlements file for hardened runtime
@@ -748,8 +1136,9 @@ fun isMachOBinary(file: File): Boolean {
 fun signDylibsInsideJar(
     jarFile: File,
     identity: String,
-    entitlementsFile: File,
+    @Suppress("UNUSED_PARAMETER") entitlementsFile: File,
     workRoot: File,
+    keychainPath: String? = null,
 ) {
     logger.lifecycle("   • Signing native binaries inside JAR: ${jarFile.name}")
     logger.lifecycle("     Path: ${jarFile.absolutePath}")
@@ -812,18 +1201,24 @@ fun signDylibsInsideJar(
                 // Make sure the binary is executable before signing
                 nativeBinary.setExecutable(true, false)
                 execOps.exec {
-                    commandLine(
-                        "codesign",
-                        "--force",
-                        "--sign",
-                        identity,
-                        "--entitlements",
-                        entitlementsFile.absolutePath,
-                        "--timestamp",
-                        "--options",
-                        "runtime",
-                        nativeBinary.absolutePath,
-                    )
+                    // Dylibs/jnilibs do NOT need entitlements — passing --entitlements
+                    // to a dylib causes errSecInternalComponent on some macOS versions.
+                    val cmd =
+                        buildList {
+                            add("codesign")
+                            if (keychainPath != null) {
+                                add("--keychain")
+                                add(keychainPath)
+                            }
+                            add("--force")
+                            add("--sign")
+                            add(identity)
+                            add("--timestamp")
+                            add("--options")
+                            add("runtime")
+                            add(nativeBinary.absolutePath)
+                        }
+                    commandLine(cmd)
                 }
             }
 
@@ -870,19 +1265,36 @@ fun signDylibsInsideJar(
 }
 
 /**
- * Sign all components of the .app bundle
+ * Sign all components of the .app bundle.
+ * Keychain setup (cert import in CI, or unlock in local dev) happens here.
  */
 tasks.register("signMacApp") {
     group = "distribution"
-    description = "Sign all components of the macOS .app bundle with entitlements"
+    description = "Prepare keychain + sign all components of the macOS .app bundle"
 
     dependsOn("createEntitlements", "createDistributable")
 
     @Suppress("DEPRECATION")
     doLast {
-        val macosIdentity =
-            getEnvOrProperty("MACOS_IDENTITY")
-                ?: throw GradleException("MACOS_IDENTITY environment variable is required")
+        // Prepares keychain (imports cert in CI, unlocks login keychain locally)
+        // and resolves the signing identity — works on any macOS machine.
+        prepareSigningKeychain()
+        val macosIdentity = resolveIdentity()
+        val keychainPath = resolveKeychainPath()
+
+        // Build a helper that appends "--keychain <path>" when a keychain is known.
+        // Passing --keychain explicitly ensures codesign can reach the private key
+        // even when running inside a JVM subprocess that doesn't inherit the macOS
+        // GUI session's keychain search list.
+        fun codesignArgs(vararg extra: String): List<String> =
+            buildList {
+                add("codesign")
+                if (keychainPath != null) {
+                    add("--keychain")
+                    add(keychainPath)
+                }
+                addAll(extra)
+            }
 
         val appDir = file("${layout.buildDirectory.get()}/compose/binaries/main/app")
         val appBundle =
@@ -934,6 +1346,9 @@ tasks.register("signMacApp") {
         logger.lifecycle("Main executable: $mainExeName at ${mainExe.absolutePath}")
 
         // 1) Sign embedded runtime dylibs + jspawnhelper
+        //    Dylibs do NOT need entitlements — passing --entitlements to a dylib
+        //    triggers errSecInternalComponent on some macOS versions.  Just sign
+        //    with --options runtime and --timestamp, which is all Apple requires.
         if (runtimeDir.exists()) {
             logger.lifecycle("🔧 Signing embedded runtime dylibs + helpers...")
             runtimeDir
@@ -942,23 +1357,22 @@ tasks.register("signMacApp") {
                 .forEach { file ->
                     execOps.exec {
                         commandLine(
-                            "codesign",
-                            "--force",
-                            "--sign",
-                            macosIdentity,
-                            "--entitlements",
-                            entitlementsFile.absolutePath,
-                            "--timestamp",
-                            "--options",
-                            "runtime",
-                            file.absolutePath,
+                            codesignArgs(
+                                "--force",
+                                "--sign",
+                                macosIdentity,
+                                "--timestamp",
+                                "--options",
+                                "runtime",
+                                file.absolutePath,
+                            ),
                         )
                     }
                     logger.lifecycle("${file.absolutePath}: replacing existing signature")
                 }
         }
 
-        // 2) Sign loose dylibs under Contents/app
+        // 2) Sign loose dylibs under Contents/app (no entitlements needed)
         if (appLibDir.exists()) {
             logger.lifecycle("🔧 Signing loose dylibs under Contents/app...")
             appLibDir
@@ -967,16 +1381,15 @@ tasks.register("signMacApp") {
                 .forEach { dylibFile ->
                     execOps.exec {
                         commandLine(
-                            "codesign",
-                            "--force",
-                            "--sign",
-                            macosIdentity,
-                            "--entitlements",
-                            entitlementsFile.absolutePath,
-                            "--timestamp",
-                            "--options",
-                            "runtime",
-                            dylibFile.absolutePath,
+                            codesignArgs(
+                                "--force",
+                                "--sign",
+                                macosIdentity,
+                                "--timestamp",
+                                "--options",
+                                "runtime",
+                                dylibFile.absolutePath,
+                            ),
                         )
                     }
                 }
@@ -991,19 +1404,41 @@ tasks.register("signMacApp") {
                 .walk()
                 .filter { it.extension == "jar" && it.isFile }
                 .forEach { jarFile ->
-                    signDylibsInsideJar(jarFile, macosIdentity, entitlementsFile, workRoot)
+                    signDylibsInsideJar(jarFile, macosIdentity, entitlementsFile, workRoot, keychainPath)
                 }
 
             workRoot.deleteRecursively()
         }
 
-        // 4) Sign main executable
+        // 4) Sign main executable (with entitlements — executable needs them)
         if (mainExe.exists()) {
             logger.lifecycle("🔧 Signing main executable: ${mainExe.absolutePath}")
             execOps.exec {
                 commandLine(
-                    "codesign",
+                    codesignArgs(
+                        "--force",
+                        "--sign",
+                        macosIdentity,
+                        "--entitlements",
+                        entitlementsFile.absolutePath,
+                        "--timestamp",
+                        "--options",
+                        "runtime",
+                        mainExe.absolutePath,
+                    ),
+                )
+            }
+        } else {
+            logger.warn("⚠️ Main executable not found: ${mainExe.absolutePath}")
+        }
+
+        // 5) Sign app bundle (deep, with entitlements)
+        logger.lifecycle("🔧 Signing app bundle (deep): ${appToSign.absolutePath}")
+        execOps.exec {
+            commandLine(
+                codesignArgs(
                     "--force",
+                    "--deep",
                     "--sign",
                     macosIdentity,
                     "--entitlements",
@@ -1011,28 +1446,8 @@ tasks.register("signMacApp") {
                     "--timestamp",
                     "--options",
                     "runtime",
-                    mainExe.absolutePath,
-                )
-            }
-        } else {
-            logger.warn("⚠️ Main executable not found: ${mainExe.absolutePath}")
-        }
-
-        // 5) Sign app bundle (deep)
-        logger.lifecycle("🔧 Signing app bundle (deep): ${appToSign.absolutePath}")
-        execOps.exec {
-            commandLine(
-                "codesign",
-                "--force",
-                "--deep",
-                "--sign",
-                macosIdentity,
-                "--entitlements",
-                entitlementsFile.absolutePath,
-                "--timestamp",
-                "--options",
-                "runtime",
-                appToSign.absolutePath,
+                    appToSign.absolutePath,
+                ),
             )
         }
 
@@ -1162,34 +1577,15 @@ tasks.register("notarizeApp") {
             throw GradleException("❌ .app notarization failed with status: $status")
         }
 
-        // Wait for ticket propagation
-        logger.lifecycle("⏳ Waiting 60s for ticket propagation...")
-        Thread.sleep(60000)
-
-        // Staple ticket to .app
-        logger.lifecycle("📎 Stapling ticket to .app...")
-        val staplerOutput = ByteArrayOutputStream()
-        val staplerError = ByteArrayOutputStream()
-        val stapleResult =
-            execOps.exec {
-                commandLine("xcrun", "stapler", "staple", "-v", appToSign.absolutePath)
-                isIgnoreExitValue = true
-                standardOutput = staplerOutput
-                errorOutput = staplerError
-            }
-
-        if (stapleResult.exitValue != 0) {
-            logger.warn("⚠️ Stapler failed for .app, but continuing (ticket is available online)")
-            logger.lifecycle(staplerOutput.toString())
-            logger.lifecycle(staplerError.toString())
-        } else {
-            logger.lifecycle("✅ Ticket stapled to .app")
-        }
-
-        // Clean up ZIP
+        // Clean up the temporary ZIP — we do NOT staple the .app here.
+        // The .app will be packaged inside a DMG which is stapled in customNotarizeDmg.
+        // Stapling the .app directly is unreliable: xcrun stapler computes the ticket
+        // lookup hash differently from how notarytool records it for a ZIP submission,
+        // causing "Could not validate ticket" errors even when notarization was Accepted.
+        // Gatekeeper falls back to Apple's CDN for online verification when there is no
+        // embedded staple ticket, so the .app inside the stapled DMG is fully accepted.
         appZip.delete()
-
-        logger.lifecycle("✅ .app notarization complete!")
+        logger.lifecycle("✅ .app notarization complete! (ticket on Apple CDN — DMG will be stapled)")
     }
 }
 
@@ -1204,9 +1600,9 @@ tasks.register("createSignedDmg") {
 
     @Suppress("DEPRECATION")
     doLast {
-        val macosIdentity =
-            getEnvOrProperty("MACOS_IDENTITY")
-                ?: throw GradleException("MACOS_IDENTITY environment variable is required")
+        // Identity was already resolved by signMacApp earlier in the chain
+        val macosIdentity = resolveIdentity()
+        val keychainPath = resolveKeychainPath()
 
         val notarizedDir = file("${layout.buildDirectory.get()}/compose/notarized")
         val appToSign =
@@ -1223,7 +1619,12 @@ tasks.register("createSignedDmg") {
         logger.lifecycle("📦 Preparing DMG contents...")
         // Use rsync to preserve permissions
         execOps.exec {
-            commandLine("rsync", "-a", "${appToSign.absolutePath}/", "${File(dmgStaging, appToSign.name).absolutePath}/")
+            commandLine(
+                "rsync",
+                "-a",
+                "${appToSign.absolutePath}/",
+                "${File(dmgStaging, appToSign.name).absolutePath}/",
+            )
         }
 
         // Create Applications symlink
@@ -1232,9 +1633,14 @@ tasks.register("createSignedDmg") {
             commandLine("ln", "-s", "/Applications", "Applications")
         }
 
-        // Create temporary read-write DMG
+        // ── Step 1: Create temporary read-write DMG ───────────────────────────
+        // Use -nobrowse so Finder never auto-opens the volume (which would hold
+        // it open and make hdiutil detach fail with "Resource busy").
         val tempDmg = File(notarizedDir, "Askimo-temp.dmg").apply { delete() }
-        logger.lifecycle("📀 Creating temporary DMG...")
+        logger.lifecycle("── createSignedDmg ─────────────────────────────────────────────────")
+        logger.lifecycle("📀 [1/6] Creating temporary read-write DMG from staging dir...")
+        logger.lifecycle("   srcfolder : ${dmgStaging.absolutePath}")
+        logger.lifecycle("   output    : ${tempDmg.absolutePath}")
         execOps.exec {
             commandLine(
                 "hdiutil",
@@ -1249,131 +1655,166 @@ tasks.register("createSignedDmg") {
                 tempDmg.absolutePath,
             )
         }
+        if (!tempDmg.exists()) throw GradleException("❌ Temp DMG was not created: ${tempDmg.absolutePath}")
+        logger.lifecycle("   ✅ Temp DMG created (${tempDmg.length() / 1024 / 1024} MB)")
 
-        // Mount the DMG
-        logger.lifecycle("💿 Mounting DMG for customization...")
+        // ── Step 2: Mount with -nobrowse (no Finder auto-open) ───────────────
+        logger.lifecycle("💿 [2/6] Mounting DMG (nobrowse, noverify)...")
         val mountOutput = ByteArrayOutputStream()
         execOps.exec {
-            commandLine("hdiutil", "attach", "-readwrite", "-noverify", tempDmg.absolutePath)
+            commandLine(
+                "hdiutil",
+                "attach",
+                "-readwrite",
+                "-noverify",
+                "-nobrowse", // <-- prevents Finder from holding the volume open
+                tempDmg.absolutePath,
+            )
             standardOutput = mountOutput
         }
 
+        val mountOutputStr = mountOutput.toString()
+        logger.lifecycle("   hdiutil attach output:\n$mountOutputStr")
+
+        // hdiutil attach output (UDRW image) looks like:
+        //   /dev/disk7              Apple_partition_scheme
+        //   /dev/disk7s1            Apple_partition_map
+        //   /dev/disk7s2  GUID_…    /Volumes/Askimo
+        // OR for APFS/HFS images:
+        //   /dev/disk7              Apple_HFS   /Volumes/Askimo
+        //
+        // We need BOTH:
+        //   mountPath  = the /Volumes/... path  (for filesystem ops)
+        //   deviceNode = the parent /dev/diskN  (for hdiutil detach — unmounts the whole image)
+        //
+        // The parent device is the first /dev/disk line (no slice suffix like s1, s2).
+
         val mountPath =
-            mountOutput
-                .toString()
+            mountOutputStr
                 .lines()
                 .firstOrNull { it.contains("/Volumes/") }
-                ?.substringAfter("/Volumes/")
+                ?.split("\t")
+                ?.lastOrNull { it.trim().startsWith("/Volumes/") }
                 ?.trim()
-                ?.let { "/Volumes/$it" }
-                ?: throw GradleException("Could not determine mount path")
+                ?: mountOutputStr
+                    .lines()
+                    .firstOrNull { it.contains("/Volumes/") }
+                    ?.let { line ->
+                        val idx = line.indexOf("/Volumes/")
+                        line
+                            .substring(idx)
+                            .trim()
+                            .substringBefore("\t")
+                            .trim()
+                    }
+                ?: throw GradleException("❌ Could not determine mount path from hdiutil output:\n$mountOutputStr")
 
-        logger.lifecycle("✅ Mounted at: $mountPath")
+        // Parent device: first line whose first tab-field matches /dev/diskN (no slice suffix)
+        val deviceNode =
+            mountOutputStr
+                .lines()
+                .mapNotNull { line ->
+                    val dev = line.split("\t").firstOrNull()?.trim() ?: return@mapNotNull null
+                    if (dev.matches(Regex("""/dev/disk\d+$"""))) dev else null
+                }.firstOrNull()
+                ?: run {
+                    // Fallback: derive from the slice device found on the /Volumes/ line
+                    val sliceDev =
+                        mountOutputStr
+                            .lines()
+                            .firstOrNull { it.contains("/Volumes/") }
+                            ?.split("\t")
+                            ?.firstOrNull()
+                            ?.trim()
+                    sliceDev?.replace(Regex("""s\d+$"""), "")
+                }
 
+        logger.lifecycle("   ✅ Mounted at  : $mountPath")
+        logger.lifecycle("   📀 Device node : ${deviceNode ?: "(could not determine — will use mount path for detach)"}")
+
+        // ── Step 3: Copy background (no Finder involved) ─────────────────────
         try {
-            // Copy background image to .background folder in DMG
+            logger.lifecycle("🖼️  [3/6] Copying background image (headless, no Finder)...")
             val backgroundDir = File(mountPath, ".background")
             backgroundDir.mkdirs()
             val backgroundImage = project.file("src/main/resources/images/dmg-background.png")
 
             if (backgroundImage.exists()) {
-                logger.lifecycle("🖼️ Copying background image...")
                 backgroundImage.copyTo(File(backgroundDir, "background.png"), overwrite = true)
+                logger.lifecycle("   ✅ Background image copied")
+            } else {
+                logger.lifecycle("   ⚠️  No background image found at ${backgroundImage.absolutePath} — skipping")
             }
 
-            // Wait for Finder to recognize the mounted volume
-            logger.lifecycle("⏳ Waiting for Finder to recognize volume...")
-            Thread.sleep(2000)
-
-            // Set background image and window settings
-            val backgroundScript =
-                """
-                tell application "Finder"
-                    tell disk "Askimo"
-                        open
-                        set current view of container window to icon view
-                        set toolbar visible of container window to false
-                        set statusbar visible of container window to false
-                        set the bounds of container window to {400, 100, 920, 480}
-                        set viewOptions to the icon view options of container window
-                        set arrangement of viewOptions to not arranged
-                        set icon size of viewOptions to 100
-                        set background picture of viewOptions to file ".background:background.png"
-                        set text size of viewOptions to 13
-                        set position of item "${appToSign.name}" of container window to {130, 190}
-                        set position of item "Applications" of container window to {390, 190}
-                        update without registering applications
-                        delay 1
-                        close
-                    end tell
-                end tell
-                """.trimIndent()
-
-            logger.lifecycle("🎨 Applying window settings...")
-            execOps.exec {
-                commandLine("osascript", "-e", backgroundScript)
-                isIgnoreExitValue = true
-            }
-
-            // Give Finder time to save the settings
-            logger.lifecycle("⏳ Waiting for Finder to save settings...")
-            Thread.sleep(3000)
-
-            // Sync to ensure all changes are written
-            logger.lifecycle("💾 Syncing filesystem...")
+            // Sync filesystem writes before unmount
+            logger.lifecycle("💾 [3/6] Syncing filesystem writes...")
             execOps.exec {
                 commandLine("sync")
                 isIgnoreExitValue = true
             }
             Thread.sleep(500)
-
-            // Force Finder to close all windows for the volume
-            logger.lifecycle("🔒 Closing Finder windows...")
-            execOps.exec {
-                commandLine("osascript", "-e", "tell application \"Finder\" to close every window")
-                isIgnoreExitValue = true
-            }
-            Thread.sleep(1000)
         } finally {
-            // Unmount with retries
-            logger.lifecycle("💿 Unmounting DMG...")
-            var unmounted = false
-            var attempts = 0
-            val maxAttempts = 5
+            // ── Step 4: Detach the disk image ────────────────────────────────────
+            // IMPORTANT: "diskutil unmount" only unmounts the filesystem (volume).
+            // The disk image device (/dev/diskN) stays attached until "hdiutil detach"
+            // is called. hdiutil convert fails with EAGAIN if the device is still open.
+            // Strategy:
+            //   1. diskutil unmount <mountPath>   — flush & unmount filesystem
+            //   2. hdiutil detach  <deviceNode>   — release the block device (REQUIRED)
+            //   If device node is unknown, fall back to detaching by mount path.
+            logger.lifecycle("💿 [4/6] Detaching disk image...")
 
-            while (!unmounted && attempts < maxAttempts) {
-                attempts++
-                try {
-                    if (attempts > 1) {
-                        logger.lifecycle("   Retry attempt $attempts/$maxAttempts...")
-                        Thread.sleep(2000)
-                    }
+            // Step 4a: unmount the filesystem first (flush buffers)
+            val unmountOut = ByteArrayOutputStream()
+            val unmountExit =
+                execOps
+                    .exec {
+                        commandLine("diskutil", "unmount", mountPath)
+                        standardOutput = unmountOut
+                        errorOutput = unmountOut
+                        isIgnoreExitValue = true
+                    }.exitValue
+            logger.lifecycle("   diskutil unmount '$mountPath'  exit=$unmountExit  $unmountOut")
 
-                    execOps.exec {
-                        commandLine("hdiutil", "detach", mountPath, "-force")
-                        isIgnoreExitValue = false
-                    }
-                    unmounted = true
-                    logger.lifecycle("✅ DMG unmounted successfully")
-                } catch (_: Exception) {
-                    if (attempts < maxAttempts) {
-                        logger.lifecycle("⚠️  Unmount failed, will retry...")
-                        // Kill any processes that might be using the volume
-                        execOps.exec {
-                            commandLine("lsof", "+D", mountPath)
-                            isIgnoreExitValue = true
-                            standardOutput = System.out
-                        }
-                    } else {
-                        logger.warn("⚠️  Could not unmount DMG after $maxAttempts attempts, continuing anyway...")
-                    }
+            // Step 4b: detach the whole disk image by device node (critical!)
+            // This is what actually frees the image file so hdiutil convert can open it.
+            val detachTarget = deviceNode ?: mountPath
+            logger.lifecycle("   hdiutil detach '$detachTarget' -force ...")
+            val detachOut = ByteArrayOutputStream()
+            val detachExit =
+                execOps
+                    .exec {
+                        commandLine("hdiutil", "detach", detachTarget, "-force")
+                        standardOutput = detachOut
+                        errorOutput = detachOut
+                        isIgnoreExitValue = true
+                    }.exitValue
+            logger.lifecycle("   hdiutil detach exit=$detachExit  $detachOut")
+
+            if (detachExit != 0) {
+                // List who still has the file open to aid diagnosis
+                val lsofOut = ByteArrayOutputStream()
+                execOps.exec {
+                    commandLine("lsof", tempDmg.absolutePath)
+                    standardOutput = lsofOut
+                    errorOutput = lsofOut
+                    isIgnoreExitValue = true
                 }
+                throw GradleException(
+                    "❌ hdiutil detach FAILED (exit $detachExit) — disk image is still attached.\n" +
+                        "detach output:\n$detachOut\n" +
+                        "open handles on temp DMG:\n$lsofOut\n" +
+                        "hdiutil convert will fail until the image is fully detached.",
+                )
             }
+            logger.lifecycle("   ✅ Disk image fully detached")
         }
 
-        // Convert to compressed, read-only DMG
+        // ── Step 5: Convert to compressed, read-only DMG ─────────────────────
         val signedDmg = File(notarizedDir, "Askimo-signed.dmg").apply { delete() }
-        logger.lifecycle("📀 Creating final compressed DMG...")
+        logger.lifecycle("📀 [5/6] Converting temp DMG → compressed read-only DMG...")
+        logger.lifecycle("   input  : ${tempDmg.absolutePath} (${tempDmg.length() / 1024 / 1024} MB)")
+        logger.lifecycle("   output : ${signedDmg.absolutePath}")
         execOps.exec {
             commandLine(
                 "hdiutil",
@@ -1385,31 +1826,75 @@ tasks.register("createSignedDmg") {
                 signedDmg.absolutePath,
             )
         }
+        if (!signedDmg.exists()) throw GradleException("❌ Compressed DMG was not created: ${signedDmg.absolutePath}")
+        logger.lifecycle("   ✅ Compressed DMG created (${signedDmg.length() / 1024 / 1024} MB)")
 
-        // Clean up
+        // Clean up temp artifacts
         tempDmg.delete()
         dmgStaging.deleteRecursively()
 
-        // Sign DMG
-        logger.lifecycle("🔧 Signing DMG...")
+        // ── Step 6: Sign the compressed DMG ──────────────────────────────────
+        logger.lifecycle("🔧 [6/6] Code-signing the compressed DMG...")
+        logger.lifecycle("   identity  : $macosIdentity")
+        logger.lifecycle("   keychain  : ${keychainPath ?: "(default)"}")
         execOps.exec {
-            commandLine(
-                "codesign",
-                "--force",
-                "--sign",
-                macosIdentity,
-                "--timestamp",
-                signedDmg.absolutePath,
-            )
+            val cmd =
+                buildList {
+                    add("codesign")
+                    if (keychainPath != null) {
+                        add("--keychain")
+                        add(keychainPath)
+                    }
+                    add("--force")
+                    add("--sign")
+                    add(macosIdentity)
+                    add("--timestamp")
+                    add(signedDmg.absolutePath)
+                }
+            commandLine(cmd)
         }
 
-        // Verify DMG signature
-        logger.lifecycle("🔎 Verifying DMG signature...")
-        execOps.exec {
-            commandLine("codesign", "--verify", "--verbose=2", signedDmg.absolutePath)
+        // Hard-fail verification of DMG signature
+        logger.lifecycle("🔎 [6/6] Verifying DMG code signature...")
+        val verifyOut = ByteArrayOutputStream()
+        val verifyResult =
+            execOps.exec {
+                commandLine("codesign", "--verify", "--verbose=2", signedDmg.absolutePath)
+                standardOutput = verifyOut
+                errorOutput = verifyOut
+                isIgnoreExitValue = true
+            }
+        logger.lifecycle(verifyOut.toString())
+        if (verifyResult.exitValue != 0) {
+            throw GradleException("❌ codesign verify failed (exit ${verifyResult.exitValue}) — DMG signature is invalid")
         }
 
+        // Display signature details
+        val displayOut = ByteArrayOutputStream()
+        execOps.exec {
+            commandLine("codesign", "--display", "--verbose=4", signedDmg.absolutePath)
+            standardOutput = displayOut
+            errorOutput = displayOut
+            isIgnoreExitValue = true
+        }
+        logger.lifecycle(
+            displayOut
+                .toString()
+                .lines()
+                .filter { line ->
+                    line.contains("CDHash") || line.contains("TeamIdentifier") ||
+                        line.contains("Identifier") || line.contains("Authority") ||
+                        line.contains("Signed Time")
+                }.joinToString("\n"),
+        )
+
+        logger.lifecycle("── createSignedDmg complete ────────────────────────────────────────")
         logger.lifecycle("✅ DMG created and signed: ${signedDmg.absolutePath}")
+        logger.lifecycle("   SHA-256:")
+        execOps.exec {
+            commandLine("shasum", "-a", "256", signedDmg.absolutePath)
+            isIgnoreExitValue = true
+        }
     }
 }
 
@@ -1427,9 +1912,44 @@ tasks.register("customNotarizeDmg") {
         val notarizedDir = file("${layout.buildDirectory.get()}/compose/notarized")
         val signedDmg = File(notarizedDir, "Askimo-signed.dmg")
 
+        logger.lifecycle("── customNotarizeDmg ───────────────────────────────────────────────")
+
         if (!signedDmg.exists()) {
-            throw GradleException("Signed DMG not found: ${signedDmg.absolutePath}")
+            throw GradleException(
+                "❌ Signed DMG not found: ${signedDmg.absolutePath}\n" +
+                    "Contents of $notarizedDir:\n" +
+                    (notarizedDir.listFiles()?.joinToString("\n") { "  ${it.name}" } ?: "  (empty)"),
+            )
         }
+        logger.lifecycle("📦 DMG: ${signedDmg.absolutePath} (${signedDmg.length() / 1024 / 1024} MB)")
+
+        // ── Pre-submission check: DMG must be signed ──────────────────────
+        logger.lifecycle("🔍 [pre] Verifying DMG is signed before submission...")
+        val preVerifyOut = ByteArrayOutputStream()
+        val preVerifyResult =
+            execOps.exec {
+                commandLine("codesign", "--verify", "--verbose=2", signedDmg.absolutePath)
+                standardOutput = preVerifyOut
+                errorOutput = preVerifyOut
+                isIgnoreExitValue = true
+            }
+        logger.lifecycle(preVerifyOut.toString())
+        if (preVerifyResult.exitValue != 0) {
+            throw GradleException("❌ DMG is not properly signed before notarization — aborting (exit ${preVerifyResult.exitValue})")
+        }
+        logger.lifecycle("   ✅ DMG signature OK before submission")
+
+        // ── SHA-256 before submission ─────────────────────────────────────
+        val sha256Before =
+            ByteArrayOutputStream().use { out ->
+                execOps.exec {
+                    commandLine("shasum", "-a", "256", signedDmg.absolutePath)
+                    standardOutput = out
+                    isIgnoreExitValue = true
+                }
+                out.toString().trim()
+            }
+        logger.lifecycle("   SHA-256 before submission: $sha256Before")
 
         // Notarization credentials - App-Specific Password
         val appleId =
@@ -1452,18 +1972,7 @@ tasks.register("customNotarizeDmg") {
                 applePassword,
             )
 
-        // Calculate SHA256 before submission
-        val sha256Before =
-            ByteArrayOutputStream().use { output ->
-                execOps.exec {
-                    commandLine("shasum", "-a", "256", signedDmg.absolutePath)
-                    standardOutput = output
-                }
-                output.toString().split(" ")[0]
-            }
-
-        logger.lifecycle("🔎 DMG SHA256 before submit: $sha256Before")
-        logger.lifecycle("🔐 Notarizing DMG...")
+        logger.lifecycle("🔐 [1/3] Submitting DMG to Apple notarytool (--wait)...")
 
         // Submit for notarization
         val notarizationOutput =
@@ -1493,7 +2002,7 @@ tasks.register("customNotarizeDmg") {
         val status = statusMatch?.groupValues?.get(1) ?: "Unknown"
         val submissionId = idMatch?.groupValues?.get(1) ?: ""
 
-        logger.lifecycle("DMG submission: id=$submissionId, status=$status")
+        logger.lifecycle("📋 Status: $status  (id: $submissionId)")
 
         if (status != "Accepted") {
             // Fetch the detailed log from Apple so we can see exactly which file was rejected
@@ -1518,90 +2027,49 @@ tasks.register("customNotarizeDmg") {
             }
             throw GradleException("❌ Notarization failed (status=$status)")
         }
+        logger.lifecycle("   ✅ Apple accepted the notarization submission")
 
-        // Verify bytes didn't change
+        // ── Staple the ticket ─────────────────────────────────────────────
+        logger.lifecycle("📎 [2/3] Stapling notarization ticket to DMG...")
+        stapleWithRetry(signedDmg)
+
+        // ── Post-staple validation: hard fail if ticket is missing ────────
+        logger.lifecycle("🔍 [3/3] Post-staple validation...")
+        val validateOut = ByteArrayOutputStream()
+        val validateResult =
+            execOps.exec {
+                commandLine("xcrun", "stapler", "validate", signedDmg.absolutePath)
+                standardOutput = validateOut
+                errorOutput = validateOut
+                isIgnoreExitValue = true
+            }
+        logger.lifecycle(validateOut.toString())
+        if (validateResult.exitValue != 0) {
+            throw GradleException(
+                "❌ xcrun stapler validate FAILED after stapling (exit ${validateResult.exitValue})\n" +
+                    "The staple ticket was NOT embedded — this DMG will trigger Gatekeeper warnings.\n" +
+                    validateOut.toString(),
+            )
+        }
+        logger.lifecycle("   ✅ Staple ticket embedded and validated")
+
+        // Final SHA-256 (should match before since stapler only adds a resource)
         val sha256After =
-            ByteArrayOutputStream().use { output ->
+            ByteArrayOutputStream().use { out ->
                 execOps.exec {
                     commandLine("shasum", "-a", "256", signedDmg.absolutePath)
-                    standardOutput = output
+                    standardOutput = out
+                    isIgnoreExitValue = true
                 }
-                output.toString().split(" ")[0]
+                out.toString().trim()
             }
+        logger.lifecycle("   SHA-256 after staple : $sha256After")
 
-        if (sha256Before != sha256After) {
-            throw GradleException("❌ DMG bytes changed after notarization submission")
-        }
-
-        // Wait for ticket propagation
-        logger.lifecycle("⏳ Waiting 60s for ticket propagation...")
-        Thread.sleep(60000)
-
-        // Try to staple
-        logger.lifecycle("📎 Stapling DMG...")
-        val staplerOutput = ByteArrayOutputStream()
-        val staplerError = ByteArrayOutputStream()
-        val stapleResult =
-            execOps.exec {
-                commandLine("xcrun", "stapler", "staple", "-v", signedDmg.absolutePath)
-                isIgnoreExitValue = true
-                standardOutput = staplerOutput
-                errorOutput = staplerError
-            }
-
-        if (stapleResult.exitValue != 0) {
-            logger.warn("⚠️ Stapler failed, attempting manual ticket attachment...")
-
-            // Extract ticket path from stapler output
-            val combinedOutput = staplerOutput.toString() + staplerError.toString()
-            val ticketPathMatch = Regex("""file://([^\s]+\.ticket)""").find(combinedOutput)
-            val ticketPath = ticketPathMatch?.groupValues?.get(1)
-
-            if (ticketPath != null && File(ticketPath).exists()) {
-                logger.lifecycle("📋 Found downloaded ticket: $ticketPath")
-                logger.lifecycle("📎 Manually attaching ticket to DMG...")
-
-                // Use Python to attach binary ticket data
-                val pythonScript =
-                    """
-                    import subprocess
-                    ticket_path = '$ticketPath'
-                    dmg_path = '${signedDmg.absolutePath}'
-                    with open(ticket_path, 'rb') as f:
-                        ticket_data = f.read()
-                    subprocess.run(['xattr', '-wx', 'com.apple.stapler', ticket_data.hex(), dmg_path], check=True)
-                    print('✅ Ticket attached successfully')
-                    """.trimIndent()
-
-                execOps.exec {
-                    commandLine("python3", "-c", pythonScript)
-                }
-
-                // Verify ticket is attached
-                val xattrOutput = ByteArrayOutputStream()
-                execOps.exec {
-                    commandLine("xattr", "-l", signedDmg.absolutePath)
-                    standardOutput = xattrOutput
-                }
-
-                val hasTicket = xattrOutput.toString().contains("com.apple.stapler")
-
-                if (hasTicket) {
-                    logger.lifecycle("✅ Ticket is attached via xattr")
-                } else {
-                    throw GradleException("❌ Failed to attach notarization ticket")
-                }
-            } else {
-                throw GradleException("❌ Could not find downloaded ticket file")
-            }
-        } else {
-            logger.lifecycle("✅ Stapled DMG successfully")
-        }
-
+        logger.lifecycle("── customNotarizeDmg complete ──────────────────────────────────────")
         logger.lifecycle("✅ Done. Output: ${signedDmg.absolutePath}")
         logger.lifecycle("")
-        logger.lifecycle("Suggested checks:")
-        logger.lifecycle("  spctl -a -t open -vv \"${signedDmg.absolutePath}\"")
+        logger.lifecycle("Verify with:")
+        logger.lifecycle("  spctl -a -t open --context context:primary-signature -v \"${signedDmg.absolutePath}\"")
     }
 }
 


### PR DESCRIPTION
- Update GitHub Actions to latest versions (checkout v6, java v5, gradle v5, upload‑artifact v6)
- Refine desktop release workflow: change upload step name, adjust prerelease/draft logic, and clean up tags
- Remove unused background image path helper and related comments
- Add missing import for RectangleShape and apply it to ProjectSidePanel shape
- Change macOS bundle ID to `io.askimo.askimo-personal`
- Simplify native‑image reflective config entries
- Update notarization log wording for clearer output