### PR TITLE
fix(publish-packages): wait for release assets before publishing formulas

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -33,28 +33,45 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"   # e.g. v0.4.0
           VERSION_PLAIN="${TAG#v}"                      # e.g. 0.4.0
           API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
-          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
 
           echo "Release : $TAG"
           echo "Draft   : ${{ github.event.release.draft }}"
           echo "Pre     : ${{ github.event.release.prerelease }}"
-          echo "Assets  :"
-          echo "$JSON" | jq -r '.assets[].name'
-          echo ""
 
           ARM_NAME="askimo-darwin-arm64.tar.gz"
           AMD_NAME="askimo-darwin-amd64.tar.gz"
 
-          ARM_URL="$(echo "$JSON" | jq -r --arg N "$ARM_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
-          AMD_URL="$(echo "$JSON" | jq -r --arg N "$AMD_NAME" '.assets[] | select(.name==$N) | .browser_download_url // empty')"
-          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
+          # Poll until the expected ARM asset appears (race condition: assets may still be uploading)
+          ARM_URL=""
+          SHA_URL=""
+          WAIT=0
+          MAX_WAIT=600   # 10 minutes
+          INTERVAL=20
+          until [ -n "${ARM_URL:-}" ] && [ -n "${SHA_URL:-}" ]; do
+            JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
+            echo "Assets  :"
+            echo "$JSON" | jq -r '.assets[].name'
+            echo ""
 
-          # If no macOS CLI binary is present this is a desktop-only release — skip silently
-          if [ -z "${ARM_URL:-}" ] || [ -z "${SHA_URL:-}" ]; then
-            echo "⚠️  No CLI macOS assets found — skipping homebrew (desktop-only release?)"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            ARM_URL="$(echo "$JSON" | jq -r --arg N "$ARM_NAME" '.assets[] | select(.name==$N) | .browser_download_url // empty')"
+            SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url // empty')"
+
+            if [ -n "${ARM_URL:-}" ] && [ -n "${SHA_URL:-}" ]; then
+              echo "✅ Required assets found."
+              break
+            fi
+
+            WAIT=$((WAIT + INTERVAL))
+            if [ "$WAIT" -ge "$MAX_WAIT" ]; then
+              echo "⚠️  No CLI macOS assets found after ${MAX_WAIT}s — skipping homebrew (desktop-only release?)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "⏳ Assets not ready yet — waiting ${INTERVAL}s (${WAIT}/${MAX_WAIT}s elapsed)..."
+            sleep "$INTERVAL"
+          done
+
+          AMD_URL="$(echo "$JSON" | jq -r --arg N "$AMD_NAME" '.assets[] | select(.name==$N) | .browser_download_url // empty')"
 
           curl -sSL -o SHA256SUMS.txt "$SHA_URL"
 
@@ -194,22 +211,40 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"
           VERSION_PLAIN="${TAG#v}"
           API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
-          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
 
           echo "Release : $TAG"
-          echo "Assets  :"
-          echo "$JSON" | jq -r '.assets[].name'
-          echo ""
 
           WIN_NAME="askimo-windows-x64.zip"
-          WIN_URL="$(echo "$JSON" | jq -r --arg N "$WIN_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
-          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
 
-          if [ -z "${WIN_URL:-}" ] || [ -z "${SHA_URL:-}" ]; then
-            echo "⚠️  No CLI Windows assets found — skipping scoop (desktop-only release?)"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Poll until the expected Windows asset appears
+          WIN_URL=""
+          SHA_URL=""
+          WAIT=0
+          MAX_WAIT=600   # 10 minutes
+          INTERVAL=20
+          until [ -n "${WIN_URL:-}" ] && [ -n "${SHA_URL:-}" ]; do
+            JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
+            echo "Assets  :"
+            echo "$JSON" | jq -r '.assets[].name'
+            echo ""
+
+            WIN_URL="$(echo "$JSON" | jq -r --arg N "$WIN_NAME" '.assets[] | select(.name==$N) | .browser_download_url // empty')"
+            SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url // empty')"
+
+            if [ -n "${WIN_URL:-}" ] && [ -n "${SHA_URL:-}" ]; then
+              echo "✅ Required assets found."
+              break
+            fi
+
+            WAIT=$((WAIT + INTERVAL))
+            if [ "$WAIT" -ge "$MAX_WAIT" ]; then
+              echo "⚠️  No CLI Windows assets found after ${MAX_WAIT}s — skipping scoop (desktop-only release?)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "⏳ Assets not ready yet — waiting ${INTERVAL}s (${WAIT}/${MAX_WAIT}s elapsed)..."
+            sleep "$INTERVAL"
+          done
 
           curl -sSL -o SHA256SUMS.txt "$SHA_URL"
           WIN_SHA="$(grep "  $WIN_NAME" SHA256SUMS.txt | awk '{print $1}')"
@@ -302,20 +337,41 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.release.tag_name }}"
           API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
-          JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
 
           AMD_NAME="askimo-linux-x64.tar.gz"
-          AMD_URL="$(echo "$JSON" | jq -r --arg N "$AMD_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
-
-          if [ -z "${AMD_URL:-}" ]; then
-            echo "⚠️  No CLI Linux x64 asset found — skipping docker (desktop-only release?)"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url')"
           ARM_NAME="askimo-linux-arm64.tar.gz"
-          ARM_URL="$(echo "$JSON" | jq -r --arg N "$ARM_NAME" '.assets[] | select(.name==$N) | .browser_download_url')"
+
+          # Poll until the expected Linux x64 asset appears (race condition: assets may still be uploading)
+          AMD_URL=""
+          SHA_URL=""
+          WAIT=0
+          MAX_WAIT=600   # 10 minutes
+          INTERVAL=20
+          until [ -n "${AMD_URL:-}" ] && [ -n "${SHA_URL:-}" ]; do
+            JSON="$(curl -sSL -H "Authorization: Bearer $GH_TOKEN" "$API")"
+            echo "Assets  :"
+            echo "$JSON" | jq -r '.assets[].name'
+            echo ""
+
+            AMD_URL="$(echo "$JSON" | jq -r --arg N "$AMD_NAME" '.assets[] | select(.name==$N) | .browser_download_url // empty')"
+            SHA_URL="$(echo "$JSON" | jq -r '.assets[] | select(.name=="SHA256SUMS.txt") | .browser_download_url // empty')"
+
+            if [ -n "${AMD_URL:-}" ] && [ -n "${SHA_URL:-}" ]; then
+              echo "✅ Required assets found."
+              break
+            fi
+
+            WAIT=$((WAIT + INTERVAL))
+            if [ "$WAIT" -ge "$MAX_WAIT" ]; then
+              echo "⚠️  No CLI Linux x64 asset found after ${MAX_WAIT}s — skipping docker (desktop-only release?)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "⏳ Assets not ready yet — waiting ${INTERVAL}s (${WAIT}/${MAX_WAIT}s elapsed)..."
+            sleep "$INTERVAL"
+          done
+
+          ARM_URL="$(echo "$JSON" | jq -r --arg N "$ARM_NAME" '.assets[] | select(.name==$N) | .browser_download_url // empty')"
 
           curl -sSL -o SHA256SUMS.txt "$SHA_URL"
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ cd askimo
 ./gradlew :desktop:package
 
 # Build CLI native binary (requires GraalVM)
-./gradlew :cli:nativeImage
+./gradlew :cli:nativeCompile
 ```
 
 ### Project Structure


### PR DESCRIPTION
- Poll GitHub release assets until CLI binaries are available
- Skip Docker publishing when Linux x64 assets never appear for desktop-only releases
- Make Homebrew and Scoop publishing more reliable against release timing races
- Reduce noisy asset logging and streamline workflow release checks
- Update README to use the current nativeCompile Gradle task