### PR TITLE
feat(ui): improve tooltips and preserve directive selection

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.core.providers.openai
 
-import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import dev.langchain4j.data.message.UserMessage
 import io.askimo.core.config.AppConfig
@@ -22,7 +21,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
-import java.net.InetSocketAddress
 import kotlin.inc
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -324,27 +322,5 @@ class OpenAiModelFactoryProxyTest {
 
         println("✓ Fetched ${models.size} OpenAI models through proxy")
         println("Sample models: ${models.take(3)}")
-    }
-
-    /**
-     * Helper to start a simple HTTP proxy server for testing
-     * (Currently not used, but available for future local proxy testing)
-     */
-    @Suppress("unused")
-    private fun startMockProxyServer(port: Int, handler: (HttpExchange) -> Unit): HttpServer {
-        val server = HttpServer.create(InetSocketAddress("localhost", port), 0)
-        server.createContext("/") { exchange ->
-            try {
-                proxyRequestCount++
-                handler(exchange)
-            } catch (e: Exception) {
-                println("Mock proxy server error: ${e.message}")
-            } finally {
-                exchange.close()
-            }
-        }
-        server.executor = null
-        server.start()
-        return server
     }
 }

--- a/cli/src/test/kotlin/io/askimo/tools/fs/LocalFsToolsTest.kt
+++ b/cli/src/test/kotlin/io/askimo/tools/fs/LocalFsToolsTest.kt
@@ -132,22 +132,19 @@ class LocalFsToolsTest {
         // Create files
         val imgDir = tmp.resolve("imgs").apply { createDirectories() }
         val nested = imgDir.resolve("nested").apply { createDirectories() }
-        val f1 =
-            imgDir.resolve("a.PNG").apply {
-                createFile()
-                writeBytes(ByteArray(10))
-            }
-        val f2 =
-            imgDir.resolve("b.png").apply {
-                createFile()
-                writeBytes(ByteArray(20))
-            }
-        val f3 =
-            nested.resolve("c.jpg").apply {
-                createFile()
-                writeBytes(ByteArray(30))
-            }
-        val doc = tmp.resolve("readme.md").apply { writeText("# readme") }
+        imgDir.resolve("a.PNG").apply {
+            createFile()
+            writeBytes(ByteArray(10))
+        }
+        imgDir.resolve("b.png").apply {
+            createFile()
+            writeBytes(ByteArray(20))
+        }
+        nested.resolve("c.jpg").apply {
+            createFile()
+            writeBytes(ByteArray(30))
+        }
+        tmp.resolve("readme.md").apply { writeText("# readme") }
 
         val r1 = parseToolResponse(LocalFsTools.filesByType(imgDir.toString(), extensions = " PNG, jpg ", recursive = false, limit = 10))
         assertEquals(imgDir.toString(), r1["directory"])
@@ -187,7 +184,7 @@ class LocalFsToolsTest {
         val d = tmp.resolve("data").apply { createDirectories() }
         val p1 = d.resolve("one.PDF").apply { writeBytes(ByteArray(5)) }
         val p2 = d.resolve("two.pdf").apply { writeBytes(ByteArray(7)) }
-        val i1 = d.resolve("pic.png").apply { writeBytes(ByteArray(11)) }
+        d.resolve("pic.png").apply { writeBytes(ByteArray(11)) }
 
         val res = parseToolResponse(LocalFsTools.totalSizeByType(d.toString(), extensions = "['PDF', ' pdf ' ]", category = "image", recursive = false))
         assertEquals(d.toString(), res["directory"])
@@ -257,11 +254,11 @@ class LocalFsToolsTest {
         val srcDir = tmp.resolve("src").apply { createDirectories() }
         val testDir = tmp.resolve("test").apply { createDirectories() }
 
-        val userService = srcDir.resolve("UserService.kt").apply { createFile() }
-        val userHelper = srcDir.resolve("user_helper.py").apply { createFile() }
-        val userConfig = testDir.resolve("user-config.json").apply { createFile() }
-        val readme = tmp.resolve("README.md").apply { createFile() }
-        val hiddenFile = tmp.resolve(".hidden.txt").apply { createFile() }
+        srcDir.resolve("UserService.kt").apply { createFile() }
+        srcDir.resolve("user_helper.py").apply { createFile() }
+        testDir.resolve("user-config.json").apply { createFile() }
+        tmp.resolve("README.md").apply { createFile() }
+        tmp.resolve(".hidden.txt").apply { createFile() }
 
         // Test exact filename search
         val result1 = parseToolResponse(LocalFsTools.searchFilesByGlob(tmp.toString(), "UserService"))
@@ -446,16 +443,16 @@ class LocalFsToolsTest {
         val srcDir = tmp.resolve("src").apply { createDirectories() }
         val docsDir = tmp.resolve("docs").apply { createDirectories() }
 
-        val javaFile = srcDir.resolve("Example.java").apply {
+        srcDir.resolve("Example.java").apply {
             writeText("public class Example {\n    // TODO: implement this\n    private String name;\n}")
         }
-        val kotlinFile = srcDir.resolve("Service.kt").apply {
+        srcDir.resolve("Service.kt").apply {
             writeText("class Service {\n    fun getName(): String {\n        return \"service\"\n    }\n}")
         }
-        val readmeFile = docsDir.resolve("README.md").apply {
+        docsDir.resolve("README.md").apply {
             writeText("# Documentation\nThis is a TODO list\nfor the project.")
         }
-        val binaryFile = tmp.resolve("binary.dat").apply {
+        tmp.resolve("binary.dat").apply {
             writeBytes(byteArrayOf(0, 1, 2, 3, 255.toByte()))
         }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -6,7 +6,6 @@ package io.askimo.ui.chat
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollbarStyle
-import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
@@ -14,14 +13,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
@@ -48,7 +44,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -413,78 +408,17 @@ fun chatView(
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
                                     // Clickable project name as breadcrumb
-                                    TooltipArea(
-                                        tooltip = {
-                                            Surface(
-                                                color = MaterialTheme.colorScheme.surfaceVariant,
-                                                shape = RoundedCornerShape(4.dp),
-                                                modifier = Modifier.width(350.dp),
-                                            ) {
-                                                Column(
-                                                    modifier = Modifier.padding(12.dp),
-                                                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                                                ) {
-                                                    Text(
-                                                        text = project.name,
-                                                        style = MaterialTheme.typography.titleSmall,
-                                                        fontWeight = FontWeight.Bold,
-                                                    )
-
-                                                    project.description?.let { description ->
-                                                        if (description.isNotBlank()) {
-                                                            Text(
-                                                                text = description,
-                                                                style = MaterialTheme.typography.bodySmall,
-                                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                            )
-                                                        }
-                                                    }
-
-                                                    if (project.knowledgeSources.isNotEmpty()) {
-                                                        Spacer(modifier = Modifier.height(4.dp))
-                                                        Text(
-                                                            text = stringResource("projects.sources.title"),
-                                                            style = MaterialTheme.typography.labelSmall,
-                                                            fontWeight = FontWeight.Bold,
-                                                        )
-                                                        Column(
-                                                            modifier = Modifier.padding(start = 8.dp),
-                                                            verticalArrangement = Arrangement.spacedBy(2.dp),
-                                                        ) {
-                                                            project.knowledgeSources.forEach { source ->
-                                                                Row(
-                                                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                                                    verticalAlignment = Alignment.CenterVertically,
-                                                                ) {
-                                                                    Text(
-                                                                        text = "•",
-                                                                        style = MaterialTheme.typography.bodySmall,
-                                                                    )
-                                                                    Text(
-                                                                        text = source.resourceIdentifier,
-                                                                        style = MaterialTheme.typography.bodySmall,
-                                                                        maxLines = 1,
-                                                                        overflow = TextOverflow.Ellipsis,
-                                                                    )
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-
-                                                    // Timestamps
-                                                    Spacer(modifier = Modifier.height(4.dp))
-                                                    Text(
-                                                        text = "Created: ${formatDisplay(project.createdAt)}",
-                                                        style = MaterialTheme.typography.labelSmall,
-                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                    )
-                                                    Text(
-                                                        text = "Updated: ${formatDisplay(project.updatedAt)}",
-                                                        style = MaterialTheme.typography.labelSmall,
-                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                    )
-                                                }
+                                    themedTooltip(
+                                        text = buildString {
+                                            append(project.name)
+                                            project.description?.takeIf { it.isNotBlank() }?.let {
+                                                append("\n").append(it)
                                             }
+                                            if (project.knowledgeSources.isNotEmpty()) {
+                                                append("\n").append(project.knowledgeSources.joinToString("\n") { "• ${it.resourceIdentifier}" })
+                                            }
+                                            append("\nCreated: ${formatDisplay(project.createdAt)}")
+                                            append("\nUpdated: ${formatDisplay(project.updatedAt)}")
                                         },
                                     ) {
                                         TextButton(
@@ -535,20 +469,7 @@ fun chatView(
                                 }
 
                                 if (statusText != null) {
-                                    TooltipArea(
-                                        tooltip = {
-                                            Surface(
-                                                color = MaterialTheme.colorScheme.surfaceVariant,
-                                                shape = RoundedCornerShape(4.dp),
-                                            ) {
-                                                Text(
-                                                    text = statusText,
-                                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                )
-                                            }
-                                        },
-                                    ) {
+                                    themedTooltip(text = statusText) {
                                         Row(
                                             horizontalArrangement = Arrangement.spacedBy(4.dp),
                                             verticalAlignment = Alignment.CenterVertically,
@@ -610,31 +531,11 @@ fun chatView(
                             }
 
                             Box {
-                                TooltipArea(
-                                    tooltip = {
-                                        if (selectedDirectiveObj != null) {
-                                            Surface(
-                                                modifier = Modifier.width(400.dp),
-                                                shadowElevation = 4.dp,
-                                                shape = MaterialTheme.shapes.small,
-                                            ) {
-                                                Column(
-                                                    modifier = Modifier.padding(12.dp),
-                                                ) {
-                                                    Text(
-                                                        text = selectedDirectiveObj.name,
-                                                        style = MaterialTheme.typography.labelMedium,
-                                                        color = MaterialTheme.colorScheme.onSurface,
-                                                        fontWeight = FontWeight.Bold,
-                                                    )
-                                                    Text(
-                                                        text = selectedDirectiveObj.content,
-                                                        style = MaterialTheme.typography.bodySmall,
-                                                        modifier = Modifier.padding(top = 8.dp),
-                                                    )
-                                                }
-                                            }
-                                        }
+                                themedTooltip(
+                                    text = if (selectedDirectiveObj != null) {
+                                        "${selectedDirectiveObj.name}\n${selectedDirectiveObj.content}"
+                                    } else {
+                                        ""
                                     },
                                 ) {
                                     TextButton(
@@ -694,30 +595,8 @@ fun chatView(
                                         HorizontalDivider()
 
                                         availableDirectives.forEach { directive ->
-                                            TooltipArea(
-                                                tooltip = {
-                                                    Surface(
-                                                        modifier = Modifier.width(400.dp),
-                                                        shadowElevation = 4.dp,
-                                                        shape = MaterialTheme.shapes.small,
-                                                    ) {
-                                                        Column(
-                                                            modifier = Modifier.padding(12.dp),
-                                                        ) {
-                                                            Text(
-                                                                text = directive.name,
-                                                                style = MaterialTheme.typography.labelMedium,
-                                                                color = MaterialTheme.colorScheme.onSurface,
-                                                                fontWeight = FontWeight.Bold,
-                                                            )
-                                                            Text(
-                                                                text = directive.content,
-                                                                style = MaterialTheme.typography.bodySmall,
-                                                                modifier = Modifier.padding(top = 8.dp),
-                                                            )
-                                                        }
-                                                    }
-                                                },
+                                            themedTooltip(
+                                                text = "${directive.name}\n${directive.content}",
                                             ) {
                                                 DropdownMenuItem(
                                                     text = {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -587,6 +587,7 @@ class ChatViewModel(
                     userMessage = userMessage,
                     willSaveUserMessage = true,
                     disabledServerIds = disabledServerIds,
+                    directiveId = selectedDirective,
                 )
 
                 if (threadId == null) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/McpTabContent.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/McpTabContent.kt
@@ -4,8 +4,6 @@
  */
 package io.askimo.ui.chat
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -17,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -29,7 +26,6 @@ import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.ExtensionOff
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -46,7 +42,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -57,6 +52,7 @@ import io.askimo.core.mcp.McpInstance
 import io.askimo.core.mcp.ProjectMcpInstanceService
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.ui.themedTooltip
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
@@ -67,7 +63,6 @@ import org.koin.core.context.GlobalContext as KoinGlobalContext
 /**
  * Shows list of MCP instances and their available tools.
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun mcpTabContent(project: Project?) {
     if (project == null) {
@@ -182,7 +177,6 @@ fun mcpTabContent(project: Project?) {
 /**
  * MCP instance item with expandable tools list
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun mcpInstanceItem(
     instance: McpInstance,
@@ -359,7 +353,6 @@ private fun mcpInstanceItem(
 /**
  * Individual tool item with selection support and detailed tooltip
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun toolItem(
     tool: ToolSpecification,
@@ -367,80 +360,30 @@ private fun toolItem(
     isSelected: Boolean,
     onSelected: () -> Unit,
 ) {
-    TooltipArea(
-        tooltip = {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                shape = RoundedCornerShape(4.dp),
-                modifier = Modifier.widthIn(max = 500.dp),
-            ) {
-                Column(
-                    modifier = Modifier.padding(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    // Tool name
-                    Text(
-                        text = tool.name(),
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-
-                    // Tool description
-                    tool.description()?.let { desc ->
-                        Text(
-                            text = desc,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+    val tooltipText = remember(tool) {
+        buildString {
+            append(tool.name())
+            tool.description()?.let { desc ->
+                append("\n\n")
+                append(desc)
+            }
+            val params = tool.parameters()
+            if (params != null) {
+                val properties = params.properties()
+                if (!properties.isNullOrEmpty()) {
+                    append("\n\nParameters:")
+                    properties.entries.take(5).forEach { (paramName, _) ->
+                        append("\n• $paramName")
                     }
-
-                    // Parameters section
-                    if (tool.parameters() != null) {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = 4.dp),
-                            color = MaterialTheme.colorScheme.outlineVariant,
-                        )
-
-                        Text(
-                            text = stringResource("mcp.tool.parameters"),
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-
-                        // Show parameter structure (simplified)
-                        val params = tool.parameters()
-                        if (params != null) {
-                            val properties = params.properties()
-                            if (properties != null && properties.isNotEmpty()) {
-                                Column(
-                                    modifier = Modifier.padding(start = 8.dp),
-                                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                                ) {
-                                    properties.entries.take(5).forEach { (paramName, _) ->
-                                        Text(
-                                            text = "• $paramName",
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = AppComponents.secondaryTextColor(),
-                                        )
-                                    }
-                                    if (properties.size > 5) {
-                                        Text(
-                                            text = "... and ${properties.size - 5} more",
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = AppComponents.tertiaryTextColor(),
-                                            fontStyle = FontStyle.Italic,
-                                        )
-                                    }
-                                }
-                            }
-                        }
+                    if (properties.size > 5) {
+                        append("\n... and ${properties.size - 5} more")
                     }
                 }
             }
-        },
-    ) {
+        }
+    }
+
+    themedTooltip(text = tooltipText) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -65,7 +65,6 @@ import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.RunCodeEvent
-import io.askimo.core.logging.currentFileLogger
 import io.askimo.core.util.formatFileSize
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
@@ -77,8 +76,6 @@ import io.askimo.ui.common.ui.util.highlightSearchText
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
-
-private val log = currentFileLogger()
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ProjectSidePanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ProjectSidePanel.kt
@@ -6,8 +6,6 @@ package io.askimo.ui.chat
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -42,7 +40,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -71,6 +68,7 @@ import io.askimo.core.event.internal.ProjectRefreshEvent
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.project.addReferenceMaterialDialog
 import io.askimo.ui.project.buildKnowledgeSourceConfigs
 import io.askimo.ui.project.mergeKnowledgeSourceConfigs
@@ -92,7 +90,6 @@ enum class PanelTab(
  * Shows as icon bar when collapsed, full panel when expanded.
  * Supports drag-to-resize when expanded.
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun projectSidePanel(
     project: Project?,
@@ -386,7 +383,6 @@ fun projectSidePanel(
 /**
  * Tab icon with tooltip and selection state
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun tabIcon(
     tab: PanelTab,
@@ -401,19 +397,7 @@ private fun tabIcon(
         PanelTab.MCP -> stringResource("panel.tab.mcp")
     }
 
-    TooltipArea(
-        tooltip = {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceVariant,
-            ) {
-                Text(
-                    text = tooltipText,
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-        },
-    ) {
+    themedTooltip(text = tooltipText) {
         Box(
             contentAlignment = Alignment.Center,
             modifier = Modifier
@@ -580,12 +564,6 @@ private fun ragSourcesEmptyState(
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(stringResource("rag.empty.button.add"))
             }
-
-            Text(
-                text = stringResource("rag.empty.coming.soon"),
-                style = MaterialTheme.typography.labelSmall,
-                color = AppComponents.tertiaryTextColor(),
-            )
         }
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/RagSourcesTree.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/RagSourcesTree.kt
@@ -6,7 +6,6 @@ package io.askimo.ui.chat
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
-import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,7 +17,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.onClick
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -32,7 +30,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -54,6 +51,7 @@ import io.askimo.core.chat.domain.LocalFoldersKnowledgeSourceConfig
 import io.askimo.core.chat.domain.UrlKnowledgeSourceConfig
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.ui.themedTooltip
 import java.awt.Desktop
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
@@ -204,22 +202,7 @@ private fun folderNodeItem(
 
     Column(modifier = modifier) {
         // Folder row
-        TooltipArea(
-            tooltip = {
-                Surface(
-                    color = MaterialTheme.colorScheme.surfaceVariant,
-                    shape = RoundedCornerShape(4.dp),
-                ) {
-                    Text(
-                        text = node.fullPath,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                        style = MaterialTheme.typography.bodySmall,
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            },
-        ) {
+        themedTooltip(text = node.fullPath) {
             Box {
                 Row(
                     modifier = Modifier
@@ -358,22 +341,7 @@ private fun fileNodeItem(
         Color.Transparent
     }
 
-    TooltipArea(
-        tooltip = {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp),
-            ) {
-                Text(
-                    text = node.fullPath,
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        },
-    ) {
+    themedTooltip(text = node.fullPath) {
         Box {
             Row(
                 modifier = modifier
@@ -486,22 +454,7 @@ private fun urlNodeItem(
         Color.Transparent
     }
 
-    TooltipArea(
-        tooltip = {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp),
-            ) {
-                Text(
-                    text = node.fullPath,
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        },
-    ) {
+    themedTooltip(text = node.fullPath) {
         Box {
             Row(
                 modifier = modifier

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/Tooltip.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/Tooltip.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -26,7 +25,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
@@ -35,11 +34,19 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupPositionProvider
 import kotlinx.coroutines.delay
 
+/** Maximum number of characters shown in a tooltip before truncating with "…". */
+const val TOOLTIP_MAX_CHARS = 1200
+
 /**
  * A reusable tooltip component that follows the application theme.
  * Automatically positions itself to avoid overlapping with the component and screen edges.
  *
+ * Long texts are truncated at [maxChars] characters and an ellipsis is appended so the
+ * tooltip never grows beyond a readable size. Use the default [TOOLTIP_MAX_CHARS] for
+ * consistency across the app.
+ *
  * @param text The text to display in the tooltip
+ * @param maxChars Maximum characters to show before truncating (default [TOOLTIP_MAX_CHARS])
  * @param modifier Optional modifier for the TooltipBox
  * @param content The composable content that the tooltip wraps
  */
@@ -47,31 +54,38 @@ import kotlinx.coroutines.delay
 @Composable
 fun themedTooltip(
     text: String,
+    maxChars: Int = TOOLTIP_MAX_CHARS,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
+    if (text.isBlank()) {
+        content()
+        return
+    }
+
+    val displayText = remember(text, maxChars) {
+        if (text.length > maxChars) text.take(maxChars) + "…" else text
+    }
+
     val tooltipState = rememberTooltipState(isPersistent = true)
     var shouldShowTooltip by remember { mutableStateOf(false) }
 
-    // Show/hide tooltip based on hover state with a slight delay before showing
     LaunchedEffect(shouldShowTooltip) {
         if (shouldShowTooltip) {
-            delay(300) // Shorter delay for better UX
+            delay(300)
             tooltipState.show()
         } else {
             tooltipState.dismiss()
         }
     }
 
-    BoxWithConstraints {
-        val density = LocalDensity.current
-        val maxHeightPx = with(density) { maxHeight.toPx() }
+    val windowInfo = LocalWindowInfo.current
+    val containerHeight = windowInfo.containerSize.height.toFloat()
 
+    Box {
         TooltipBox(
-            positionProvider = remember(maxHeightPx) {
-                SmartTooltipPositionProvider(
-                    maxHeightPx = maxHeightPx,
-                )
+            positionProvider = remember(containerHeight) {
+                SmartTooltipPositionProvider(maxHeightPx = containerHeight)
             },
             tooltip = {
                 Surface(
@@ -81,7 +95,7 @@ fun themedTooltip(
                     shadowElevation = 4.dp,
                 ) {
                     Text(
-                        text = text,
+                        text = displayText,
                         modifier = Modifier.padding(8.dp),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -123,33 +137,23 @@ private class SmartTooltipPositionProvider(
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize,
     ): IntOffset {
-        val spacing = 8 // 8dp spacing between component and tooltip
+        val spacing = 8
 
-        // Determine if component is in bottom half of screen
         val isInBottomHalf = anchorBounds.top > maxHeightPx / 2
 
         return when {
-            // Bottom of screen: show tooltip above
-            isInBottomHalf -> {
-                IntOffset(
-                    x = anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2,
-                    y = anchorBounds.top - popupContentSize.height - spacing,
-                )
-            }
-            // Top of screen: show tooltip below
-            !isInBottomHalf -> {
-                IntOffset(
-                    x = anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2,
-                    y = anchorBounds.bottom + spacing,
-                )
-            }
-            // Default: to the right
-            else -> {
-                IntOffset(
-                    x = anchorBounds.right + spacing,
-                    y = anchorBounds.top + (anchorBounds.height - popupContentSize.height) / 2,
-                )
-            }
+            isInBottomHalf -> IntOffset(
+                x = anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2,
+                y = anchorBounds.top - popupContentSize.height - spacing,
+            )
+            !isInBottomHalf -> IntOffset(
+                x = anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2,
+                y = anchorBounds.bottom + spacing,
+            )
+            else -> IntOffset(
+                x = anchorBounds.right + spacing,
+                y = anchorBounds.top + (anchorBounds.height - popupContentSize.height) / 2,
+            )
         }
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
@@ -275,10 +275,9 @@ fun projectView(
                             modifier = Modifier.fillMaxWidth(),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
-                            projectSessions.forEachIndexed { index, session ->
+                            projectSessions.forEach { session ->
                                 sessionCard(
                                     session = session,
-                                    index = index,
                                     onClick = { onResumeSession(session.id) },
                                     onDeleteSession = { sessionId ->
                                         onDeleteSession(sessionId, currentProject.id)
@@ -395,7 +394,6 @@ fun projectView(
 @Composable
 private fun sessionCard(
     session: ChatSession,
-    index: Int,
     onClick: () -> Unit,
     onDeleteSession: (String) -> Unit,
     onRenameSession: (String, String) -> Unit,
@@ -408,19 +406,13 @@ private fun sessionCard(
     var showNewProjectDialog by remember { mutableStateOf(false) }
     var sessionIdToMove by remember { mutableStateOf<String?>(null) }
 
-    val backgroundColor = if (index % 2 == 0) {
-        MaterialTheme.colorScheme.surface
-    } else {
-        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-    }
-
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .clickableCard(cornerRadius = 8.dp, onClick = onClick),
         shape = RoundedCornerShape(8.dp),
         colors = CardDefaults.cardColors(
-            containerColor = backgroundColor,
+            containerColor = MaterialTheme.colorScheme.surface,
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         border = BorderStroke(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/service/AvatarService.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/service/AvatarService.kt
@@ -33,7 +33,6 @@ class AvatarService {
         private val USER_AVATAR_DIR get() = File(AVATARS_DIR, "user")
         private val AI_AVATAR_DIR get() = File(AVATARS_DIR, "ai")
 
-        private const val DEFAULT_USER_AVATAR = "user-avatar.png"
         private const val DEFAULT_AI_AVATAR = "ai-avatar.png"
 
         /** Built-in fallback — decoded once for the entire app lifetime. */

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
@@ -4,8 +4,6 @@
  */
 package io.askimo.ui.session
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,8 +47,8 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.ui.themedTooltip
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun manageDirectivesDialog(
     directives: List<ChatDirective>,
@@ -215,7 +213,7 @@ fun manageDirectivesDialog(
                                             // Action buttons for edit mode
                                             Row(
                                                 modifier = Modifier.fillMaxWidth(),
-                                                horizontalArrangement = Arrangement.End,
+                                                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                                                 verticalAlignment = Alignment.CenterVertically,
                                             ) {
                                                 secondaryButton(
@@ -259,39 +257,10 @@ fun manageDirectivesDialog(
                                             }
                                         }
                                     } else {
-                                        // Display mode with truncated content and tooltip
-                                        val truncatedContent = if (directive.content.length > 150) {
-                                            directive.content.take(150) + "..."
-                                        } else {
-                                            directive.content
-                                        }
-
-                                        TooltipArea(
-                                            tooltip = {
-                                                Surface(
-                                                    modifier = Modifier.width(400.dp),
-                                                    shadowElevation = 4.dp,
-                                                    shape = MaterialTheme.shapes.small,
-                                                ) {
-                                                    Column(
-                                                        modifier = Modifier.padding(12.dp),
-                                                    ) {
-                                                        Text(
-                                                            text = stringResource("directive.tooltip.full.content"),
-                                                            style = MaterialTheme.typography.labelMedium,
-                                                            color = MaterialTheme.colorScheme.onSurface,
-                                                        )
-                                                        Text(
-                                                            text = directive.content,
-                                                            style = MaterialTheme.typography.bodySmall,
-                                                            modifier = Modifier.padding(top = 8.dp),
-                                                        )
-                                                    }
-                                                }
-                                            },
-                                        ) {
+                                        // Display mode: show truncated content, full text in tooltip
+                                        themedTooltip(text = directive.content) {
                                             Text(
-                                                text = truncatedContent,
+                                                text = directive.content,
                                                 style = MaterialTheme.typography.bodyMedium,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                                 maxLines = 3,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
@@ -127,7 +127,7 @@ fun newDirectiveDialog(
                 // Action buttons
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     secondaryButton(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
@@ -165,6 +165,7 @@ class SessionManager(
         userMessage: ChatMessageDTO,
         willSaveUserMessage: Boolean,
         disabledServerIds: Set<String> = emptySet(),
+        directiveId: String? = null,
     ): String? {
         // Create session lazily on first message (only once per session)
         if (!createdSessions.contains(sessionId)) {
@@ -180,6 +181,12 @@ class SessionManager(
                     )
                     createdSessions.add(sessionId)
                     log.debug("Created new session: $sessionId")
+
+                    // Persist the selected directive (if any) to the newly created session
+                    if (directiveId != null) {
+                        chatSessionService.updateSessionDirective(sessionId, directiveId)
+                        log.debug("Applied directive $directiveId to new session $sessionId")
+                    }
                 }
             }
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NativeMenuBar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NativeMenuBar.kt
@@ -72,8 +72,7 @@ object NativeMenuBar {
                     desktop.setAboutHandler { onShowAbout() }
                 }
             }
-        } catch (e: Exception) {
-            e.printStackTrace()
+        } catch (_: Exception) {
         }
     }
 

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -152,7 +152,6 @@ projects.page=Page {0} of {1}
 projects.page.previous=Previous page
 projects.page.next=Next page
 projects.sources.count={0} reference material(s)
-projects.sources.title=Reference Materials
 projects.sources.expand=Show reference materials
 projects.sources.collapse=Hide reference materials
 projects.sources.empty.title=No reference materials yet
@@ -231,9 +230,8 @@ theme.indigo=Indigo
 theme.indigo.description=Deep violet-blue, mystical and creative
 settings.background.image=Background Image
 settings.background.image.description=Choose a background image — pick a preset or use your own image. A translucent overlay keeps text readable. Background images are independent of the selected theme.
-settings.background.image.browse=Browse\u2026
+settings.background.image.browse=Browse
 settings.background.image.custom=Custom Image
-settings.accent.color=Accent Color
 settings.appearance.avatar.ai=AI Assistant Avatar
 settings.appearance.avatar.ai.description=Customize the AI assistant's avatar in chat conversations. User avatar is managed in User Profile.
 settings.appearance.avatar.ai.label=AI Avatar
@@ -566,7 +564,6 @@ directive.edit.content.label=Content
 directive.edit.content.placeholder=Enter directive instructions...
 directive.edit.name.required=Name is required
 directive.edit.content.required=Content is required
-directive.tooltip.full.content=Full Content:
 directive.created=Created: {0}
 directive.new.title=New Directive
 directive.new.guidelines=Directives guide how the AI responds to your messages. Be specific about tone, detail level, format, or any special requirements you need.
@@ -681,7 +678,6 @@ provider.lmstudio.setup.help=💡To use LMStudio, you need to have it running lo
 # System Resources
 system.memory=Memory
 system.cpu=CPU
-system.resources.tooltip=Memory: {0} MB | CPU: {1}%
 system.share.feedback=Share feedback
 system.ai.provider.tooltip=AI Provider: {0}\nClick to configure
 
@@ -761,7 +757,6 @@ error.app.message=An unexpected error occurred: {0}
 
 # Send Message Errors
 error.send_message.title=Failed to Send Message
-error.send_message.message=Failed to send your message to the AI. Please try again.
 
 # Indexing Errors
 error.indexing.model_not_found.title=Embedding Model Not Found
@@ -1108,7 +1103,6 @@ rag.status.not.indexed=Not Indexed
 rag.empty.title=No Knowledge Sources
 rag.empty.description=Add files or folders to enable RAG\nfor this project
 rag.empty.button.add=Add Sources
-rag.empty.coming.soon=(Coming soon)
 
 # MCP Tab
 mcp.title=MCP (Model Context Protocol)
@@ -1117,7 +1111,6 @@ mcp.instance.disabled=Disabled
 mcp.tools.loading=Loading tools...
 mcp.tools.failed=Connection failed. Click to retry.
 mcp.tools.none=No tools available
-mcp.tool.parameters=Parameters:
 mcp.no.instances.title=No MCP Instances
 mcp.no.instances.description=Configure MCP server instances in project settings\nto connect external tools and services
 

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=System
 menu.view.appearance.light=Hell
 menu.view.appearance.dark=Dunkel
 menu.view.appearance.sepia=Sepia
+menu.view.appearance.ocean=Ozean
+menu.view.appearance.nord=Nord
+menu.view.appearance.sage=Salbei
+menu.view.appearance.rose=Rosa
+menu.view.appearance.indigo=Indigo
 menu.view.fullscreen=Vollbildmodus aktivieren
 menu.terminal=Terminal
 menu.terminal.new=Neues Terminal
@@ -147,7 +152,6 @@ projects.page=Seite {0} von {1}
 projects.page.previous=Vorherige Seite
 projects.page.next=Nächste Seite
 projects.sources.count={0} Referenzmaterial(ien)
-projects.sources.title=Referenzmaterialien
 projects.sources.expand=Referenzmaterialien anzeigen
 projects.sources.collapse=Referenzmaterialien ausblenden
 projects.sources.empty.title=Noch keine Referenzmaterialien
@@ -214,7 +218,20 @@ theme.system=System
 theme.system.description=Systemthema verwenden
 theme.sepia=Sepia
 theme.sepia.description=Warme Pergamenttöne, angenehm für die Augen
-settings.accent.color=Akzentfarbe
+theme.ocean=Ozean
+theme.ocean.description=Sanfte himmelblaue Töne, ruhig und erfrischend
+theme.nord=Nord
+theme.nord.description=Dunkle arktische Farbpalette, kühl und fokussiert
+theme.sage=Salbei
+theme.sage.description=Gedämpfte graugrüne Töne, anspruchsvoll und ruhig
+theme.rose=Rose
+theme.rose.description=Zartes Blush-Rosa, elegant und warm
+theme.indigo=Indigo
+theme.indigo.description=Tiefes Violettblau, mystisch und kreativ
+settings.background.image=Hintergrundbild
+settings.background.image.description=Wählen Sie ein Hintergrundbild aus — verwenden Sie eine Vorlage oder Ihr eigenes Bild. Eine transparente Überlagerung sorgt dafür, dass der Text gut lesbar bleibt. Hintergrundbilder sind unabhängig vom ausgewählten Design.
+settings.background.image.browse=Durchsuchen
+settings.background.image.custom=Benutzerdefiniertes Bild
 settings.appearance.avatar.ai=KI-Assistenten-Avatar
 settings.appearance.avatar.ai.description=Passen Sie den Avatar des KI-Assistenten in Chat-Unterhaltungen an. Der Benutzeravatar wird im Benutzerprofil verwaltet.
 settings.appearance.avatar.ai.label=KI-Avatar
@@ -550,7 +567,6 @@ directive.edit.content.label=Inhalt
 directive.edit.content.placeholder=Direktivenanweisungen eingeben...
 directive.edit.name.required=Name ist erforderlich
 directive.edit.content.required=Inhalt ist erforderlich
-directive.tooltip.full.content=Vollständiger Inhalt:
 directive.created=Erstellt: {0}
 directive.new.title=Neue Direktive
 directive.new.guidelines=Direktiven leiten, wie die KI auf Ihre Nachrichten antwortet. Seien Sie spezifisch über Ton, Detailgrad, Format oder besondere Anforderungen, die Sie benötigen.
@@ -665,7 +681,6 @@ provider.lmstudio.setup.help=💡 So verwenden Sie LMStudio:\n\n1. Installieren:
 # System Resources
 system.memory=Speicher
 system.cpu=CPU
-system.resources.tooltip=Speicher: {0} MB | CPU: {1}%
 system.share.feedback=Feedback teilen
 system.ai.provider.tooltip=KI-Anbieter: {0}\nKlicken, um zu konfigurieren
 
@@ -746,7 +761,6 @@ error.app.message=Ein unerwarteter Fehler ist aufgetreten: {0}
 
 # Send Message Errors
 error.send_message.title=Nachricht konnte nicht gesendet werden
-error.send_message.message=Ihre Nachricht konnte nicht an die KI gesendet werden. Bitte versuchen Sie es erneut.
 
 
 # Indexing Errors
@@ -1096,7 +1110,6 @@ rag.status.not.indexed=Nicht indiziert
 rag.empty.title=Keine Wissensquellen
 rag.empty.description=Fügen Sie Dateien oder Ordner hinzu,\num RAG für dieses Projekt zu aktivieren
 rag.empty.button.add=Quellen hinzufügen
-rag.empty.coming.soon=(Demnächst verfügbar)
 
 # MCP Tab
 mcp.title=MCP (Model Context Protocol)
@@ -1105,7 +1118,6 @@ mcp.instance.disabled=Deaktiviert
 mcp.tools.loading=Tools werden geladen...
 mcp.tools.failed=Verbindung fehlgeschlagen. Klicken Sie zum erneuten Versuch.
 mcp.tools.none=Keine Tools verfügbar
-mcp.tool.parameters=Parameter:
 mcp.no.instances.title=Keine MCP-Instanzen
 mcp.no.instances.description=Konfigurieren Sie MCP-Serverinstanzen in den Projekteinstellungen,\num externe Tools und Dienste zu verbinden
 

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=Sistema
 menu.view.appearance.light=Claro
 menu.view.appearance.dark=Oscuro
 menu.view.appearance.sepia=Sepia
+menu.view.appearance.ocean=Océano
+menu.view.appearance.nord=Nord
+menu.view.appearance.sage=Salvia
+menu.view.appearance.rose=Rosa
+menu.view.appearance.indigo=Índigo
 menu.view.fullscreen=Entrar en pantalla completa
 menu.terminal=Terminal
 menu.terminal.new=Nuevo terminal
@@ -147,7 +152,6 @@ projects.page=Página {0} de {1}
 projects.page.previous=Página anterior
 projects.page.next=Página siguiente
 projects.sources.count={0} material(es) de referencia
-projects.sources.title=Materiales de Referencia
 projects.sources.expand=Mostrar materiales de referencia
 projects.sources.collapse=Ocultar materiales de referencia
 projects.sources.empty.title=Aún no hay materiales de referencia
@@ -214,7 +218,20 @@ theme.system=Sistema
 theme.system.description=Seguir el tema del sistema
 theme.sepia=Sepia
 theme.sepia.description=Tonos cálidos de pergamino, agradables para la vista
-settings.accent.color=Color de acento
+theme.ocean=Océano
+theme.ocean.description=Tonos suaves de azul cielo, tranquilos y refrescantes
+theme.nord=Nord
+theme.nord.description=Paleta oscura ártica, fresca y enfocada
+theme.sage=Salvia
+theme.sage.description=Tonos verde grisáceo apagados, sofisticados y serenos
+theme.rose=Rosa
+theme.rose.description=Rosa rubor suave, elegante y cálido
+theme.indigo=Índigo
+theme.indigo.description=Azul violeta profundo, místico y creativo
+settings.background.image=Imagen de fondo
+settings.background.image.description=Elige una imagen de fondo: selecciona una predefinida o usa tu propia imagen. Una superposición translúcida mantiene el texto legible. Las imágenes de fondo son independientes del tema seleccionado.
+settings.background.image.browse=Examinar
+settings.background.image.custom=Imagen personalizada
 settings.appearance.avatar.ai=Avatar del asistente de IA
 settings.appearance.avatar.ai.description=Personalice el avatar del asistente de IA en las conversaciones de chat. El avatar del usuario se gestiona en el Perfil de usuario.
 settings.appearance.avatar.ai.label=Avatar de IA
@@ -549,7 +566,6 @@ directive.edit.content.label=Contenido
 directive.edit.content.placeholder=Escribe las instrucciones de la directiva...
 directive.edit.name.required=El nombre es obligatorio
 directive.edit.content.required=El contenido es obligatorio
-directive.tooltip.full.content=Contenido completo:
 directive.created=Creado: {0}
 directive.new.title=Nueva directiva
 directive.new.guidelines=Las directivas guían cómo responde la IA a tus mensajes. Sé específico sobre el tono, nivel de detalle, formato o cualquier requisito especial que necesites.
@@ -664,7 +680,6 @@ provider.lmstudio.setup.help=💡 Para usar LMStudio:\n\n1. Instálalo desde: ht
 # System Resources
 system.memory=Memoria
 system.cpu=CPU
-system.resources.tooltip=Memoria: {0} MB | CPU: {1}%
 system.share.feedback=Compartir comentarios
 system.ai.provider.tooltip=Proveedor de IA: {0}\nHaz clic para configurar
 
@@ -744,7 +759,6 @@ error.app.message=Ocurrió un error inesperado: {0}
 
 # Send Message Errors
 error.send_message.title=No se pudo enviar el mensaje
-error.send_message.message=No se pudo enviar tu mensaje a la IA. Por favor, inténtalo de nuevo.
 
 # Indexing Errors
 error.indexing.model_not_found.title=Modelo de incrustación no encontrado
@@ -1094,7 +1108,6 @@ rag.status.not.indexed=No indexado
 rag.empty.title=Sin fuentes de conocimiento
 rag.empty.description=Agregue archivos o carpetas para habilitar RAG\npara este proyecto
 rag.empty.button.add=Agregar fuentes
-rag.empty.coming.soon=(Próximamente)
 
 # MCP Tab
 mcp.title=MCP (Model Context Protocol)
@@ -1103,6 +1116,5 @@ mcp.instance.disabled=Deshabilitado
 mcp.tools.loading=Cargando herramientas...
 mcp.tools.failed=Conexión fallida. Haga clic para reintentar.
 mcp.tools.none=No hay herramientas disponibles
-mcp.tool.parameters=Parámetros:
 mcp.no.instances.title=No hay instancias MCP
 mcp.no.instances.description=Configure instancias del servidor MCP en la configuración del proyecto\npara conectar herramientas y servicios externos

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=Système
 menu.view.appearance.light=Clair
 menu.view.appearance.dark=Sombre
 menu.view.appearance.sepia=Sépia
+menu.view.appearance.ocean=Océan
+menu.view.appearance.nord=Nord
+menu.view.appearance.sage=Sauge
+menu.view.appearance.rose=Rose
+menu.view.appearance.indigo=Indigo
 menu.view.fullscreen=Entrer en plein écran
 menu.terminal=Terminal
 menu.terminal.new=Nouveau terminal
@@ -147,7 +152,6 @@ projects.page=Page {0} sur {1}
 projects.page.previous=Page précédente
 projects.page.next=Page suivante
 projects.sources.count={0} matériau(x) de référence
-projects.sources.title=Matériaux de Référence
 projects.sources.expand=Afficher les matériaux de référence
 projects.sources.collapse=Masquer les matériaux de référence
 projects.sources.empty.title=Aucun document de référence pour le moment
@@ -214,7 +218,20 @@ theme.system=Système
 theme.system.description=Suivre le thème du système
 theme.sepia=Sépia
 theme.sepia.description=Tons chauds parchemin, agréables pour les yeux
-settings.accent.color=Couleur d’accent
+theme.ocean=Océan
+theme.ocean.description=Douces tonalités bleu ciel, calmes et rafraîchissantes
+theme.nord=Nord
+theme.nord.description=Palette sombre arctique, froide et concentrée
+theme.sage=Sauge
+theme.sage.description=Tons vert-gris atténués, sophistiqués et apaisants
+theme.rose=Rose
+theme.rose.description=Rose poudré doux, élégant et chaleureux
+theme.indigo=Indigo
+theme.indigo.description=Bleu violet profond, mystique et créatif
+settings.background.image=Image d’arrière-plan
+settings.background.image.description=Choisissez une image d’arrière-plan — sélectionnez un préréglage ou utilisez votre propre image. Une superposition translucide permet de garder le texte lisible. Les images d’arrière-plan sont indépendantes du thème sélectionné.
+settings.background.image.browse=Parcourir
+settings.background.image.custom=Image personnalisée
 settings.appearance.avatar.ai=Avatar de l’assistant IA
 settings.appearance.avatar.ai.description=Personnalisez l’avatar de l’assistant IA dans les conversations de chat. L’avatar utilisateur est géré dans le profil utilisateur.
 settings.appearance.avatar.ai.label=Avatar IA
@@ -549,7 +566,6 @@ directive.edit.content.label=Contenu
 directive.edit.content.placeholder=Entrez les instructions de la directive...
 directive.edit.name.required=Le nom est obligatoire
 directive.edit.content.required=Le contenu est obligatoire
-directive.tooltip.full.content=Contenu complet :
 directive.created=Créée : {0}
 directive.new.title=Nouvelle directive
 directive.new.guidelines=Les directives guident la manière dont l'IA répond à vos messages. Soyez précis sur le ton, le niveau de détail, le format ou toute exigence particulière dont vous avez besoin.
@@ -664,7 +680,6 @@ provider.lmstudio.setup.help=💡 Pour utiliser LMStudio :\n\n1. Installez : htt
 # System Resources
 system.memory=Mémoire
 system.cpu=CPU
-system.resources.tooltip=Mémoire : {0} MB | CPU : {1}%
 system.share.feedback=Partager vos commentaires
 system.ai.provider.tooltip=Fournisseur d’IA : {0}\nCliquez pour configurer
 
@@ -744,7 +759,6 @@ error.app.message=Une erreur inattendue s’est produite : {0}
 
 # Send Message Errors
 error.send_message.title=Échec de l’envoi du message
-error.send_message.message=Impossible d’envoyer votre message à l’IA. Veuillez réessayer.
 
 
 # Indexing Errors
@@ -1094,7 +1108,6 @@ rag.status.not.indexed=Non indexé
 rag.empty.title=Aucune source de connaissances
 rag.empty.description=Ajoutez des fichiers ou dossiers pour activer RAG\npour ce projet
 rag.empty.button.add=Ajouter des sources
-rag.empty.coming.soon=(Bientôt disponible)
 
 # MCP Tab
 mcp.title=MCP (Model Context Protocol)
@@ -1103,6 +1116,5 @@ mcp.instance.disabled=Désactivé
 mcp.tools.loading=Chargement des outils...
 mcp.tools.failed=Échec de la connexion. Cliquez pour réessayer.
 mcp.tools.none=Aucun outil disponible
-mcp.tool.parameters=Paramètres :
 mcp.no.instances.title=Aucune instance MCP
 mcp.no.instances.description=Configurez des instances de serveur MCP dans les paramètres du projet\npour connecter des outils et services externes

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=システム
 menu.view.appearance.light=ライト
 menu.view.appearance.dark=ダーク
 menu.view.appearance.sepia=セピア
+menu.view.appearance.ocean=オーシャン
+menu.view.appearance.nord=ノルド
+menu.view.appearance.sage=セージ
+menu.view.appearance.rose=ローズ
+menu.view.appearance.indigo=インディゴ
 menu.view.fullscreen=フルスクリーンにする
 menu.terminal=ターミナル
 menu.terminal.new=新しいターミナル
@@ -147,7 +152,6 @@ projects.page={0} / {1} ページ
 projects.page.previous=前のページ
 projects.page.next=次のページ
 projects.sources.count=参考資料 {0} 件
-projects.sources.title=参考資料
 projects.sources.expand=参考資料を表示
 projects.sources.collapse=参考資料を非表示
 projects.sources.empty.title=参照資料がまだありません
@@ -214,7 +218,20 @@ theme.system=システム
 theme.system.description=システム設定に従う
 theme.sepia=セピア
 theme.sepia.description=温かみのあるパーチメント調、目に優しい
-settings.accent.color=アクセントカラー
+theme.ocean=オーシャン
+theme.ocean.description=やわらかな空色のトーンで、穏やかで爽やか
+theme.nord=ノルド
+theme.nord.description=北極を思わせるダークパレットで、クールで集中しやすい
+theme.sage=セージ
+theme.sage.description=落ち着いたグレーがかったグリーンで、洗練され穏やか
+theme.rose=ローズ
+theme.rose.description=やさしいブラッシュピンクで、上品で温かみがある
+theme.indigo=インディゴ
+theme.indigo.description=深い青紫で、神秘的で創造的
+settings.background.image=背景画像
+settings.background.image.description=背景画像を選択します — プリセットを選ぶか、自分の画像を使用できます。半透明のオーバーレイにより、テキストの読みやすさが保たれます。背景画像は選択したテーマとは独立しています。
+settings.background.image.browse=参照
+settings.background.image.custom=カスタム画像
 settings.appearance.avatar.ai=AI アシスタントのアバター
 settings.appearance.avatar.ai.description=チャット会話内で AI アシスタントのアバターをカスタマイズします。ユーザーのアバターはユーザープロファイルで管理されます。
 settings.appearance.avatar.ai.label=AI アバター
@@ -549,7 +566,6 @@ directive.edit.content.label=内容
 directive.edit.content.placeholder=ディレクティブ内容を入力...
 directive.edit.name.required=名前は必須です
 directive.edit.content.required=内容は必須です
-directive.tooltip.full.content=全文:
 directive.created=作成日: {0}
 directive.new.title=新しいディレクティブ
 directive.new.guidelines=ディレクティブは、AIがメッセージに応答する方法を指示します。トーン、詳細レベル、形式、または必要な特別な要件について具体的に指定してください。
@@ -664,7 +680,6 @@ provider.lmstudio.setup.help=💡 LMStudio の利用方法:\n\n1. https://lmstud
 # System Resources
 system.memory=メモリ
 system.cpu=CPU
-system.resources.tooltip=メモリ: {0} MB | CPU: {1}%
 system.share.feedback=フィードバックを共有
 system.ai.provider.tooltip=AI プロバイダー：{0}\nクリックして設定
 
@@ -745,7 +760,6 @@ error.app.message=予期しないエラーが発生しました: {0}
 
 # Send Message Errors
 error.send_message.title=メッセージの送信に失敗しました
-error.send_message.message=AI にメッセージを送信できませんでした。もう一度お試しください。
 
 
 # Indexing Errors
@@ -1094,7 +1108,6 @@ rag.status.not.indexed=未インデックス
 rag.empty.title=ナレッジソースがありません
 rag.empty.description=このプロジェクトでRAGを有効にするには\nファイルまたはフォルダを追加してください
 rag.empty.button.add=ソースを追加
-rag.empty.coming.soon=（近日公開）
 
 # MCP Tab
 mcp.title=MCP（Model Context Protocol）
@@ -1103,6 +1116,5 @@ mcp.instance.disabled=無効
 mcp.tools.loading=ツールを読み込み中...
 mcp.tools.failed=接続に失敗しました。クリックして再試行してください。
 mcp.tools.none=利用可能なツールはありません
-mcp.tool.parameters=パラメーター:
 mcp.no.instances.title=MCPインスタンスがありません
 mcp.no.instances.description=外部ツールやサービスに接続するには、\nプロジェクト設定でMCPサーバーインスタンスを構成してください

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=시스템
 menu.view.appearance.light=라이트
 menu.view.appearance.dark=다크
 menu.view.appearance.sepia=세피아
+menu.view.appearance.ocean=오션
+menu.view.appearance.nord=노르드
+menu.view.appearance.sage=세이지
+menu.view.appearance.rose=로즈
+menu.view.appearance.indigo=인디고
 menu.view.fullscreen=전체 화면으로 전환
 menu.terminal=터미널
 menu.terminal.new=새 터미널
@@ -148,7 +153,6 @@ projects.page={0} / {1} 페이지
 projects.page.previous=이전 페이지
 projects.page.next=다음 페이지
 projects.sources.count=참고 자료 {0}개
-projects.sources.title=참고 자료
 projects.sources.expand=참고 자료 표시
 projects.sources.collapse=참고 자료 숨기기
 projects.sources.empty.title=아직 참조 자료가 없습니다
@@ -215,7 +219,20 @@ theme.system=시스템
 theme.system.description=시스템 테마 따르기
 theme.sepia=세피아
 theme.sepia.description=따뜻한 양피지 톤, 눈이 편안함
-settings.accent.color=강조 색상
+theme.ocean=오션
+theme.ocean.description=부드러운 하늘빛 톤으로 차분하고 산뜻함
+theme.nord=노르드
+theme.nord.description=북극을 닮은 어두운 팔레트로 차갑고 집중감 있는 분위기
+theme.sage=세이지
+theme.sage.description=차분한 회녹색 톤으로 세련되고 안정감 있음
+theme.rose=로즈
+theme.rose.description=부드러운 블러시 핑크로 우아하고 따뜻함
+theme.indigo=인디고
+theme.indigo.description=짙은 보랏빛 푸른색으로 신비롭고 창의적임
+settings.background.image=배경 이미지
+settings.background.image.description=배경 이미지를 선택하세요 — 기본 제공 이미지를 고르거나 직접 이미지를 사용할 수 있습니다. 반투명 오버레이가 텍스트 가독성을 유지해 줍니다. 배경 이미지는 선택한 테마와는 별개로 적용됩니다.
+settings.background.image.browse=찾아보기
+settings.background.image.custom=사용자 지정 이미지
 settings.appearance.avatar.ai=AI 어시스턴트 아바타
 settings.appearance.avatar.ai.description=채팅 대화에서 AI 어시스턴트의 아바타를 사용자 지정합니다. 사용자 아바타는 사용자 프로필에서 관리됩니다.
 settings.appearance.avatar.ai.label=AI 아바타
@@ -550,7 +567,6 @@ directive.edit.content.label=내용
 directive.edit.content.placeholder=지시문 내용을 입력하세요...
 directive.edit.name.required=이름은 필수입니다
 directive.edit.content.required=내용은 필수입니다
-directive.tooltip.full.content=전체 내용:
 directive.created=생성됨: {0}
 directive.new.title=새 지시문
 directive.new.guidelines=지시문은 AI가 메시지에 응답하는 방식을 안내합니다. 어조, 세부 수준, 형식 또는 필요한 특별 요구 사항에 대해 구체적으로 작성하세요.
@@ -665,7 +681,6 @@ provider.lmstudio.setup.help=💡 LMStudio 사용 방법:\n\n1. https://lmstudio
 # System Resources
 system.memory=메모리
 system.cpu=CPU
-system.resources.tooltip=메모리: {0} MB | CPU: {1}%
 system.share.feedback=피드백 공유
 system.ai.provider.tooltip=AI 제공자: {0}\n클릭하여 설정
 
@@ -746,8 +761,6 @@ error.app.message=예기치 않은 오류가 발생했습니다: {0}
 
 # Send Message Errors
 error.send_message.title=메시지 전송 실패
-error.send_message.message=AI로 메시지를 전송하지 못했습니다. 다시 시도해 주세요.
-
 
 # Indexing Errors
 error.indexing.model_not_found.title=임베딩 모델을 찾을 수 없음
@@ -1095,7 +1108,6 @@ rag.status.not.indexed=인덱싱되지 않음
 rag.empty.title=지식 소스가 없습니다
 rag.empty.description=이 프로젝트에서 RAG를 활성화하려면\n파일 또는 폴더를 추가하세요
 rag.empty.button.add=소스 추가
-rag.empty.coming.soon=(곧 제공 예정)
 
 # MCP Tab
 mcp.title=MCP (Model Context Protocol)
@@ -1104,6 +1116,5 @@ mcp.instance.disabled=비활성화됨
 mcp.tools.loading=도구를 불러오는 중...
 mcp.tools.failed=연결에 실패했습니다. 클릭하여 다시 시도하세요.
 mcp.tools.none=사용 가능한 도구가 없습니다
-mcp.tool.parameters=매개변수:
 mcp.no.instances.title=MCP 인스턴스가 없습니다
 mcp.no.instances.description=외부 도구 및 서비스에 연결하려면\n프로젝트 설정에서 MCP 서버 인스턴스를 구성하세요

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=Sistema
 menu.view.appearance.light=Claro
 menu.view.appearance.dark=Escuro
 menu.view.appearance.sepia=Sépia
+menu.view.appearance.ocean=Oceano
+menu.view.appearance.nord=Nord
+menu.view.appearance.sage=Sálvia
+menu.view.appearance.rose=Rosa
+menu.view.appearance.indigo=Índigo
 menu.view.fullscreen=Entrar em tela cheia
 menu.terminal=Terminal
 menu.terminal.new=Novo terminal
@@ -147,7 +152,6 @@ projects.page=Página {0} de {1}
 projects.page.previous=Página anterior
 projects.page.next=Próxima página
 projects.sources.count={0} material(is) de referência
-projects.sources.title=Materiais de Referência
 projects.sources.expand=Mostrar materiais de referência
 projects.sources.collapse=Ocultar materiais de referência
 projects.sources.empty.title=Ainda não há materiais de referência
@@ -214,7 +218,20 @@ theme.system=Sistema
 theme.system.description=Seguir o tema do sistema
 theme.sepia=Sépia
 theme.sepia.description=Tons quentes de pergaminho, agradáveis para os olhos
-settings.accent.color=Cor de destaque
+theme.ocean=Oceano
+theme.ocean.description=Tons suaves de azul-céu, calmos e refrescantes
+theme.nord=Nord
+theme.nord.description=Paleta escura ártica, fria e focada
+theme.sage=Sálvia
+theme.sage.description=Tons verde-acinzentados suaves, sofisticados e calmos
+theme.rose=Rosa
+theme.rose.description=Rosa blush suave, elegante e acolhedor
+theme.indigo=Índigo
+theme.indigo.description=Azul-violeta profundo, místico e criativo
+settings.background.image=Imagem de fundo
+settings.background.image.description=Escolha uma imagem de fundo — selecione uma predefinida ou use a sua própria imagem. Uma sobreposição translúcida mantém o texto legível. As imagens de fundo são independentes do tema selecionado.
+settings.background.image.browse=Procurar
+settings.background.image.custom=Imagem personalizada
 settings.appearance.avatar.ai=Avatar do assistente de IA
 settings.appearance.avatar.ai.description=Personalize o avatar do assistente de IA nas conversas de chat. O avatar do usuário é gerenciado no Perfil do usuário.
 settings.appearance.avatar.ai.label=Avatar de IA
@@ -550,7 +567,6 @@ directive.edit.content.label=Conteúdo
 directive.edit.content.placeholder=Digite as instruções da diretiva...
 directive.edit.name.required=Nome é obrigatório
 directive.edit.content.required=Conteúdo é obrigatório
-directive.tooltip.full.content=Conteúdo Completo:
 directive.created=Criado: {0}
 directive.new.title=Nova Diretiva
 directive.new.guidelines=As diretivas orientam como a IA responde às suas mensagens. Seja específico sobre tom, nível de detalhe, formato ou quaisquer requisitos especiais que você precisa.
@@ -665,7 +681,6 @@ provider.lmstudio.setup.help=💡 Para usar o LMStudio:\n\n1. Instale: https://l
 # System Resources
 system.memory=Memória
 system.cpu=CPU
-system.resources.tooltip=Memória: {0} MB | CPU: {1}%
 system.share.feedback=Compartilhar feedback
 system.ai.provider.tooltip=Provedor de IA: {0}\nClique para configurar
 
@@ -746,8 +761,6 @@ error.app.message=Ocorreu um erro inesperado: {0}
 
 # Send Message Errors
 error.send_message.title=Falha ao enviar mensagem
-error.send_message.message=Não foi possível enviar sua mensagem para a IA. Tente novamente.
-
 
 # Indexing Errors
 error.indexing.model_not_found.title=Modelo de embedding não encontrado
@@ -1095,7 +1108,6 @@ rag.status.not.indexed=Não indexado
 rag.empty.title=Nenhuma fonte de conhecimento
 rag.empty.description=Adicione arquivos ou pastas para ativar o RAG\npara este projeto
 rag.empty.button.add=Adicionar fontes
-rag.empty.coming.soon=(Em breve)
 
 # MCP Tab
 mcp.title=MCP (Model Context Protocol)
@@ -1104,6 +1116,5 @@ mcp.instance.disabled=Desativado
 mcp.tools.loading=Carregando ferramentas...
 mcp.tools.failed=Falha na conexão. Clique para tentar novamente.
 mcp.tools.none=Nenhuma ferramenta disponível
-mcp.tool.parameters=Parâmetros:
 mcp.no.instances.title=Nenhuma instância MCP
 mcp.no.instances.description=Configure instâncias do servidor MCP nas configurações do projeto\npara conectar ferramentas e serviços externos

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=Hệ thống
 menu.view.appearance.light=Sáng
 menu.view.appearance.dark=Tối
 menu.view.appearance.sepia=Nâu Sepia
+menu.view.appearance.ocean=Đại dương
+menu.view.appearance.nord=Nord
+menu.view.appearance.sage=Xanh xô thơm
+menu.view.appearance.rose=Hồng
+menu.view.appearance.indigo=Chàm
 menu.view.fullscreen=Chuyển sang toàn màn hình
 menu.terminal=Terminal
 menu.terminal.new=Terminal mới
@@ -147,7 +152,6 @@ projects.page=Trang {0} trên {1}
 projects.page.previous=Trang trước
 projects.page.next=Trang sau
 projects.sources.count={0} tài liệu tham khảo
-projects.sources.title=Tài Liệu Tham Khảo
 projects.sources.expand=Hiển thị tài liệu tham khảo
 projects.sources.collapse=Ẩn tài liệu tham khảo
 projects.sources.empty.title=Chưa có tài liệu tham chiếu
@@ -211,7 +215,20 @@ theme.system=Hệ thống
 theme.system.description=Theo chủ đề hệ thống
 theme.sepia=Nâu Sepia
 theme.sepia.description=Tông màu ấm áp, dễ chịu cho mắt
-settings.accent.color=Màu nhấn
+theme.ocean=Đại dương
+theme.ocean.description=Tông xanh da trời dịu nhẹ, êm dịu và tươi mát
+theme.nord=Nord
+theme.nord.description=Bảng màu tối Bắc Cực, mát lạnh và tập trung
+theme.sage=Xanh xô thơm
+theme.sage.description=Tông xanh xám dịu, tinh tế và điềm tĩnh
+theme.rose=Hồng
+theme.rose.description=Màu hồng phấn nhẹ, thanh lịch và ấm áp
+theme.indigo=Chàm
+theme.indigo.description=Xanh tím đậm, huyền bí và sáng tạo
+settings.background.image=Ảnh nền
+settings.background.image.description=Chọn ảnh nền — chọn một ảnh có sẵn hoặc dùng ảnh của riêng bạn. Một lớp phủ trong mờ giúp văn bản luôn dễ đọc. Ảnh nền hoạt động độc lập với chủ đề đã chọn.
+settings.background.image.browse=Duyệt
+settings.background.image.custom=Ảnh tùy chỉnh
 settings.appearance.avatar.ai=Ảnh đại diện trợ lý AI
 settings.appearance.avatar.ai.description=Tùy chỉnh ảnh đại diện của trợ lý AI trong các cuộc trò chuyện. Ảnh đại diện người dùng được quản lý trong Hồ sơ người dùng.
 settings.appearance.avatar.ai.label=Ảnh đại diện AI
@@ -548,7 +565,6 @@ directive.edit.content.label=Nội dung
 directive.edit.content.placeholder=Nhập hướng dẫn...
 directive.edit.name.required=Yêu cầu tên
 directive.edit.content.required=Yêu cầu nội dung
-directive.tooltip.full.content=Nội dung đầy đủ:
 directive.created=Tạo lúc: {0}
 directive.new.title=Chỉ thị mới
 directive.new.guidelines=Chỉ thị hướng dẫn cách AI phản hồi tin nhắn của bạn. Hãy cụ thể về giọng điệu, mức độ chi tiết, định dạng hoặc bất kỳ yêu cầu đặc biệt nào bạn cần.
@@ -663,7 +679,6 @@ provider.lmstudio.setup.help=💡 Để dùng LMStudio:\n\n1. Cài từ https://
 # System Resources
 system.memory=Bộ nhớ
 system.cpu=CPU
-system.resources.tooltip=Bộ nhớ: {0} MB | CPU: {1}%
 system.share.feedback=Chia sẻ phản hồi
 system.ai.provider.tooltip=Nhà cung cấp AI: {0}\nNhấn để cấu hình
 
@@ -743,7 +758,6 @@ error.app.message=Đã xảy ra lỗi không mong muốn: {0}
 
 # Send Message Errors
 error.send_message.title=Gửi tin nhắn thất bại
-error.send_message.message=Không thể gửi tin nhắn của bạn đến AI. Vui lòng thử lại.
 
 
 # Indexing Errors
@@ -1093,7 +1107,6 @@ rag.status.not.indexed=Chưa lập chỉ mục
 rag.empty.title=Không có nguồn tri thức
 rag.empty.description=Thêm tệp hoặc thư mục để bật RAG\ncho dự án này
 rag.empty.button.add=Thêm nguồn
-rag.empty.coming.soon=(Sắp ra mắt)
 
 # MCP Tab
 mcp.title=MCP (Model Context Protocol)
@@ -1102,6 +1115,5 @@ mcp.instance.disabled=Đã tắt
 mcp.tools.loading=Đang tải công cụ...
 mcp.tools.failed=Kết nối thất bại. Nhấp để thử lại.
 mcp.tools.none=Không có công cụ khả dụng
-mcp.tool.parameters=Tham số:
 mcp.no.instances.title=Không có phiên bản MCP
 mcp.no.instances.description=Cấu hình các phiên bản máy chủ MCP trong cài đặt dự án\nđể kết nối công cụ và dịch vụ bên ngoài

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=系统
 menu.view.appearance.light=浅色
 menu.view.appearance.dark=深色
 menu.view.appearance.sepia=褐色
+menu.view.appearance.ocean=海洋
+menu.view.appearance.nord=Nord
+menu.view.appearance.sage=鼠尾草
+menu.view.appearance.rose=玫瑰
+menu.view.appearance.indigo=靛蓝
 menu.view.fullscreen=进入全屏
 menu.terminal=终端
 menu.terminal.new=新建终端
@@ -147,7 +152,6 @@ projects.page=第 {0} 页，共 {1} 页
 projects.page.previous=上一页
 projects.page.next=下一页
 projects.sources.count={0} 个参考资料
-projects.sources.title=参考资料
 projects.sources.expand=显示参考资料
 projects.sources.collapse=隐藏参考资料
 projects.sources.empty.title=尚未添加参考资料
@@ -214,7 +218,20 @@ theme.system=系统
 theme.system.description=跟随系统主题
 theme.sepia=褐色
 theme.sepia.description=温暖的羊皮纸色调，护眼
-settings.accent.color=强调色
+theme.ocean=海洋
+theme.ocean.description=柔和的天蓝色调，平静清新
+theme.nord=Nord
+theme.nord.description=北极风深色调色板，冷静而专注
+theme.sage=鼠尾草
+theme.sage.description=低饱和灰绿色调，沉稳而雅致
+theme.rose=玫瑰
+theme.rose.description=柔和的腮红粉，优雅而温暖
+theme.indigo=靛蓝
+theme.indigo.description=深邃的紫蓝色，神秘而富有创意
+settings.background.image=背景图片
+settings.background.image.description=选择背景图片——可选择预设图片或使用您自己的图片。半透明覆盖层可保持文字清晰易读。背景图片独立于所选主题。
+settings.background.image.browse=浏览
+settings.background.image.custom=自定义图片
 settings.appearance.avatar.ai=AI 助手头像
 settings.appearance.avatar.ai.description=自定义聊天对话中 AI 助手的头像。用户头像在用户资料中管理。
 settings.appearance.avatar.ai.label=AI 头像
@@ -549,7 +566,6 @@ directive.edit.content.label=内容
 directive.edit.content.placeholder=输入指令内容...
 directive.edit.name.required=名称为必填项
 directive.edit.content.required=内容为必填项
-directive.tooltip.full.content=完整内容：
 directive.created=创建时间：{0}
 directive.new.title=新指令
 directive.new.guidelines=指令用于指导AI如何回应您的消息。请具体说明语气、详细程度、格式或您需要的任何特殊要求。
@@ -664,7 +680,6 @@ provider.lmstudio.setup.help=使用 LMStudio：\n\n1. 安装：https://lmstudio.
 # System Resources
 system.memory=内存
 system.cpu=CPU
-system.resources.tooltip=内存：{0} MB | CPU：{1}%
 system.share.feedback=分享反馈
 system.ai.provider.tooltip=AI 提供商：{0}\n点击进行配置
 
@@ -745,7 +760,6 @@ error.app.message=发生了一个意外错误：{0}
 
 # Send Message Errors
 error.send_message.title=发送消息失败
-error.send_message.message=无法将你的消息发送给 AI。请重试。
 
 
 # Indexing Errors
@@ -1095,7 +1109,6 @@ rag.status.not.indexed=未建立索引
 rag.empty.title=暂无知识来源
 rag.empty.description=添加文件或文件夹以为此项目启用 RAG
 rag.empty.button.add=添加来源
-rag.empty.coming.soon=（即将推出）
 
 # MCP Tab
 mcp.title=MCP（Model Context Protocol）
@@ -1104,6 +1117,5 @@ mcp.instance.disabled=已禁用
 mcp.tools.loading=正在加载工具...
 mcp.tools.failed=连接失败。点击重试。
 mcp.tools.none=暂无可用工具
-mcp.tool.parameters=参数：
 mcp.no.instances.title=没有 MCP 实例
 mcp.no.instances.description=请在项目设置中配置 MCP 服务器实例，\n以连接外部工具和服务

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -24,6 +24,11 @@ menu.view.appearance.system=系統
 menu.view.appearance.light=淺色
 menu.view.appearance.dark=深色
 menu.view.appearance.sepia=褐色
+menu.view.appearance.ocean=海洋
+menu.view.appearance.nord=Nord
+menu.view.appearance.sage=鼠尾草
+menu.view.appearance.rose=玫瑰
+menu.view.appearance.indigo=靛藍
 menu.view.fullscreen=進入全螢幕
 menu.terminal=終端機
 menu.terminal.new=新增終端機
@@ -147,7 +152,6 @@ projects.page=第 {0} 頁，共 {1} 頁
 projects.page.previous=上一頁
 projects.page.next=下一頁
 projects.sources.count={0} 個參考資料
-projects.sources.title=參考資料
 projects.sources.expand=顯示參考資料
 projects.sources.collapse=隱藏參考資料
 projects.sources.empty.title=尚未新增參考資料
@@ -214,7 +218,20 @@ theme.system=系統
 theme.system.description=依照系統主題
 theme.sepia=褐色
 theme.sepia.description=溫暖的羊皮紙色調，護眼舒適
-settings.accent.color=強調色
+theme.ocean=海洋
+theme.ocean.description=柔和的天藍色調，平靜清新
+theme.nord=Nord
+theme.nord.description=北極風深色調色盤，冷靜而專注
+theme.sage=鼠尾草
+theme.sage.description=低飽和灰綠色調，沉穩而雅緻
+theme.rose=玫瑰
+theme.rose.description=柔和的腮紅粉，優雅而溫暖
+theme.indigo=靛藍
+theme.indigo.description=深邃的紫藍色，神秘且富有創意
+settings.background.image=背景圖片
+settings.background.image.description=選擇背景圖片——可選擇預設圖片或使用您自己的圖片。半透明覆蓋層可保持文字清晰易讀。背景圖片獨立於所選主題。
+settings.background.image.browse=瀏覽
+settings.background.image.custom=自訂圖片
 settings.appearance.avatar.ai=AI 助手頭像
 settings.appearance.avatar.ai.description=自訂聊天對話中的 AI 助手頭像。使用者頭像於使用者個人資料中管理。
 settings.appearance.avatar.ai.label=AI 頭像
@@ -549,7 +566,6 @@ directive.edit.content.label=內容
 directive.edit.content.placeholder=輸入指令內容...
 directive.edit.name.required=名稱為必填
 directive.edit.content.required=內容為必填
-directive.tooltip.full.content=完整內容：
 directive.created=建立時間：{0}
 directive.new.title=新增指令
 directive.new.guidelines=指令用於指導AI如何回應您的訊息。請具體說明語氣、詳細程度、格式或您需要的任何特殊要求。
@@ -664,7 +680,6 @@ provider.lmstudio.setup.help=💡 若要使用 LMStudio：\n\n1. 安裝：https:
 # System Resources
 system.memory=記憶體
 system.cpu=CPU
-system.resources.tooltip=記憶體：{0} MB | CPU：{1}%
 system.share.feedback=分享回饋
 system.ai.provider.tooltip=AI 提供者：{0}\n點擊以進行設定
 
@@ -746,7 +761,6 @@ error.app.message=發生未預期的錯誤：{0}
 
 # Send Message Errors
 error.send_message.title=傳送訊息失敗
-error.send_message.message=無法將你的訊息傳送給 AI。請再試一次。
 
 
 # Indexing Errors
@@ -1096,7 +1110,6 @@ rag.status.not.indexed=尚未建立索引
 rag.empty.title=尚無知識來源
 rag.empty.description=新增檔案或資料夾以啟用此專案的 RAG
 rag.empty.button.add=新增來源
-rag.empty.coming.soon=（即將推出）
 
 # MCP Tab
 mcp.title=MCP（Model Context Protocol）
@@ -1105,6 +1118,5 @@ mcp.instance.disabled=已停用
 mcp.tools.loading=正在載入工具...
 mcp.tools.failed=連線失敗。點擊以重新嘗試。
 mcp.tools.none=沒有可用工具
-mcp.tool.parameters=參數：
 mcp.no.instances.title=沒有 MCP 實例
 mcp.no.instances.description=請在專案設定中設定 MCP 伺服器實例，\n以連接外部工具與服務

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
@@ -421,17 +421,14 @@ fun footerBar(
 ) {
     val resourceMonitor = remember { get<SystemResourceMonitor>(SystemResourceMonitor::class.java) }
     val appContext = remember { get<AppContext>(AppContext::class.java) }
-    val scope = rememberCoroutineScope()
 
     val memoryUsage by resourceMonitor.memoryUsageMB.collectAsState()
     val cpuUsage by resourceMonitor.cpuUsagePercent.collectAsState()
     val metrics by appContext.telemetry.metricsFlow.collectAsState()
     var telemetryExpanded by remember { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
-        scope.launch {
-            resourceMonitor.startMonitoring(intervalMillis = 2000)
-        }
+    LaunchedEffect(resourceMonitor) {
+        resourceMonitor.startMonitoring(intervalMillis = 2000)
     }
 
     Column(
@@ -449,46 +446,42 @@ fun footerBar(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            themedTooltip(
-                text = stringResource("system.resources.tooltip", memoryUsage.toString(), "%.1f".format(cpuUsage)),
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource("system.memory") + ":",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = "$memoryUsage MB",
-                            style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
+                    Text(
+                        text = stringResource("system.memory") + ":",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "$memoryUsage MB",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
 
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource("system.cpu") + ":",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = "%.1f%%".format(cpuUsage),
-                            style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource("system.cpu") + ":",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "%.1f%%".format(cpuUsage),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
                 }
             }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/TelemetryPanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/TelemetryPanel.kt
@@ -4,9 +4,6 @@
  */
 package io.askimo.desktop.shell
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.TooltipArea
-import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -39,7 +35,6 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.askimo.core.context.AppContext
@@ -203,7 +198,6 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun telemetryMetricCard(
     label: String,
@@ -223,26 +217,7 @@ private fun telemetryMetricCard(
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             if (valueTooltip != null) {
-                TooltipArea(
-                    tooltip = {
-                        Surface(
-                            modifier = Modifier.padding(4.dp),
-                            color = MaterialTheme.colorScheme.inverseSurface,
-                            shape = RoundedCornerShape(4.dp),
-                        ) {
-                            Text(
-                                text = valueTooltip,
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.inverseOnSurface,
-                            )
-                        }
-                    },
-                    delayMillis = 300,
-                    tooltipPlacement = TooltipPlacement.CursorPoint(
-                        offset = DpOffset(0.dp, 16.dp),
-                    ),
-                ) {
+                themedTooltip(text = valueTooltip) {
                     Text(
                         text = value,
                         style = MaterialTheme.typography.titleMedium,
@@ -273,7 +248,6 @@ private fun telemetryMetricCard(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun telemetryProviderRow(
     providerModel: String,
@@ -310,25 +284,8 @@ private fun telemetryProviderRow(
                 fontSize = 11.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            TooltipArea(
-                tooltip = {
-                    Surface(
-                        modifier = Modifier.padding(4.dp),
-                        color = MaterialTheme.colorScheme.inverseSurface,
-                        shape = RoundedCornerShape(4.dp),
-                    ) {
-                        Text(
-                            text = formatDurationDetailed(avgDurationMs),
-                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.inverseOnSurface,
-                        )
-                    }
-                },
-                delayMillis = 300,
-                tooltipPlacement = TooltipPlacement.CursorPoint(
-                    offset = DpOffset(0.dp, 16.dp),
-                ),
+            themedTooltip(
+                text = formatDurationDetailed(avgDurationMs),
             ) {
                 Text(
                     text = formatDuration(avgDurationMs),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ mockitoKotlin = "6.1.0"
 kotlin = "2.3.20"
 jackson = "2.19.2"
 spotless = "8.0.0"
+detekt = "1.23.8"
 shadow = "9.0.1"
 graalvmSvm = "25.0.2"
 sqlite = "3.51.1.0"
@@ -123,6 +124,11 @@ testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", ve
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
+# Detekt
+detekt-cli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
+detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
+detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
+
 [bundles]
 langchain4j = [
     "langchain4j",
@@ -200,6 +206,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvm-plugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -101,10 +101,6 @@ private class CommaSeparatedSetDeserializer : StdDeserializer<Set<String>>(Set::
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Set<String> = parseCommaSeparated(p).toSet()
 }
 
-private class CommaSeparatedListDeserializer : StdDeserializer<List<String>>(List::class.java) {
-    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): List<String> = parseCommaSeparated(p)
-}
-
 // TODO: Remove @JsonAlias camelCase aliases in v1.2.30 — kept for backward compatibility with pre-snake_case config files
 data class IndexingConfig(
     @field:JsonAlias("maxFileBytes") val maxFileBytes: Long = 5_000_000,

--- a/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
@@ -356,15 +356,6 @@ class AppContext private constructor(
     }
 
     /**
-     * Get the vision model name for the current provider.
-     */
-    private fun getVisionModelForProvider(provider: ModelProvider): String = if (provider == ModelProvider.UNKNOWN) {
-        params.model
-    } else {
-        AppConfig.models[provider].visionModel
-    }
-
-    /**
      * Set the language directive based on user's locale selection.
      * This constructs a comprehensive instruction for the AI to communicate in the specified language,
      * with a fallback to English if the language is not supported by the AI.

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -217,7 +217,8 @@ class DatabaseManager private constructor(
                     ALTER TABLE chat_sessions ADD COLUMN project_id TEXT REFERENCES projects(id) ON DELETE CASCADE
                     """,
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
+                // Column already exists — safe to ignore
             }
 
             // Migration: Add synced_at column if it doesn't exist.

--- a/shared/src/main/kotlin/io/askimo/core/mcp/TemplateResolver.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/TemplateResolver.kt
@@ -123,13 +123,6 @@ class TemplateResolver(private val parameterValues: Map<String, String>) {
                 errors.add("Unmatched opening braces")
             }
 
-            // Extract all placeholders and validate them
-            val simpleRegex = """\{\{(\w+)\}\}""".toRegex()
-            val conditionalRegex = """\{\{\?(\w+):([^}]+)\}\}""".toRegex()
-
-            val simplePlaceholders = simpleRegex.findAll(template).map { it.groupValues[1] }.toList()
-            val conditionalPlaceholders = conditionalRegex.findAll(template).map { it.groupValues[1] }.toList()
-
             // Check for empty placeholders
             if (template.contains("{{}}")) {
                 errors.add("Empty placeholder found")

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
@@ -57,7 +57,7 @@ object ChatRequestTransformers {
         log.trace("Processing chat request for $modelKey with context size: $contextSize tokens")
 
         // First, add custom system messages and remove duplicates
-        val requestWithCustomMessages = buildRequestWithCustomMessages(sessionId, chatRequest, memoryId)
+        val requestWithCustomMessages = buildRequestWithCustomMessages(sessionId, chatRequest)
 
         // Then, enforce token budget
         return enforceTokenBudget(requestWithCustomMessages, contextSize, provider, settings.defaultModel)
@@ -66,7 +66,6 @@ object ChatRequestTransformers {
     private fun buildRequestWithCustomMessages(
         sessionId: String?,
         chatRequest: ChatRequest,
-        @Suppress("UNUSED_PARAMETER") memoryId: Any?,
     ): ChatRequest {
         val existingMessages = chatRequest.messages()
 

--- a/shared/src/main/kotlin/io/askimo/tools/fs/LocalFsTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/fs/LocalFsTools.kt
@@ -1058,11 +1058,6 @@ object LocalFsTools {
         return control > n / 10
     }
 
-    private fun err(
-        code: String,
-        message: String,
-    ): Map<String, Any?> = mapOf("ok" to false, "error" to code, "message" to message)
-
     private fun humanReadable(bytes: Long): String {
         val units = arrayOf("B", "KB", "MB", "GB", "TB", "PB", "EB")
         var b = bytes.toDouble()


### PR DESCRIPTION
- Replace ad hoc Compose tooltips with themedTooltip across chat, MCP,
- project, telemetry, and directive screens for more consistent UI behavior
- Improve tooltip positioning logic and simplify localized strings by
- inlining content previously shown through separate labels
- Persist the selected directive when creating a new session so chat
- sessions retain the intended prompt context
- Refine desktop UI details, including footer resource display, session
- card styling, and directive dialog button spacing
- Add Detekt version and plugin coordinates while removing unused code,
- dead strings, and noisy exception handling
- Update tests to match filesystem cleanup and removed unused helpers