### PR TITLE
feat(agentic-execution): add built-in weather, web search, and datetime tools

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/providers/ChatRequestTransformersTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/ChatRequestTransformersTest.kt
@@ -49,6 +49,7 @@ class ChatRequestTransformersTest {
         AppContext.reset()
         databaseManager.close()
         DatabaseManager.reset()
+        ModelCapabilitiesCache.clear()
         testBaseScope.close()
     }
 
@@ -91,7 +92,9 @@ class ChatRequestTransformersTest {
         @Test
         @DisplayName("should truncate old messages when exceeding budget")
         fun shouldTruncateOldMessagesWhenExceedingBudget() {
-            // Given - create many large messages to exceed budget
+            val modelKey = ModelCapabilitiesCache.modelKey(ModelProvider.OPENAI, "gpt-3.5-turbo")
+            ModelCapabilitiesCache.update(modelKey) { it.copy(contextSize = 16_384) }
+
             val systemMessage = SystemMessage.from("System directive")
             val messages = mutableListOf<ChatMessage>(systemMessage)
 
@@ -105,7 +108,7 @@ class ChatRequestTransformersTest {
                 .messages(messages)
                 .build()
 
-            // When - using gpt-3.5-turbo with smaller context (typically 4096 tokens)
+            // When - using gpt-3.5-turbo with the forced small context (16 384 tokens)
             val result = ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(
                 sessionId = null,
                 chatRequest = chatRequest,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddMcpIntegrationDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddMcpIntegrationDialog.kt
@@ -1039,6 +1039,9 @@ private fun getCategoryDescription(category: ToolCategory): String = stringResou
         ToolCategory.VERSION_CONTROL -> "mcp.tool.category.VERSION_CONTROL.desc"
         ToolCategory.COMMUNICATION -> "mcp.tool.category.COMMUNICATION.desc"
         ToolCategory.MONITORING -> "mcp.tool.category.MONITORING.desc"
+        ToolCategory.WEATHER -> "mcp.tool.category.WEATHER.desc"
+        ToolCategory.WEB_SEARCH -> "mcp.tool.category.WEB_SEARCH.desc"
+        ToolCategory.DATETIME -> "mcp.tool.category.DATETIME.desc"
         ToolCategory.OTHER -> "mcp.tool.category.OTHER.desc"
     },
 )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsViewModel.kt
@@ -355,7 +355,7 @@ class SessionsViewModel(
 
                 // Set state to show dialog
                 renameSessionId = sessionId
-                renameCurrentTitle = session.title ?: ""
+                renameCurrentTitle = session.title
                 showRenameDialog = true
             } catch (e: Exception) {
                 errorMessage = ErrorHandler.getUserFriendlyError(

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1014,6 +1014,9 @@ mcp.tool.category.TRANSFORM.desc=Data transformation
 mcp.tool.category.VERSION_CONTROL.desc=Git and version control
 mcp.tool.category.COMMUNICATION.desc=Email, messaging, notifications
 mcp.tool.category.MONITORING.desc=Logging and monitoring
+mcp.tool.category.WEATHER.desc=Weather data and forecasts
+mcp.tool.category.WEB_SEARCH.desc=Web search and page reading
+mcp.tool.category.DATETIME.desc=Date and time operations
 mcp.tool.category.OTHER.desc=Unclassified tools
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1021,6 +1021,9 @@ mcp.tool.category.TRANSFORM.desc=Datentransformation
 mcp.tool.category.VERSION_CONTROL.desc=Git und Versionskontrolle
 mcp.tool.category.COMMUNICATION.desc=E-Mail, Messaging, Benachrichtigungen
 mcp.tool.category.MONITORING.desc=Protokollierung und Überwachung
+mcp.tool.category.WEATHER.desc=Wetterdaten und Vorhersagen
+mcp.tool.category.DATETIME.desc=Datums- und Zeitoperationen
+mcp.tool.category.WEB_SEARCH.desc=Websuche und Seitenlesen
 mcp.tool.category.OTHER.desc=Nicht klassifizierte Tools
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1019,6 +1019,9 @@ mcp.tool.category.TRANSFORM.desc=Transformación de datos
 mcp.tool.category.VERSION_CONTROL.desc=Git y control de versiones
 mcp.tool.category.COMMUNICATION.desc=Correo electrónico, mensajería, notificaciones
 mcp.tool.category.MONITORING.desc=Registro y monitoreo
+mcp.tool.category.WEATHER.desc=Datos meteorológicos y pronósticos
+mcp.tool.category.DATETIME.desc=Operaciones de fecha y hora
+mcp.tool.category.WEB_SEARCH.desc=Búsqueda web y lectura de páginas
 mcp.tool.category.OTHER.desc=Herramientas sin clasificar
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1019,6 +1019,9 @@ mcp.tool.category.TRANSFORM.desc=Transformation de données
 mcp.tool.category.VERSION_CONTROL.desc=Git et gestion de versions
 mcp.tool.category.COMMUNICATION.desc=E-mail, messagerie, notifications
 mcp.tool.category.MONITORING.desc=Journalisation et surveillance
+mcp.tool.category.WEATHER.desc=Données météo et prévisions
+mcp.tool.category.DATETIME.desc=Opérations de date et heure
+mcp.tool.category.WEB_SEARCH.desc=Recherche web et lecture de pages
 mcp.tool.category.OTHER.desc=Outils non classifiés
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1019,6 +1019,9 @@ mcp.tool.category.TRANSFORM.desc=データ変換
 mcp.tool.category.VERSION_CONTROL.desc=Git およびバージョン管理
 mcp.tool.category.COMMUNICATION.desc=メール、メッセージ、通知
 mcp.tool.category.MONITORING.desc=ログ記録および監視
+mcp.tool.category.WEATHER.desc=天気データと予報
+mcp.tool.category.DATETIME.desc=日付・時刻操作
+mcp.tool.category.WEB_SEARCH.desc=ウェブ検索とページ読み取り
 mcp.tool.category.OTHER.desc=未分類のツール
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1019,6 +1019,9 @@ mcp.tool.category.TRANSFORM.desc=데이터 변환
 mcp.tool.category.VERSION_CONTROL.desc=Git 및 버전 관리
 mcp.tool.category.COMMUNICATION.desc=이메일, 메시징, 알림
 mcp.tool.category.MONITORING.desc=로깅 및 모니터링
+mcp.tool.category.WEATHER.desc=날씨 데이터 및 예보
+mcp.tool.category.DATETIME.desc=날짜 및 시간 작업
+mcp.tool.category.WEB_SEARCH.desc=웹 검색 및 페이지 읽기
 mcp.tool.category.OTHER.desc=분류되지 않은 도구
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1019,6 +1019,9 @@ mcp.tool.category.TRANSFORM.desc=Transformação de dados
 mcp.tool.category.VERSION_CONTROL.desc=Git e controle de versão
 mcp.tool.category.COMMUNICATION.desc=E-mail, mensagens, notificações
 mcp.tool.category.MONITORING.desc=Registro e monitoramento
+mcp.tool.category.WEATHER.desc=Dados meteorológicos e previsões
+mcp.tool.category.DATETIME.desc=Operações de data e hora
+mcp.tool.category.WEB_SEARCH.desc=Pesquisa na web e leitura de páginas
 mcp.tool.category.OTHER.desc=Ferramentas não classificadas
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1018,6 +1018,9 @@ mcp.tool.category.TRANSFORM.desc=Chuyển đổi dữ liệu
 mcp.tool.category.VERSION_CONTROL.desc=Git và quản lý phiên bản
 mcp.tool.category.COMMUNICATION.desc=Email, nhắn tin, thông báo
 mcp.tool.category.MONITORING.desc=Ghi log và giám sát
+mcp.tool.category.WEATHER.desc=Dữ liệu thời tiết và dự báo
+mcp.tool.category.DATETIME.desc=Các thao tác ngày và giờ
+mcp.tool.category.WEB_SEARCH.desc=Tìm kiếm web và đọc trang
 mcp.tool.category.OTHER.desc=Công cụ chưa phân loại
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1020,6 +1020,9 @@ mcp.tool.category.TRANSFORM.desc=資料轉換
 mcp.tool.category.VERSION_CONTROL.desc=Git 與版本控制
 mcp.tool.category.COMMUNICATION.desc=電子郵件、訊息、通知
 mcp.tool.category.MONITORING.desc=日誌與監控
+mcp.tool.category.WEATHER.desc=天气数据和预报
+mcp.tool.category.DATETIME.desc=日期和时间操作
+mcp.tool.category.WEB_SEARCH.desc=网页搜索和页面读取
 mcp.tool.category.OTHER.desc=未分類工具
 
 # MCP Validation

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1021,6 +1021,9 @@ mcp.tool.category.TRANSFORM.desc=資料轉換
 mcp.tool.category.VERSION_CONTROL.desc=Git 與版本控制
 mcp.tool.category.COMMUNICATION.desc=電子郵件、訊息、通知
 mcp.tool.category.MONITORING.desc=日誌與監控
+mcp.tool.category.WEATHER.desc=天氣資料與預報
+mcp.tool.category.DATETIME.desc=日期與時間操作
+mcp.tool.category.WEB_SEARCH.desc=網頁搜尋與頁面讀取
 mcp.tool.category.OTHER.desc=未分類工具
 
 # MCP Validation

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -348,6 +348,9 @@ tasks.test {
 
 kotlin {
     jvmToolchain(21)
+    compilerOptions {
+        javaParameters = true
+    }
 }
 
 // Task to check for missing i18n keys across language files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.2.25
+projectVersion=1.2.26
 
 # About information
 author=Hai Nguyen

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -76,4 +76,9 @@ tasks.test {
 }
 kotlin {
     jvmToolchain(21)
+    compilerOptions {
+        // Preserve parameter names in bytecode so LangChain4j @Tool/@P reflection works correctly.
+        // Without this, tool method parameters appear as arg0, arg1 in the LLM's tool schema.
+        javaParameters = true
+    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -20,9 +20,7 @@ import io.askimo.core.chat.repository.ChatSessionRepository
 import io.askimo.core.chat.repository.PaginationDirection
 import io.askimo.core.chat.repository.ProjectRepository
 import io.askimo.core.chat.repository.SessionMemoryRepository
-import io.askimo.core.chat.util.ExtractedUrlContent
 import io.askimo.core.chat.util.FileContentExtractor
-import io.askimo.core.chat.util.UrlContentExtractor
 import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.MessageRole
@@ -635,22 +633,6 @@ class ChatSessionService(
         userMessage: ChatMessageDTO,
         willSaveUserMessage: Boolean,
     ): UserMessage {
-        val urls = UrlContentExtractor.extractUrls(userMessage.content)
-        val urlContents = urls.mapNotNull { url ->
-            if (!UrlIntentDetector.shouldExtractUrlContent(userMessage.content, url)) {
-                log.debug("Skipping URL content extraction for: $url (no explicit intent detected)")
-                return@mapNotNull null
-            }
-
-            log.info("Extracting URL content for: $url (explicit user intent detected)")
-            try {
-                UrlContentExtractor.extractContent(url)
-            } catch (e: Exception) {
-                log.warn("Failed to fetch URL content for $url: ${e.message}", e)
-                null
-            }
-        }
-
         if (willSaveUserMessage) {
             messageRepository.addMessage(
                 ChatMessage(
@@ -681,7 +663,7 @@ class ChatSessionService(
         }
 
         // Construct enriched message with attachments and URL contents
-        val enrichedContent = constructMessageWithAttachmentsAndUrls(userMessage, urlContents)
+        val enrichedContent = constructMessageWithAttachmentsAndUrls(userMessage)
 
         // Create enriched ChatMessageDTO with combined content but preserve image attachments
         val enrichedMessage = userMessage.copy(content = enrichedContent)
@@ -694,12 +676,10 @@ class ChatSessionService(
      * Constructs a formatted message with both file attachments and extracted URL contents.
      *
      * @param userMessage The original user message
-     * @param urlContents List of extracted URL contents
      * @return Formatted message with attachments and URL contents appended
      */
     private fun constructMessageWithAttachmentsAndUrls(
         userMessage: ChatMessageDTO,
-        urlContents: List<ExtractedUrlContent>,
     ): String = buildString {
         userMessage.attachments.forEach { attachment ->
             val content = when {
@@ -734,21 +714,6 @@ class ChatSessionService(
                 appendLine("File size: ${formatFileSize(attachment.size)}")
                 appendLine()
                 appendLine(content)
-                appendLine("---")
-                appendLine()
-            }
-        }
-
-        // Add URL contents if present
-        if (urlContents.isNotEmpty()) {
-            urlContents.forEach { content ->
-                appendLine("---")
-                appendLine("URL: ${content.url}")
-                if (content.title != null) {
-                    appendLine("Title: ${content.title}")
-                }
-                appendLine()
-                appendLine(content.content)
                 appendLine("---")
                 appendLine()
             }

--- a/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
-import org.koin.java.KoinJavaComponent
+import org.koin.java.KoinJavaComponent.getKoin
 import java.util.Locale
 
 /**
@@ -445,7 +445,7 @@ class AppContext private constructor(
      * @return ToolProvider instance or null if not available
      */
     fun getToolProvider(): ToolProvider? = try {
-        KoinJavaComponent.getKoin().getOrNull<ToolProviderImpl>()
+        getKoin().getOrNull<ToolProviderImpl>()
     } catch (_: Exception) {
         log.debug("ToolProvider not available (Koin not initialized or CLI mode)")
         null

--- a/shared/src/main/kotlin/io/askimo/core/intent/IntentDetectionChain.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/IntentDetectionChain.kt
@@ -15,6 +15,8 @@ import io.askimo.core.intent.detectors.SearchDetector
 import io.askimo.core.intent.detectors.TransformDetector
 import io.askimo.core.intent.detectors.VersionControlDetector
 import io.askimo.core.intent.detectors.VisualizationDetector
+import io.askimo.core.intent.detectors.WeatherDetector
+import io.askimo.core.intent.detectors.WebSearchDetector
 
 /**
  * Chain of Responsibility pattern for intent detection.
@@ -61,6 +63,8 @@ class IntentDetectionChain(
             DatabaseDetector(),
             NetworkDetector(),
             SearchDetector(),
+            WeatherDetector(),
+            WebSearchDetector(),
             TransformDetector(),
             VersionControlDetector(),
             CommunicationDetector(),

--- a/shared/src/main/kotlin/io/askimo/core/intent/ToolConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/ToolConfig.kt
@@ -136,6 +136,24 @@ enum class ToolCategory {
     MONITORING,
 
     /**
+     * Weather data retrieval: current conditions, forecasts
+     * Examples: get_weather, weather_forecast, check_temperature
+     */
+    WEATHER,
+
+    /**
+     * Web search and page reading: live internet searches, page content extraction
+     * Examples: search_web, read_web_page, browse_url
+     */
+    WEB_SEARCH,
+
+    /**
+     * Date and time operations: current date/time, timezone conversion, date arithmetic
+     * Examples: get_current_datetime, convert_timezone, days_until
+     */
+    DATETIME,
+
+    /**
      * Other/unclassified tools that don't fit into above categories
      */
     OTHER,

--- a/shared/src/main/kotlin/io/askimo/core/intent/ToolRegistry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/ToolRegistry.kt
@@ -7,6 +7,9 @@ package io.askimo.core.intent
 import dev.langchain4j.agent.tool.ToolSpecifications
 import io.askimo.core.logging.logger
 import io.askimo.tools.chart.ChartTools
+import io.askimo.tools.datetime.DateTimeTools
+import io.askimo.tools.weather.WeatherTools
+import io.askimo.tools.web.WebSearchTools
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -33,6 +36,48 @@ object ToolRegistry {
                     specification = toolSpec,
                     category = ToolCategory.VISUALIZE,
                     strategy = ToolStrategy.BOTH,
+                    source = ToolSource.ASKIMO_BUILTIN,
+                    serverId = BUILTIN_SERVER_ID,
+                ),
+            )
+        }
+
+        // Register weather tools — intent-based (user asks) + follow-up (AI suggests after a trip plan)
+        val weatherTools = ToolSpecifications.toolSpecificationsFrom(WeatherTools)
+        weatherTools.forEach { toolSpec ->
+            register(
+                ToolConfig(
+                    specification = toolSpec,
+                    category = ToolCategory.WEATHER,
+                    strategy = ToolStrategy.BOTH,
+                    source = ToolSource.ASKIMO_BUILTIN,
+                    serverId = BUILTIN_SERVER_ID,
+                ),
+            )
+        }
+
+        // Register web search tools — intent-based (user asks) + follow-up (AI uses when researching)
+        val webSearchTools = ToolSpecifications.toolSpecificationsFrom(WebSearchTools)
+        webSearchTools.forEach { toolSpec ->
+            register(
+                ToolConfig(
+                    specification = toolSpec,
+                    category = ToolCategory.WEB_SEARCH,
+                    strategy = ToolStrategy.BOTH,
+                    source = ToolSource.ASKIMO_BUILTIN,
+                    serverId = BUILTIN_SERVER_ID,
+                ),
+            )
+        }
+
+        // Register date/time tools — intent-based (user asks about current date/time, conversions)
+        val dateTimeTools = ToolSpecifications.toolSpecificationsFrom(DateTimeTools)
+        dateTimeTools.forEach { toolSpec ->
+            register(
+                ToolConfig(
+                    specification = toolSpec,
+                    category = ToolCategory.DATETIME,
+                    strategy = ToolStrategy.INTENT_BASED,
                     source = ToolSource.ASKIMO_BUILTIN,
                     serverId = BUILTIN_SERVER_ID,
                 ),

--- a/shared/src/main/kotlin/io/askimo/core/intent/detectors/WeatherWebSearchDetectors.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/detectors/WeatherWebSearchDetectors.kt
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.core.intent.detectors
+
+import io.askimo.core.intent.BaseIntentDetector
+import io.askimo.core.intent.ToolCategory
+
+/**
+ * Detector for weather-related queries.
+ * Triggers on requests for current conditions, forecasts, temperature, and climate data.
+ */
+class WeatherDetector :
+    BaseIntentDetector(
+        category = ToolCategory.WEATHER,
+        directKeywords = listOf(
+            "weather", "forecast", "temperature", "humidity",
+            "wind speed", "raining", "snowing", "sunny", "cloudy",
+            "precipitation", "climate", "next week weather", "weekly forecast",
+        ),
+        contextualPatterns = listOf(
+            "\\bweather\\b.*\\bin\\b", "\\bweather\\b.*\\bfor\\b",
+            "\\bforecast\\b.*\\bfor\\b", "\\bforecast\\b.*\\bin\\b", "\\bforecast\\b.*\\bnext\\b",
+            "\\btemperature\\b.*\\bin\\b", "\\btemperature\\b.*\\bat\\b",
+            "\\bwill\\b.*\\brain\\b", "\\bwill\\b.*\\bsnow\\b", "\\bwill\\b.*\\bsunny\\b",
+            "\\bis\\b.*\\braining\\b", "\\bis\\b.*\\bsnowing\\b",
+            "\\bhot\\b.*\\bin\\b", "\\bcold\\b.*\\bin\\b",
+            "\\bwhat.*\\bweather\\b", "\\bhow.*\\bweather\\b",
+            "\\bpack\\b.*\\bumbrel", "\\bneed\\b.*\\bcoat\\b",
+            "\\btrip\\b.*\\bweather\\b", "\\btravel\\b.*\\bweather\\b",
+            "\\bweekend\\b.*\\bweather\\b", "\\bweather\\b.*\\bweekend\\b",
+            "\\bcurrent\\b.*\\bconditions\\b", "\\bweather\\b.*\\bnow\\b",
+            "\\bhow.*\\bwarm\\b", "\\bhow.*\\bcold\\b", "\\bhow.*\\bhot\\b",
+            // Multi-day forecast patterns
+            "\\bnext\\b.*\\bdays\\b", "\\bnext\\b.*\\bweek\\b",
+            "\\b\\d+\\s*days?\\b.*\\bweather\\b", "\\bweather\\b.*\\b\\d+\\s*days?\\b",
+            "\\bforecast\\b.*\\b\\d+\\s*days?\\b", "\\b\\d+\\s*days?\\b.*\\bforecast\\b",
+            "\\bweather\\b.*\\bnext\\b", "\\bnext\\b.*\\bforecast\\b",
+            "\\btomorrow\\b.*\\bweather\\b", "\\bweather\\b.*\\btomorrow\\b",
+            "\\bthis\\b.*\\bweek\\b.*\\bweather\\b", "\\bweather\\b.*\\bthis\\b.*\\bweek\\b",
+        ),
+    )
+
+/**
+ * Detector for live web search and page reading queries.
+ * Triggers on requests for internet search, browsing URLs, or reading web pages.
+ */
+class WebSearchDetector :
+    BaseIntentDetector(
+        category = ToolCategory.WEB_SEARCH,
+        directKeywords = listOf(
+            "search the web", "web search", "google", "browse", "look it up",
+            "search online", "internet search", "brave search",
+            "read this url", "read this page", "read this link",
+            "open this link", "visit this url", "fetch this page",
+            "what does this url say", "latest news", "recent news",
+        ),
+        contextualPatterns = listOf(
+            "\\bsearch\\b.*\\bweb\\b", "\\bsearch\\b.*\\bonline\\b", "\\bsearch\\b.*\\binternet\\b",
+            "\\bweb\\b.*\\bsearch\\b", "\\bonline\\b.*\\bsearch\\b",
+            "\\bgoogle\\b.*\\bfor\\b", "\\bgoogle\\b.*\\babout\\b",
+            "\\bbrowse\\b.*\\bweb\\b", "\\bbrowse\\b.*\\binternet\\b",
+            "\\bread\\b.*\\bpage\\b", "\\bread\\b.*\\burl\\b", "\\bread\\b.*\\blink\\b",
+            "\\bopen\\b.*\\burl\\b", "\\bopen\\b.*\\blink\\b",
+            "\\bvisit\\b.*\\burl\\b", "\\bvisit\\b.*\\bsite\\b", "\\bvisit\\b.*\\bpage\\b",
+            "\\bfetch\\b.*\\bpage\\b", "\\bfetch\\b.*\\burl\\b", "\\bfetch\\b.*\\bsite\\b",
+            "\\blatest\\b.*\\bnews\\b", "\\bcurrent\\b.*\\bnews\\b", "\\brecent\\b.*\\bnews\\b",
+            "\\bwhat.*\\bsays\\b.*\\burl\\b", "\\bwhat.*\\burl\\b.*\\bsay\\b",
+            "\\blook\\b.*\\bup\\b.*\\bonline\\b", "\\blook\\b.*\\bup\\b.*\\bweb\\b",
+            "https?://\\S+", // direct URL pasted in message
+            "\\bwww\\.\\S+", // www. domain reference
+        ),
+    ) {
+    override fun detectDirectKeywords(message: String): Boolean {
+        // Check for URLs in the message (http:// or https:// or www.)
+        if (message.contains(Regex("https?://\\S+|www\\.\\S+"))) return true
+        return directKeywords.any { message.contains(it) }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
@@ -120,17 +120,57 @@ fun ChatMessage.getTextContent(): String = when (this) {
 
 /**
  * Returns a copy of this [ChatMessage] with all inline base64 images stripped.
- * The message type is preserved; only the text content is sanitised.
+ * The message type and all other attributes (tool calls, tool execution id, name, etc.)
+ * are preserved — only base64 image data in text content is replaced with placeholders.
  */
-fun ChatMessage.stripImages(): ChatMessage {
-    val stripped = MemoryMessage.stripBase64Images(getTextContent())
-    return when (this) {
-        is UserMessage -> UserMessage.from(stripped)
-        is AiMessage -> AiMessage.from(stripped)
-        is SystemMessage -> SystemMessage.from(stripped)
-        is ToolExecutionResultMessage -> ToolExecutionResultMessage.builder().text(stripped).build()
-        else -> UserMessage.from(stripped)
+fun ChatMessage.stripImages(): ChatMessage = when (this) {
+    is AiMessage -> {
+        val strippedText = text()?.let { MemoryMessage.stripBase64Images(it) }
+        // Preserve tool execution requests — they must not be lost when stripping images
+        if (hasToolExecutionRequests()) {
+            if (strippedText != null) {
+                AiMessage.from(strippedText, toolExecutionRequests())
+            } else {
+                AiMessage.from(toolExecutionRequests())
+            }
+        } else {
+            AiMessage.from(strippedText ?: "")
+        }
     }
+
+    is UserMessage -> {
+        // Filter out ImageContent parts with base64 src; keep all other content parts
+        val filteredContents = contents().filter { content ->
+            content !is dev.langchain4j.data.message.ImageContent ||
+                content.image().url() != null // keep URL-based images, drop base64-only
+        }
+        // Strip base64 image markdown from any TextContent parts
+        val sanitisedContents = filteredContents.map { content ->
+            if (content is dev.langchain4j.data.message.TextContent) {
+                dev.langchain4j.data.message.TextContent.from(
+                    MemoryMessage.stripBase64Images(content.text()),
+                )
+            } else {
+                content
+            }
+        }
+        if (name() != null) {
+            UserMessage.from(name(), sanitisedContents)
+        } else {
+            UserMessage.from(sanitisedContents)
+        }
+    }
+
+    is SystemMessage -> SystemMessage.from(MemoryMessage.stripBase64Images(text()))
+
+    is ToolExecutionResultMessage ->
+        ToolExecutionResultMessage.from(
+            id(),
+            toolName(),
+            MemoryMessage.stripBase64Images(text() ?: ""),
+        )
+
+    else -> this
 }
 
 /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/AiServiceBuilder.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/AiServiceBuilder.kt
@@ -179,7 +179,7 @@ object AiServiceBuilder {
             }
 
         if (toolProvider != null) {
-            builder.toolProvider(toolProvider).maxSequentialToolsInvocations(3)
+            builder.toolProvider(toolProvider).maxSequentialToolsInvocations(10)
         }
 
         if (retriever != null) {
@@ -206,18 +206,21 @@ object AiServiceBuilder {
      * Can be overridden by passing custom instructions to buildChatClient.
      */
     fun defaultToolResponseFormatInstructions(): String = """
-        Tool response format:
-        • All tools return: { "success": boolean, "output": string, "error": string, "metadata": object }
-        • success=true: Tool executed successfully, check "output" for results and "metadata" for structured data
-        • success=false: Tool failed, check "error" for reason
-        • Always check the "success" field before using "output"
-        • If success=false, inform the user about the error from the "error" field
-        • When success=true, extract data from "metadata" field for detailed information
+    Tool response format:
+    • All tools return: { "success": boolean, "output": string, "error": string, "metadata": object }
+    • success=true: Tool executed successfully, check "output" for results and "metadata" for structured data
+    • success=false: Tool failed, check "error" for reason
+    • Always check the "success" field before using "output"
+    • If success=false, inform the user about the error from the "error" field
+    • When success=true, extract data from "metadata" field for detailed information
 
-        Tool execution guidelines:
-        • Parse the tool response JSON before responding to user
-        • If success=true: Use the output and metadata to answer user's question
-        • If success=false: Explain what went wrong using the error message
-        • Never assume tool success without checking the response
+    Tool execution guidelines:
+    • Parse the tool response JSON before responding to user
+    • If success=true: Use the output and metadata to answer the user IMMEDIATELY — do NOT call the same tool again
+    • If success=false: Explain what went wrong using the error message
+    • Never assume tool success without checking the response
+    • STOP calling tools as soon as you have enough information to answer the user
+    • Do NOT call the same tool twice with the same or similar arguments
+    • If a tool returns success=true with data, synthesise the answer and respond directly — do not retry
     """.trimIndent()
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -119,13 +119,9 @@ fun ChatClient.sendStreamingMessageWithCallback(
                             }
                             done.countDown()
                         }.onToolExecuted { tool ->
-//                            if (tool.hasFailed()) {
-//                                throw ToolExecutionException(
-//                                    toolName = tool.request().name() ?: "unknown",
-//                                    errorDetails = tool.result(),
-//                                )
-//                            }
-                        }.onError { e ->
+                            log.debug("Tool executed: {}", tool)
+                        }
+                        .onError { e ->
                             errorOccurred = true
                             capturedError = e
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
@@ -69,25 +69,23 @@ object ChatRequestTransformers {
     ): ChatRequest {
         val existingMessages = chatRequest.messages()
 
-        val existingSystemMessageTexts = existingMessages
-            .filterIsInstance<SystemMessage>()
-            .map { it.text() }
-            .toSet()
+        val existingSystemMessages = existingMessages.filterIsInstance<SystemMessage>()
+        val existingSystemMessageTexts = existingSystemMessages.map { it.text() }.toSet()
 
         val nonSystemMessages = existingMessages.filterNot { it is SystemMessage }
 
-        val newSystemMessages = mutableListOf<SystemMessage>()
+        val additionalSystemMessages = mutableListOf<SystemMessage>()
 
-        // Add language directive if set
+        // Add language directive if set and not already present
         val appSystemDirective = AppContext.getInstance().systemLanguageDirective
         if (appSystemDirective != null && appSystemDirective !in existingSystemMessageTexts) {
-            newSystemMessages.add(SystemMessage.from(appSystemDirective))
+            additionalSystemMessages.add(SystemMessage.from(appSystemDirective))
         }
 
-        // Add user profile directive if set
+        // Add user profile directive if set and not already present
         val userProfileDirective = AppContext.getInstance().userProfileDirective
         if (userProfileDirective != null && userProfileDirective !in existingSystemMessageTexts) {
-            newSystemMessages.add(SystemMessage.from(userProfileDirective))
+            additionalSystemMessages.add(SystemMessage.from(userProfileDirective))
         }
 
         if (sessionId != null) {
@@ -96,11 +94,13 @@ object ChatRequestTransformers {
                 directive.content.isNotBlank() &&
                 directive.content !in existingSystemMessageTexts
             ) {
-                newSystemMessages.add(SystemMessage.from(directive.content))
+                additionalSystemMessages.add(SystemMessage.from(directive.content))
             }
         }
 
-        val rebuiltMessages = newSystemMessages + nonSystemMessages
+        // Preserve existing system messages (e.g. tool instructions from AiServiceBuilder),
+        // append new non-duplicate ones after, then all conversation messages
+        val rebuiltMessages = existingSystemMessages + additionalSystemMessages + nonSystemMessages
         return chatRequest.toBuilder().messages(rebuiltMessages).build()
     }
 
@@ -121,18 +121,16 @@ object ChatRequestTransformers {
         model: String,
     ): ChatRequest {
         val messages = chatRequest.messages()
-        // Reserve percentage of context for AI response
+
         val reservedForResponse = (maxTokens * RESPONSE_RESERVE_PERCENT).toInt()
         val availableForMessages = maxTokens - reservedForResponse
 
         val keptMessages = mutableListOf<ChatMessage>()
         var totalTokens = 0
 
-        // Separate system and non-system messages
         val systemMessages = messages.filterIsInstance<SystemMessage>()
         val nonSystemMessages = messages.filterNot { it is SystemMessage }
 
-        // Always keep system messages (they're critical for behavior)
         systemMessages.forEach { msg ->
             val tokens = estimateTokens(getMessageText(msg))
             totalTokens += tokens

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -79,7 +79,7 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
                 .temperature(AppConfig.chat.samplingTemperature)
                 .logger(log)
                 .logRequests(log.isDebugEnabled)
-                .logResponses(log.isTraceEnabled)
+                .logResponses(log.isDebugEnabled)
                 .listeners(listOf(TelemetryChatModelListener(telemetry, OPENAI.name.lowercase())))
                 .build()
 

--- a/shared/src/main/kotlin/io/askimo/tools/datetime/DateTimeTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/datetime/DateTimeTools.kt
@@ -1,0 +1,374 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.tools.datetime
+
+import dev.langchain4j.agent.tool.P
+import dev.langchain4j.agent.tool.Tool
+import io.askimo.tools.ToolResponseBuilder
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.format.TextStyle
+import java.util.Locale
+
+/**
+ * Date and time tools that give the AI accurate current temporal context
+ * without relying on training-data knowledge of "today".
+ *
+ * - [getCurrentDateTime]: Current local date and time in a given timezone.
+ * - [convertTimezone]: Convert a datetime from one timezone to another.
+ * - [calculateDateDiff]: Number of days between two dates.
+ * - [addDaysToDate]: Add or subtract days from a date.
+ */
+@Suppress("unused")
+object DateTimeTools {
+
+    private const val CLASS_NAME = "io.askimo.tools.datetime.DateTimeTools"
+
+    private val isoDateFormatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+
+    @Tool(
+        """Get the current date and time for a given timezone (or the system local timezone).
+
+Use this tool when the user asks about:
+- What is today's date?
+- What time is it now (in a city / timezone)?
+- What day of the week is today?
+- Current date and time in any location
+
+TIMEZONE PARAMETER:
+- Accept IANA timezone IDs: "America/New_York", "Europe/London", "Asia/Tokyo", "UTC"
+- Also accept common abbreviations: "PST", "EST", "GMT", "IST" (mapped internally)
+- If the user does not specify a timezone, pass an empty string — the system local timezone will be used.
+
+OUTPUT FORMAT:
+Present the date and time in a human-friendly format. Include:
+- Full date (e.g., Monday, April 7, 2026)
+- Time with timezone abbreviation (e.g., 14:35 JST)
+- Day of the week
+""",
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"getCurrentDateTime\" }",
+    )
+    fun getCurrentDateTime(
+        @P("IANA timezone ID (e.g. 'America/New_York', 'Asia/Tokyo', 'UTC'). Leave empty for system local time.")
+        timezone: String = "",
+    ): String = try {
+        val zone = resolveZone(timezone)
+        val now = ZonedDateTime.now(zone)
+        val dateStr = now.format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy", Locale.ENGLISH))
+        val timeStr = now.format(DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ENGLISH))
+        val tzAbbr = now.zone.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)
+        val tzFull = now.zone.id
+
+        ToolResponseBuilder.successWithData(
+            output = buildString {
+                appendLine("Current date and time:")
+                appendLine("Date: $dateStr")
+                appendLine("Time: $timeStr $tzAbbr ($tzFull)")
+                appendLine("Day of week: ${now.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH)}")
+                appendLine("ISO: ${now.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)}")
+            }.trim(),
+            data = mapOf(
+                "date" to now.toLocalDate().toString(),
+                "time" to timeStr,
+                "datetime_iso" to now.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                "day_of_week" to now.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH),
+                "timezone_id" to tzFull,
+                "timezone_abbr" to tzAbbr,
+                "year" to now.year,
+                "month" to now.monthValue,
+                "day" to now.dayOfMonth,
+                "hour" to now.hour,
+                "minute" to now.minute,
+            ),
+        )
+    } catch (e: Exception) {
+        ToolResponseBuilder.failure(
+            error = "Could not get current date/time: ${e.message}",
+            metadata = mapOf("timezone" to timezone),
+        )
+    }
+
+    @Tool(
+        """Convert a date and time from one timezone to another.
+
+Use this tool when the user asks:
+- "What time is 3pm New York in London?"
+- "Convert 09:00 Tokyo time to UTC"
+- "If it's 14:00 in Paris, what time is it in Los Angeles?"
+
+PARAMETERS:
+- datetime: The date and time to convert, in format "yyyy-MM-dd HH:mm" or "yyyy-MM-dd HH:mm:ss"
+- fromTimezone: Source IANA timezone ID (e.g. "America/New_York")
+- toTimezone: Target IANA timezone ID (e.g. "Europe/London")
+
+OUTPUT FORMAT:
+Show both the original and converted datetime clearly with their timezone names.
+""",
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"convertTimezone\" }",
+    )
+    fun convertTimezone(
+        @P("Date and time to convert, e.g. '2026-04-07 14:30' or '2026-04-07 14:30:00'")
+        datetime: String,
+        @P("Source IANA timezone ID, e.g. 'America/New_York', 'UTC', 'Asia/Tokyo'")
+        fromTimezone: String,
+        @P("Target IANA timezone ID, e.g. 'Europe/London', 'Asia/Singapore'")
+        toTimezone: String,
+    ): String = try {
+        val fromZone = resolveZone(fromTimezone)
+        val toZone = resolveZone(toTimezone)
+
+        val localDt = parseDateTime(datetime)
+            ?: return ToolResponseBuilder.failure(
+                error = "Could not parse datetime: \"$datetime\". Use format 'yyyy-MM-dd HH:mm' or 'yyyy-MM-dd HH:mm:ss'.",
+                metadata = mapOf("datetime" to datetime, "fromTimezone" to fromTimezone, "toTimezone" to toTimezone),
+            )
+
+        val fromZoned = ZonedDateTime.of(localDt, fromZone)
+        val toZoned = fromZoned.withZoneSameInstant(toZone)
+
+        val fmt = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy 'at' HH:mm:ss", Locale.ENGLISH)
+
+        ToolResponseBuilder.successWithData(
+            output = buildString {
+                appendLine("Timezone conversion result:")
+                appendLine("From: ${fromZoned.format(fmt)} ${fromZone.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)} (${fromZone.id})")
+                appendLine("To:   ${toZoned.format(fmt)} ${toZone.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)} (${toZone.id})")
+            }.trim(),
+            data = mapOf(
+                "original_datetime" to fromZoned.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                "converted_datetime" to toZoned.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                "from_timezone" to fromZone.id,
+                "to_timezone" to toZone.id,
+                "from_date" to fromZoned.toLocalDate().toString(),
+                "to_date" to toZoned.toLocalDate().toString(),
+                "from_time" to fromZoned.toLocalTime().toString(),
+                "to_time" to toZoned.toLocalTime().toString(),
+            ),
+        )
+    } catch (e: Exception) {
+        ToolResponseBuilder.failure(
+            error = "Timezone conversion failed: ${e.message}",
+            metadata = mapOf("datetime" to datetime, "fromTimezone" to fromTimezone, "toTimezone" to toTimezone),
+        )
+    }
+
+    @Tool(
+        """Calculate the number of days between two dates.
+
+Use this tool when the user asks:
+- "How many days until Christmas / New Year / my birthday?"
+- "How many days between date A and date B?"
+- "How long ago was [date]?"
+- "How many days until / since [event]?"
+
+PARAMETERS:
+- fromDate: Start date in ISO format "yyyy-MM-dd"
+- toDate: End date in ISO format "yyyy-MM-dd"
+
+If the user asks about days until/since a future/past event without knowing "today",
+first call getCurrentDateTime to get today's date, then call this tool.
+
+OUTPUT FORMAT:
+State the number of days clearly. For large numbers also show years and months.
+""",
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"calculateDateDiff\" }",
+    )
+    fun calculateDateDiff(
+        @P("Start date in ISO format, e.g. '2026-01-01'")
+        fromDate: String,
+        @P("End date in ISO format, e.g. '2026-12-31'")
+        toDate: String,
+    ): String = try {
+        val from = LocalDate.parse(fromDate, isoDateFormatter)
+        val to = LocalDate.parse(toDate, isoDateFormatter)
+
+        val days = java.time.temporal.ChronoUnit.DAYS.between(from, to)
+        val absDays = Math.abs(days)
+        val direction = when {
+            days > 0 -> "after"
+            days < 0 -> "before"
+            else -> "same day"
+        }
+
+        val years = absDays / 365
+        val remainingDays = absDays % 365
+        val months = remainingDays / 30
+        val leftoverDays = remainingDays % 30
+
+        val humanReadable = buildString {
+            if (days == 0L) {
+                append("same day")
+            } else {
+                if (years > 0) append("$years year${if (years != 1L) "s" else ""}")
+                if (years > 0 && months > 0) append(", ")
+                if (months > 0) append("$months month${if (months != 1L) "s" else ""}")
+                if ((years > 0 || months > 0) && leftoverDays > 0) append(", ")
+                if (leftoverDays > 0 || (years == 0L && months == 0L)) append("$leftoverDays day${if (leftoverDays != 1L) "s" else ""}")
+                append(" $direction")
+            }
+        }
+
+        ToolResponseBuilder.successWithData(
+            output = buildString {
+                appendLine("Date difference: $from → $to")
+                appendLine("Difference: $days day${if (Math.abs(days) != 1L) "s" else ""} ($humanReadable)")
+            }.trim(),
+            data = mapOf(
+                "from_date" to fromDate,
+                "to_date" to toDate,
+                "days" to days,
+                "absolute_days" to absDays,
+                "direction" to direction,
+                "human_readable" to humanReadable,
+            ),
+        )
+    } catch (_: DateTimeParseException) {
+        ToolResponseBuilder.failure(
+            error = "Invalid date format. Use ISO format 'yyyy-MM-dd', e.g. '2026-04-07'.",
+            metadata = mapOf("fromDate" to fromDate, "toDate" to toDate),
+        )
+    } catch (e: Exception) {
+        ToolResponseBuilder.failure(
+            error = "Date difference calculation failed: ${e.message}",
+            metadata = mapOf("fromDate" to fromDate, "toDate" to toDate),
+        )
+    }
+
+    @Tool(
+        """Add or subtract a number of days from a given date and return the resulting date.
+
+Use this tool when the user asks:
+- "What date is 30 days from today?"
+- "What was the date 90 days ago?"
+- "What date is 2 weeks from [date]?"
+
+PARAMETERS:
+- date: A date in ISO format "yyyy-MM-dd"
+- days: Number of days to add (positive) or subtract (negative)
+
+If the user says "from today" or "from now", first call getCurrentDateTime to get today's date.
+
+OUTPUT FORMAT:
+Show the input date, the offset, and the resulting date clearly.
+""",
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"addDaysToDate\" }",
+    )
+    fun addDaysToDate(
+        @P("Base date in ISO format, e.g. '2026-04-07'")
+        date: String,
+        @P("Number of days to add (positive) or subtract (negative)")
+        days: Long,
+    ): String = try {
+        val base = LocalDate.parse(date, isoDateFormatter)
+        val result = base.plusDays(days)
+
+        val action = if (days >= 0) {
+            "Adding $days day${if (days != 1L) "s" else ""} to"
+        } else {
+            "Subtracting ${-days} day${if (-days != 1L) "s" else ""} from"
+        }
+        val fmt = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy", Locale.ENGLISH)
+
+        ToolResponseBuilder.successWithData(
+            output = buildString {
+                appendLine("$action $date:")
+                appendLine("Result: ${result.format(fmt)} ($result)")
+            }.trim(),
+            data = mapOf(
+                "input_date" to date,
+                "days_added" to days,
+                "result_date" to result.toString(),
+                "result_day_of_week" to result.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.ENGLISH),
+            ),
+        )
+    } catch (_: DateTimeParseException) {
+        ToolResponseBuilder.failure(
+            error = "Invalid date format. Use ISO format 'yyyy-MM-dd', e.g. '2026-04-07'.",
+            metadata = mapOf("date" to date, "days" to days),
+        )
+    } catch (e: Exception) {
+        ToolResponseBuilder.failure(
+            error = "Date calculation failed: ${e.message}",
+            metadata = mapOf("date" to date, "days" to days),
+        )
+    }
+
+    /**
+     * Resolves a timezone string to a [ZoneId].
+     * Accepts IANA IDs ("America/New_York"), UTC offsets ("+05:30"),
+     * and common abbreviations mapped to unambiguous IANA IDs.
+     */
+    private fun resolveZone(timezone: String): ZoneId {
+        if (timezone.isBlank()) return ZoneId.systemDefault()
+        val mapped = TIMEZONE_ALIASES[timezone.uppercase()] ?: timezone
+        return try {
+            ZoneId.of(mapped)
+        } catch (_: Exception) {
+            ZoneId.systemDefault()
+        }
+    }
+
+    private fun parseDateTime(datetime: String): LocalDateTime? {
+        val formats = listOf(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"),
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME,
+        )
+        for (fmt in formats) {
+            try {
+                return LocalDateTime.parse(datetime.trim(), fmt)
+            } catch (_: Exception) {}
+        }
+        return null
+    }
+
+    private val TIMEZONE_ALIASES = mapOf(
+        "UTC" to "UTC",
+        "GMT" to "GMT",
+        "EST" to "America/New_York",
+        "EDT" to "America/New_York",
+        "CST" to "America/Chicago",
+        "CDT" to "America/Chicago",
+        "MST" to "America/Denver",
+        "MDT" to "America/Denver",
+        "PST" to "America/Los_Angeles",
+        "PDT" to "America/Los_Angeles",
+        "IST" to "Asia/Kolkata",
+        "JST" to "Asia/Tokyo",
+        "AEST" to "Australia/Sydney",
+        "AEDT" to "Australia/Sydney",
+        "CET" to "Europe/Paris",
+        "CEST" to "Europe/Paris",
+        "BST" to "Europe/London",
+        "WET" to "Europe/Lisbon",
+        "EET" to "Europe/Helsinki",
+        "MSK" to "Europe/Moscow",
+        "HKT" to "Asia/Hong_Kong",
+        "SGT" to "Asia/Singapore",
+        "ICT" to "Asia/Bangkok",
+        "WIB" to "Asia/Jakarta",
+        "PKT" to "Asia/Karachi",
+        "NPT" to "Asia/Kathmandu",
+        "BDT" to "Asia/Dhaka",
+        "NZST" to "Pacific/Auckland",
+        "NZDT" to "Pacific/Auckland",
+        "HST" to "Pacific/Honolulu",
+        "AKST" to "America/Anchorage",
+        "BRT" to "America/Sao_Paulo",
+        "ART" to "America/Argentina/Buenos_Aires",
+        "CLT" to "America/Santiago",
+        "COT" to "America/Bogota",
+        "PET" to "America/Lima",
+        "VET" to "America/Caracas",
+        "AST" to "America/Halifax",
+        "CAT" to "Africa/Harare",
+        "EAT" to "Africa/Nairobi",
+        "WAT" to "Africa/Lagos",
+    )
+}

--- a/shared/src/main/kotlin/io/askimo/tools/weather/WeatherTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/weather/WeatherTools.kt
@@ -1,0 +1,363 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.tools.weather
+
+import dev.langchain4j.agent.tool.P
+import dev.langchain4j.agent.tool.Tool
+import io.askimo.core.logging.logger
+import io.askimo.core.util.httpGet
+import io.askimo.tools.ToolResponseBuilder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Weather tools powered by the free Open-Meteo API (https://open-meteo.com).
+ * No API key required.
+ *
+ * - [getCurrentWeather]: Current conditions for any city or location.
+ * - [getWeatherForecast]: Multi-day forecast (1–16 days) for any city or location.
+ */
+object WeatherTools {
+
+    private val log = logger<WeatherTools>()
+
+    private const val CLASS_NAME = "io.askimo.tools.weather.WeatherTools"
+    private const val GEOCODING_URL = "https://geocoding-api.open-meteo.com/v1/search"
+    private const val FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+    private const val REQUEST_TIMEOUT_MS = 15_000L
+
+    /**
+     * Get the current weather for a city or location.
+     *
+     * @param location City name or location string, e.g. "Tokyo" or "Paris, France"
+     * @return JSON with current temperature, weather condition, wind speed, and humidity
+     */
+    @Tool(
+        """Get the current weather for a city or location.
+
+Use this tool when the user asks about:
+- Current weather conditions for any city or place
+- Temperature right now
+- Whether it is raining, sunny, cloudy etc.
+- Wind speed or humidity at a location
+
+OUTPUT FORMAT:
+Once this tool returns a result, DO NOT call it again.
+Summarise the weather directly to the user in plain text. Include:
+- Location name and country
+- Temperature in °C (and °F if helpful)
+- Weather condition description
+- Feels-like temperature
+- Wind speed and humidity
+        """,
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"getCurrentWeather\" }",
+    )
+    fun getCurrentWeather(
+        @P("City name or location, e.g. 'Seattle', 'Paris, France', 'Tokyo'") location: String,
+    ): String = try {
+        require(location.isNotBlank()) { "Location cannot be empty" }
+
+        val geo = geocode(location)
+            ?: return ToolResponseBuilder.failure(
+                error = "Could not find location: \"$location\". Try a more specific name (e.g. \"Paris, France\").",
+                metadata = mapOf("location" to location),
+            )
+
+        val url = "$FORECAST_URL?latitude=${geo.latitude}&longitude=${geo.longitude}" +
+            "&current=temperature_2m,relative_humidity_2m,apparent_temperature" +
+            ",weather_code,wind_speed_10m,wind_direction_10m,precipitation" +
+            "&temperature_unit=celsius&wind_speed_unit=kmh&timezone=auto"
+
+        val (weatherStatus, weatherBody) = runCatching {
+            httpGet(url, readTimeoutMs = REQUEST_TIMEOUT_MS)
+        }.getOrElse { e ->
+            log.error("HTTP request failed for getCurrentWeather: {}", e.message)
+            return ToolResponseBuilder.failure(
+                error = "Network error fetching weather for \"${geo.displayName}\": ${e.message}",
+                metadata = mapOf("location" to location),
+            )
+        }
+
+        if (weatherStatus != 200) {
+            return ToolResponseBuilder.failure(
+                error = "Weather API returned HTTP $weatherStatus for \"${geo.displayName}\".",
+                metadata = mapOf("location" to location, "statusCode" to weatherStatus),
+            )
+        }
+
+        val current = parseCurrentWeather(weatherBody)
+            ?: return ToolResponseBuilder.failure(
+                error = "Could not parse weather data for \"${geo.displayName}\".",
+                metadata = mapOf("location" to location),
+            )
+
+        val temp = current["temperature_2m"]?.jsonPrimitive?.doubleOrNull ?: 0.0
+        val feelsLike = current["apparent_temperature"]?.jsonPrimitive?.doubleOrNull ?: temp
+        val humidity = current["relative_humidity_2m"]?.jsonPrimitive?.intOrNull ?: 0
+        val windSpeed = current["wind_speed_10m"]?.jsonPrimitive?.doubleOrNull ?: 0.0
+        val windDir = current["wind_direction_10m"]?.jsonPrimitive?.intOrNull ?: 0
+        val weatherCode = current["weather_code"]?.jsonPrimitive?.intOrNull ?: 0
+        val precipitation = current["precipitation"]?.jsonPrimitive?.doubleOrNull ?: 0.0
+        val tempF = String.format("%.1f", temp * 9.0 / 5.0 + 32)
+
+        ToolResponseBuilder.successWithData(
+            output = buildString {
+                appendLine("Location: ${geo.displayName}")
+                appendLine("WMO weather_code: $weatherCode (describe this condition in the user's language)")
+                appendLine("Temperature: $temp°C ($tempF°F), feels like $feelsLike°C")
+                appendLine("Humidity: $humidity%")
+                appendLine("Wind: $windSpeed km/h ${windDegToCompass(windDir)}")
+                if (precipitation > 0) appendLine("Precipitation: ${precipitation}mm")
+            }.trim(),
+            data = mapOf(
+                "location" to geo.displayName,
+                "country" to geo.country,
+                "latitude" to geo.latitude,
+                "longitude" to geo.longitude,
+                "temperature_celsius" to temp,
+                "temperature_fahrenheit" to (tempF.toDoubleOrNull() ?: 0.0),
+                "feels_like_celsius" to feelsLike,
+                "humidity_percent" to humidity,
+                "wind_speed_kmh" to windSpeed,
+                "wind_direction_degrees" to windDir,
+                "wind_direction" to windDegToCompass(windDir),
+                "weather_code" to weatherCode,
+                "precipitation_mm" to precipitation,
+            ),
+        )
+    } catch (e: Exception) {
+        log.error("Cannot get weather for location {}", location, e)
+        ToolResponseBuilder.failure(
+            error = "Weather lookup failed: ${e.message}",
+            metadata = mapOf("location" to location, "exception" to (e::class.simpleName ?: "Exception")),
+        )
+    }
+
+    /**
+     * Get a 3-day weather forecast for a city or location.
+     *
+     * @param location City name or location string, e.g. "Tokyo" or "Paris, France"
+     * @return JSON with daily high/low temperatures, weather conditions, and precipitation chances
+     */
+    @Tool(
+        """Get a weather forecast for a city or location for 1 to 16 days.
+
+Use this tool when the user asks about:
+- Weather over the next few days or weeks
+- Whether to pack an umbrella / rain expected
+- Temperature range for an upcoming trip
+- Weekend weather or any future date range
+
+DAYS PARAMETER:
+- Always extract the number of days from the user's question.
+- If the user says "next week" use 7. "next 10 days" use 10. "tomorrow" use 1.
+- Maximum is 16. If user asks for more, use 16.
+- Default to 7 if no specific number is mentioned.
+
+OUTPUT FORMAT:
+Present the forecast as a day-by-day summary with date, high/low temp, condition, rain chance.
+        """,
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"getWeatherForecast\" }",
+    )
+    fun getWeatherForecast(
+        @P("City name or location, e.g. 'Seattle', 'Paris, France', 'Tokyo'") location: String,
+        @P("Number of days to forecast, between 1 and 16. Default 7.") days: Int = 7,
+    ): String = try {
+        require(location.isNotBlank()) { "Location cannot be empty" }
+        val safeDays = days.coerceIn(1, 16)
+
+        val geo = geocode(location)
+            ?: return ToolResponseBuilder.failure(
+                error = "Could not find location: \"$location\". Try a more specific name (e.g. \"Paris, France\").",
+                metadata = mapOf("location" to location, "days" to safeDays),
+            )
+
+        val url = "$FORECAST_URL?latitude=${geo.latitude}&longitude=${geo.longitude}" +
+            "&daily=weather_code,temperature_2m_max,temperature_2m_min" +
+            ",precipitation_sum,precipitation_probability_max,wind_speed_10m_max" +
+            "&temperature_unit=celsius&wind_speed_unit=kmh" +
+            "&timezone=auto&forecast_days=$safeDays"
+
+        val (forecastStatus, forecastBody) = runCatching {
+            httpGet(url, readTimeoutMs = REQUEST_TIMEOUT_MS)
+        }.getOrElse { e ->
+            log.error("HTTP request failed for getWeatherForecast: {}", e.message)
+            return ToolResponseBuilder.failure(
+                error = "Network error fetching forecast for \"${geo.displayName}\": ${e.message}",
+                metadata = mapOf("location" to location, "days" to safeDays),
+            )
+        }
+
+        if (forecastStatus != 200) {
+            return ToolResponseBuilder.failure(
+                error = "Weather API returned HTTP $forecastStatus for \"${geo.displayName}\".",
+                metadata = mapOf("location" to location, "days" to safeDays, "statusCode" to forecastStatus),
+            )
+        }
+
+        val forecast = parseDailyForecast(forecastBody)
+
+        if (forecast.isEmpty()) {
+            return ToolResponseBuilder.failure(
+                error = "No forecast data returned for \"${geo.displayName}\".",
+                metadata = mapOf("location" to location, "days" to safeDays),
+            )
+        }
+
+        val summaryLines = forecast.joinToString("\n") { day ->
+            "- ${day["date"]}: weather_code=${day["weather_code"]}, High ${day["max_temp_c"]}°C / Low ${day["min_temp_c"]}°C" +
+                (if ((day["precipitation_prob"] as? Int ?: 0) > 20) ", rain ${day["precipitation_prob"]}%" else "") +
+                (if ((day["precipitation_mm"] as? Double ?: 0.0) > 0.0) " (${day["precipitation_mm"]}mm)" else "")
+        }
+
+        ToolResponseBuilder.successWithData(
+            output = buildString {
+                appendLine("$safeDays-day forecast for ${geo.displayName}.")
+                appendLine("WMO weather_code values: describe each condition in the user's language.")
+                appendLine(summaryLines)
+            }.trim(),
+            data = mapOf(
+                "location" to geo.displayName,
+                "country" to geo.country,
+                "latitude" to geo.latitude,
+                "longitude" to geo.longitude,
+                "days" to safeDays,
+                "forecast" to forecast,
+            ),
+        )
+    } catch (e: Exception) {
+        ToolResponseBuilder.failure(
+            error = "Weather forecast failed: ${e.message}",
+            metadata = mapOf("location" to location, "exception" to (e::class.simpleName ?: "Exception")),
+        )
+    }
+
+    private val jsonParser = Json { ignoreUnknownKeys = true }
+
+    private data class GeoLocation(
+        val displayName: String,
+        val country: String,
+        val latitude: Double,
+        val longitude: Double,
+    )
+
+    private fun geocode(location: String): GeoLocation? {
+        val encoded = java.net.URLEncoder.encode(location.trim(), "UTF-8")
+        val (geoStatus, geoBody) = runCatching {
+            httpGet(
+                "$GEOCODING_URL?name=$encoded&count=1&language=en&format=json",
+                readTimeoutMs = REQUEST_TIMEOUT_MS,
+            )
+        }.getOrElse { return null }
+        if (geoStatus != 200) return null
+        val body = geoBody
+        return try {
+            val root = jsonParser.parseToJsonElement(body).jsonObject
+            val result = root["results"]?.jsonArray?.firstOrNull()?.jsonObject ?: return null
+            val name = result["name"]?.jsonPrimitive?.contentOrNull ?: location
+            val country = result["country"]?.jsonPrimitive?.contentOrNull ?: ""
+            val latitude = result["latitude"]?.jsonPrimitive?.doubleOrNull ?: return null
+            val longitude = result["longitude"]?.jsonPrimitive?.doubleOrNull ?: return null
+            GeoLocation(
+                displayName = if (country.isNotBlank()) "$name, $country" else name,
+                country = country,
+                latitude = latitude,
+                longitude = longitude,
+            )
+        } catch (e: Exception) {
+            log.warn("Failed to parse geocoding response: {}", e.message)
+            null
+        }
+    }
+
+    private fun parseDailyForecast(body: String): List<Map<String, Any>> {
+        return try {
+            val root = jsonParser.parseToJsonElement(body).jsonObject
+            val daily = root["daily"]?.jsonObject ?: return emptyList()
+
+            fun strings(key: String): List<String> = daily[key]?.jsonArray?.map { (it as? JsonPrimitive)?.contentOrNull ?: "" } ?: emptyList()
+
+            fun doubles(key: String): List<Double> = daily[key]?.jsonArray?.map { (it as? JsonPrimitive)?.doubleOrNull ?: 0.0 } ?: emptyList()
+
+            fun ints(key: String): List<Int> = daily[key]?.jsonArray?.map { (it as? JsonPrimitive)?.intOrNull ?: 0 } ?: emptyList()
+
+            val dates = strings("time")
+            val codes = ints("weather_code")
+            val maxTemps = doubles("temperature_2m_max")
+            val minTemps = doubles("temperature_2m_min")
+            val precip = doubles("precipitation_sum")
+            val precipProb = ints("precipitation_probability_max")
+            val wind = doubles("wind_speed_10m_max")
+
+            if (dates.isEmpty()) return emptyList()
+
+            dates.indices.map { i ->
+                val code = codes.getOrElse(i) { 0 }
+                mapOf<String, Any>(
+                    "date" to (dates.getOrElse(i) { "" }),
+                    "condition" to weatherCodeToDescription(code),
+                    "weather_code" to code,
+                    "max_temp_c" to (maxTemps.getOrElse(i) { 0.0 }),
+                    "min_temp_c" to (minTemps.getOrElse(i) { 0.0 }),
+                    "precipitation_mm" to (precip.getOrElse(i) { 0.0 }),
+                    "precipitation_prob" to (precipProb.getOrElse(i) { 0 }),
+                    "wind_speed_max_kmh" to (wind.getOrElse(i) { 0.0 }),
+                )
+            }
+        } catch (e: Exception) {
+            log.warn("Failed to parse forecast response: {}", e.message)
+            emptyList()
+        }
+    }
+
+    private fun parseCurrentWeather(body: String): JsonObject? = try {
+        jsonParser.parseToJsonElement(body).jsonObject["current"]?.jsonObject
+    } catch (e: Exception) {
+        log.warn("Failed to parse current weather response: {}", e.message)
+        null
+    }
+
+    private fun weatherCodeToDescription(code: Int): String = when (code) {
+        0 -> "Clear sky"
+        1 -> "Mainly clear"
+        2 -> "Partly cloudy"
+        3 -> "Overcast"
+        45 -> "Foggy"
+        48 -> "Icy fog"
+        51 -> "Light drizzle"
+        53 -> "Moderate drizzle"
+        55 -> "Dense drizzle"
+        61 -> "Slight rain"
+        63 -> "Moderate rain"
+        65 -> "Heavy rain"
+        66 -> "Freezing rain"
+        67 -> "Heavy freezing rain"
+        71 -> "Slight snow"
+        73 -> "Moderate snow"
+        75 -> "Heavy snow"
+        77 -> "Snow grains"
+        80 -> "Slight showers"
+        81 -> "Moderate showers"
+        82 -> "Violent showers"
+        85 -> "Slight snow showers"
+        86 -> "Heavy snow showers"
+        95 -> "Thunderstorm"
+        96 -> "Thunderstorm with slight hail"
+        99 -> "Thunderstorm with heavy hail"
+        else -> "Unknown ($code)"
+    }
+
+    private fun windDegToCompass(deg: Int): String {
+        val dirs = arrayOf("N", "NE", "E", "SE", "S", "SW", "W", "NW")
+        return dirs[((deg + 22.5) / 45).toInt() % 8]
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/tools/web/WebSearchTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/WebSearchTools.kt
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.tools.web
+
+import dev.langchain4j.agent.tool.P
+import dev.langchain4j.agent.tool.Tool
+import io.askimo.tools.ToolResponseBuilder
+import org.jsoup.HttpStatusException
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+
+/**
+ * Web search and page reading tools.
+ *
+ * - [searchWeb]: Searches the web using Brave Search API (requires `BRAVE_SEARCH_API_KEY`
+ *   env variable) and returns structured results with titles, URLs, and snippets.
+ * - [readWebPage]: Fetches and extracts clean text content from any URL using Jsoup.
+ */
+object WebSearchTools {
+    private const val CLASS_NAME = "io.askimo.tools.web.WebSearchTools"
+    private const val PAGE_TIMEOUT_MS = 15_000
+    private const val USER_AGENT =
+        "Mozilla/5.0 (compatible; Askimo/1.0; +https://askimo.chat)"
+
+    /**
+     * Fetch and extract the readable text content of a web page.
+     *
+     * @param url The URL of the web page to read
+     * @param maxChars Maximum number of characters to return (default 8000)
+     * @return JSON with the page title, url, and extracted text content
+     */
+    @Tool(
+        """Fetch and read the content of a web page from a URL.
+
+Use this tool when you need to:
+- Read the full content of a specific URL found in search results
+- Extract information from a known web page or article
+- Summarise or analyse content from a specific webpage
+- Get more detail from a search result snippet
+
+OUTPUT FORMAT:
+Return the extracted page title and the most relevant portions of the text.
+Keep your summary focused on what the user actually asked about.
+        """,
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"readWebPage\" }",
+    )
+    fun readWebPage(
+        @P("Full URL of the page to fetch, must start with http:// or https://") url: String,
+    ): String = try {
+        val maxChars = 100_000
+        require(url.isNotBlank()) { "URL cannot be empty" }
+        require(url.startsWith("http://") || url.startsWith("https://")) {
+            "URL must start with http:// or https://"
+        }
+
+        val doc: Document = Jsoup.connect(url)
+            .userAgent(USER_AGENT)
+            .timeout(PAGE_TIMEOUT_MS)
+            .get()
+
+        val title = doc.title().ifBlank { url }
+
+        // Remove noise elements
+        doc.select("script, style, nav, footer, header, aside, .ads, .advertisement, #cookie-banner").remove()
+
+        // Extract main content — prefer article/main, fall back to body
+        val contentEl = doc.selectFirst("article, main, [role=main], .content, .post-content, .entry-content")
+            ?: doc.body()
+
+        val rawText = contentEl.wholeText()
+            .lines()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .joinToString("\n")
+
+        val truncated = if (rawText.length > maxChars) {
+            rawText.take(maxChars) + "\n\n[Content truncated at $maxChars characters. Use a smaller maxChars or ask about specific sections.]"
+        } else {
+            rawText
+        }
+
+        ToolResponseBuilder.successWithData(
+            output = "Read page: $title ($url)",
+            data = mapOf(
+                "url" to url,
+                "title" to title,
+                "content" to truncated,
+                "characterCount" to rawText.length,
+                "truncated" to (rawText.length > maxChars),
+            ),
+        )
+    } catch (e: HttpStatusException) {
+        ToolResponseBuilder.failure(
+            error = "Failed to fetch page (HTTP ${e.statusCode}): ${e.message}",
+            metadata = mapOf("url" to url, "statusCode" to e.statusCode),
+        )
+    } catch (e: Exception) {
+        ToolResponseBuilder.failure(
+            error = "Failed to read web page: ${e.message}",
+            metadata = mapOf(
+                "url" to url,
+                "exception" to (e::class.simpleName ?: "Exception"),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
- Register new built-in tool categories and expose localized labels in the MCP UI
- Add weather and web search intent detectors so relevant tools are selected automatically
- Introduce weather, web search, and datetime tool implementations for agentic flows
- Preserve tool instructions in rebuilt chat requests and improve guidance to avoid repeat calls
- Enable Java parameter metadata so tool schemas keep meaningful argument names for reflection
- Fix message sanitization and session rename handling to preserve existing metadata and titles