### PR TITLE
refactor(chat-model-factory): split chat, streaming, and secondary model creation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.2.26
+projectVersion=1.2.27-SNAPSHOT
 
 # About information
 author=Hai Nguyen

--- a/shared/src/main/kotlin/io/askimo/core/providers/AgentExecutor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/AgentExecutor.kt
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.core.providers
+
+import dev.langchain4j.agentic.Agent
+
+interface AgentExecutor {
+
+    @Agent()
+    fun execute(): String
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatModelFactory.kt
@@ -5,6 +5,8 @@
 package io.askimo.core.providers
 
 import dev.langchain4j.memory.ChatMemory
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
@@ -69,6 +71,43 @@ interface ChatModelFactory<T : ProviderSettings> {
     fun createImageModel(
         settings: T,
     ): ImageModel
+
+    /**
+     * Creates a bare [StreamingChatModel] instance configured for this provider.
+     * @param settings Provider-specific settings (credentials, model name, base URL, etc.)
+     * @return A fully configured [StreamingChatModel] ready to be used or wrapped
+     */
+    fun createStreamingModel(settings: T): StreamingChatModel
+
+    /**
+     * Creates a bare [ChatModel] (non-streaming) instance configured for this provider.
+     *
+     * Uses the same model as [createStreamingModel] — i.e. `settings.defaultModel` with the
+     * same temperature — but returns a synchronous [ChatModel] instead of a streaming one.
+     * Useful when a caller needs a blocking chat call (e.g. LangChain4j components that only
+     * accept [ChatModel]) without sacrificing model quality.
+     *
+     * Note: for lightweight classification or utility tasks, prefer [createUtilityClient] which
+     * uses a cheaper secondary model where available.
+     *
+     * @param settings Provider-specific settings (credentials, model name, base URL, etc.)
+     * @return A fully configured [ChatModel] ready to be used or wrapped
+     */
+    fun createModel(settings: T): ChatModel
+
+    /**
+     * Creates a lightweight secondary [ChatModel] using the provider's utility/cheap model.
+     *
+     * This is the non-streaming counterpart used for tasks that don't need the full frontier
+     * model — e.g. RAG query compression, intent classification, session title generation.
+     * For cloud providers this maps to a smaller/cheaper model (e.g. `utilityModel` from
+     * AppConfig). For local providers it typically falls back to `settings.defaultModel`
+     * since there is no extra cost distinction.
+     *
+     * @param settings Provider-specific settings (credentials, model name, base URL, etc.)
+     * @return A fully configured cheap [ChatModel] ready to be used or wrapped
+     */
+    fun createSecondaryModel(settings: T): ChatModel
 
     /**
      * Returns helpful guidance text to display when no models are available for this provider.

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -11,6 +11,7 @@ import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.anthropic.AnthropicChatModel
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.service.AiServices
@@ -64,9 +65,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
     ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (external service)
+        // Configure HTTP client for thinking probe (probe needs its own builder)
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
 
@@ -75,39 +74,13 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
             val supportsThinking = probeThinkingSupport(settings, jdkHttpClientBuilder)
             ModelCapabilitiesCache.setThinkingSupport(ModelProvider.ANTHROPIC, settings.defaultModel, supportsThinking)
         }
-        val supportsThinking = ModelCapabilitiesCache.supportsThinking(ModelProvider.ANTHROPIC, settings.defaultModel)
-
-        val chatModel =
-            AnthropicStreamingChatModel
-                .builder()
-                .httpClientBuilder(jdkHttpClientBuilder)
-                .apiKey(safeApiKey(settings.apiKey))
-                .modelName(settings.defaultModel)
-                .logger(log)
-                .logRequests(log.isDebugEnabled)
-                .logResponses(log.isTraceEnabled)
-                .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.ANTHROPIC.name.lowercase())))
-                .baseUrl(settings.baseUrl)
-                .apply {
-                    if (supportsThinking) {
-                        thinkingType("enabled")
-                        thinkingBudgetTokens(1024)
-                        maxTokens(2048) // must be > thinkingBudgetTokens
-                        sendThinking(true)
-                        returnThinking(true)
-                        temperature(1.0)
-                    } else {
-                        temperature(AppConfig.chat.samplingTemperature)
-                    }
-                }
-                .build()
 
         return AiServiceBuilder.buildChatClient(
             sessionId = sessionId,
             settings = settings,
             provider = ModelProvider.ANTHROPIC,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
+            chatModel = createStreamingModel(settings),
+            secondaryChatModel = createSecondaryModel(settings),
             chatMemory = chatMemory,
             toolProvider = toolProvider,
             retriever = retriever,
@@ -159,26 +132,66 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         TODO("Not yet implemented")
     }
 
-    private fun createSecondaryChatModel(settings: AnthropicSettings): ChatModel {
+    override fun createStreamingModel(settings: AnthropicSettings): StreamingChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
-        val modelName = AppConfig.models[ModelProvider.ANTHROPIC].utilityModel
-            .ifBlank { settings.defaultModel }
+        val supportsThinking = ModelCapabilitiesCache.supportsThinking(ModelProvider.ANTHROPIC, settings.defaultModel)
+
+        return AnthropicStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .apiKey(safeApiKey(settings.apiKey))
+            .modelName(settings.defaultModel)
+            .baseUrl(settings.baseUrl)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.ANTHROPIC.name.lowercase())))
+            .apply {
+                if (supportsThinking) {
+                    thinkingType("enabled")
+                    thinkingBudgetTokens(1024)
+                    maxTokens(2048)
+                    sendThinking(true)
+                    returnThinking(true)
+                    temperature(1.0)
+                } else {
+                    temperature(AppConfig.chat.samplingTemperature)
+                }
+            }
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: AnthropicSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        return AnthropicChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .apiKey(safeApiKey(settings.apiKey))
+            .modelName(AppConfig.models[ModelProvider.ANTHROPIC].utilityModel.ifBlank { settings.defaultModel })
+            .baseUrl(settings.baseUrl)
+            .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.ANTHROPIC].utilityModelTimeoutSeconds))
+            .build()
+    }
+
+    override fun createModel(settings: AnthropicSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
 
         return AnthropicChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(modelName)
+            .modelName(settings.defaultModel)
             .baseUrl(settings.baseUrl)
-            .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.ANTHROPIC].utilityModelTimeoutSeconds))
+            .temperature(AppConfig.chat.samplingTemperature)
             .build()
     }
 
     override fun createUtilityClient(
         settings: AnthropicSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     private fun fetchAnthropicModels(

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers.docker
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.model.openai.OpenAiChatModel
@@ -78,39 +79,17 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (automatically skips proxy for localhost)
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-
-        val chatModel =
-            OpenAiStreamingChatModel
-                .builder()
-                .httpClientBuilder(jdkHttpClientBuilder)
-                .baseUrl(settings.baseUrl)
-                .modelName(settings.defaultModel)
-                .temperature(AppConfig.chat.samplingTemperature)
-                .logger(log)
-                .logRequests(log.isDebugEnabled)
-                .logResponses(log.isTraceEnabled)
-                .timeout(Duration.ofMinutes(5))
-                .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.DOCKER.name.lowercase())))
-                .build()
-
-        return AiServiceBuilder.buildChatClient(
-            sessionId = sessionId,
-            settings = settings,
-            provider = ModelProvider.DOCKER,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
-            chatMemory = chatMemory,
-            toolProvider = toolProvider,
-            retriever = retriever,
-            executionMode = executionMode,
-        )
-    }
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = ModelProvider.DOCKER,
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
 
     override fun createImageModel(
         settings: DockerAiSettings,
@@ -123,10 +102,27 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
         .logResponses(log.isTraceEnabled)
         .build()
 
-    private fun createSecondaryChatModel(settings: DockerAiSettings): ChatModel {
+    override fun createStreamingModel(settings: DockerAiSettings): StreamingChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .timeout(Duration.ofMinutes(5))
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.DOCKER.name.lowercase())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: DockerAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
@@ -136,10 +132,26 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
             .build()
     }
 
+    override fun createModel(settings: DockerAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
+
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey("docker-ai")
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .timeout(Duration.ofMinutes(5))
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.DOCKER.name.lowercase())))
+            .build()
+    }
+
     override fun createUtilityClient(
         settings: DockerAiSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     override fun supportsEmbedding(): Boolean = true

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.Capability
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.googleai.GeminiThinkingConfig
 import dev.langchain4j.model.googleai.GoogleAiEmbeddingModel
@@ -62,9 +63,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
     ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (external service)
+        // Configure HTTP client for thinking probe (probe needs its own builder)
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
 
@@ -73,39 +72,13 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
             val supportsThinking = probeThinkingSupport(settings, jdkHttpClientBuilder)
             ModelCapabilitiesCache.setThinkingSupport(GEMINI, settings.defaultModel, supportsThinking)
         }
-        val supportsThinking = ModelCapabilitiesCache.supportsThinking(GEMINI, settings.defaultModel)
-
-        val chatModel = GoogleAiGeminiStreamingChatModel
-            .builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .apiKey(safeApiKey(settings.apiKey))
-            .modelName(settings.defaultModel)
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, GEMINI.name.lowercase())))
-            .apply {
-                if (supportsThinking) {
-                    thinkingConfig(
-                        GeminiThinkingConfig.builder()
-                            .thinkingLevel(GeminiThinkingConfig.GeminiThinkingLevel.LOW)
-                            .build(),
-                    )
-                    sendThinking(true)
-                    returnThinking(true)
-                    temperature(1.0)
-                } else {
-                    temperature(AppConfig.chat.samplingTemperature)
-                }
-            }
-            .build()
 
         return AiServiceBuilder.buildChatClient(
             sessionId = sessionId,
             settings = settings,
             provider = GEMINI,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
+            chatModel = createStreamingModel(settings),
+            secondaryChatModel = createSecondaryModel(settings),
             chatMemory = chatMemory,
             toolProvider = toolProvider,
             retriever = retriever,
@@ -161,26 +134,66 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
         .logResponses(log.isTraceEnabled)
         .build()
 
-    private fun createSecondaryChatModel(settings: GeminiSettings): ChatModel {
+    override fun createStreamingModel(settings: GeminiSettings): StreamingChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
-        val modelName = AppConfig.models[GEMINI].utilityModel
-            .ifBlank { settings.defaultModel }
+        val supportsThinking = ModelCapabilitiesCache.supportsThinking(GEMINI, settings.defaultModel)
 
+        return GoogleAiGeminiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .apiKey(safeApiKey(settings.apiKey))
+            .modelName(settings.defaultModel)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, GEMINI.name.lowercase())))
+            .apply {
+                if (supportsThinking) {
+                    thinkingConfig(
+                        GeminiThinkingConfig.builder()
+                            .thinkingLevel(GeminiThinkingConfig.GeminiThinkingLevel.LOW)
+                            .build(),
+                    )
+                    sendThinking(true)
+                    returnThinking(true)
+                    temperature(1.0)
+                } else {
+                    temperature(AppConfig.chat.samplingTemperature)
+                }
+            }
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: GeminiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
         return GoogleAiGeminiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(modelName)
+            .modelName(AppConfig.models[GEMINI].utilityModel.ifBlank { settings.defaultModel })
             .timeout(Duration.ofSeconds(AppConfig.models[GEMINI].utilityModelTimeoutSeconds))
+            .build()
+    }
+
+    override fun createModel(settings: GeminiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+
+        return GoogleAiGeminiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .apiKey(safeApiKey(settings.apiKey))
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
             .build()
     }
 
     override fun createUtilityClient(
         settings: GeminiSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     override fun supportsEmbedding(): Boolean = true

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers.lmstudio
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.model.openai.OpenAiChatModel
@@ -68,39 +69,17 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (automatically skips proxy for localhost)
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-
-        val chatModel =
-            OpenAiStreamingChatModel
-                .builder()
-                .baseUrl(settings.baseUrl)
-                .apiKey("lm-studio")
-                .modelName(settings.defaultModel)
-                .temperature(AppConfig.chat.samplingTemperature)
-                .logger(log)
-                .logRequests(log.isDebugEnabled)
-                .logResponses(log.isTraceEnabled)
-                .timeout(Duration.ofMinutes(5))
-                .httpClientBuilder(jdkHttpClientBuilder)
-                .listeners(listOf(TelemetryChatModelListener(telemetry, LMSTUDIO.name.lowercase())))
-                .build()
-
-        return AiServiceBuilder.buildChatClient(
-            sessionId = sessionId,
-            settings = settings,
-            provider = LMSTUDIO,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
-            chatMemory = chatMemory,
-            toolProvider = toolProvider,
-            retriever = retriever,
-            executionMode = executionMode,
-        )
-    }
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = LMSTUDIO,
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
 
     override fun createImageModel(
         settings: LmStudioSettings,
@@ -118,12 +97,26 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
             .build()
     }
 
-    private fun createSecondaryChatModel(
-        settings: LmStudioSettings,
-    ): ChatModel {
-        // Configure HTTP client with proxy (automatically skips proxy for localhost)
+    override fun createStreamingModel(settings: LmStudioSettings): StreamingChatModel {
         val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
+        val telemetry = AppContext.getInstance().telemetry
 
+        return OpenAiStreamingChatModel.builder()
+            .baseUrl(settings.baseUrl)
+            .apiKey("lm-studio")
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .timeout(Duration.ofMinutes(5))
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, LMSTUDIO.name.lowercase())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: LmStudioSettings): ChatModel {
+        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
         return OpenAiChatModel.builder()
             .baseUrl(settings.baseUrl)
             .apiKey("lm-studio")
@@ -133,10 +126,25 @@ class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
             .build()
     }
 
+    override fun createModel(settings: LmStudioSettings): ChatModel {
+        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
+        val telemetry = AppContext.getInstance().telemetry
+
+        return OpenAiChatModel.builder()
+            .baseUrl(settings.baseUrl)
+            .apiKey("lm-studio")
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .timeout(Duration.ofMinutes(5))
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, LMSTUDIO.name.lowercase())))
+            .build()
+    }
+
     override fun createUtilityClient(
         settings: LmStudioSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     override fun supportsEmbedding(): Boolean = true

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers.localai
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.model.openai.OpenAiChatModel
@@ -56,39 +57,17 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (automatically skips proxy for localhost)
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-
-        val chatModel =
-            OpenAiStreamingChatModel
-                .builder()
-                .httpClientBuilder(jdkHttpClientBuilder)
-                .baseUrl(settings.baseUrl)
-                .apiKey("localai")
-                .modelName(settings.defaultModel)
-                .timeout(Duration.ofMinutes(5))
-                .temperature(AppConfig.chat.samplingTemperature)
-                .logger(log)
-                .logRequests(log.isDebugEnabled)
-                .logResponses(log.isTraceEnabled)
-                .listeners(listOf(TelemetryChatModelListener(telemetry, LOCALAI.name.lowercase()))).build()
-
-        return AiServiceBuilder.buildChatClient(
-            sessionId = sessionId,
-            settings = settings,
-            provider = LOCALAI,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
-            chatMemory = chatMemory,
-            toolProvider = toolProvider,
-            retriever = retriever,
-            executionMode = executionMode,
-        )
-    }
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = LOCALAI,
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
 
     override fun createImageModel(
         settings: LocalAiSettings,
@@ -101,10 +80,28 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
         .logResponses(log.isTraceEnabled)
         .build()
 
-    private fun createSecondaryChatModel(settings: LocalAiSettings): ChatModel {
+    override fun createStreamingModel(settings: LocalAiSettings): StreamingChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey("localai")
+            .modelName(settings.defaultModel)
+            .timeout(Duration.ofMinutes(5))
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, LOCALAI.name.lowercase())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: LocalAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
@@ -114,10 +111,26 @@ class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
             .build()
     }
 
+    override fun createModel(settings: LocalAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
+
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey("localai")
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .timeout(Duration.ofMinutes(5))
+            .listeners(listOf(TelemetryChatModelListener(telemetry, LOCALAI.name.lowercase())))
+            .build()
+    }
+
     override fun createUtilityClient(
         settings: LocalAiSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     override fun supportsEmbedding(): Boolean = true

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers.ollama
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.model.openai.OpenAiChatModel
@@ -62,38 +63,17 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (automatically skips proxy for localhost)
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-
-        val chatModel =
-            OpenAiStreamingChatModel
-                .builder()
-                .httpClientBuilder(jdkHttpClientBuilder)
-                .baseUrl(settings.baseUrl)
-                .modelName(settings.defaultModel)
-                .timeout(Duration.ofMinutes(5))
-                .temperature(AppConfig.chat.samplingTemperature)
-                .logger(log)
-                .logRequests(log.isDebugEnabled)
-                .logResponses(log.isTraceEnabled)
-                .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OLLAMA.name.lowercase()))).build()
-
-        return AiServiceBuilder.buildChatClient(
-            sessionId = sessionId,
-            settings = settings,
-            provider = ModelProvider.OLLAMA,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
-            chatMemory = chatMemory,
-            toolProvider = toolProvider,
-            retriever = retriever,
-            executionMode = executionMode,
-        )
-    }
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = ModelProvider.OLLAMA,
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
 
     override fun createImageModel(
         settings: OllamaSettings,
@@ -106,10 +86,27 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
         .logResponses(log.isTraceEnabled)
         .build()
 
-    private fun createSecondaryChatModel(settings: OllamaSettings): ChatModel {
+    override fun createStreamingModel(settings: OllamaSettings): StreamingChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .modelName(settings.defaultModel)
+            .timeout(Duration.ofMinutes(5))
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OLLAMA.name.lowercase())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: OllamaSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
@@ -121,10 +118,28 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
             .build()
     }
 
+    override fun createModel(settings: OllamaSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
+
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey("ollama")
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .timeout(Duration.ofMinutes(5))
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OLLAMA.name.lowercase())))
+            .build()
+    }
+
     override fun createUtilityClient(
         settings: OllamaSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     override fun supportsEmbedding(): Boolean = true

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers.openai
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.model.openai.OpenAiChatModel
@@ -62,39 +63,17 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (external service, always use proxy if configured)
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder()
-            .httpClientBuilder(httpClientBuilder)
-
-        val chatModel =
-            OpenAiStreamingChatModel
-                .builder()
-                .httpClientBuilder(jdkHttpClientBuilder)
-                .apiKey(safeApiKey(settings.apiKey))
-                .modelName(settings.defaultModel)
-                .temperature(AppConfig.chat.samplingTemperature)
-                .logger(log)
-                .logRequests(log.isDebugEnabled)
-                .logResponses(log.isDebugEnabled)
-                .listeners(listOf(TelemetryChatModelListener(telemetry, OPENAI.name.lowercase())))
-                .build()
-
-        return AiServiceBuilder.buildChatClient(
-            sessionId = sessionId,
-            settings = settings,
-            provider = OPENAI,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
-            chatMemory = chatMemory,
-            toolProvider = toolProvider,
-            retriever = retriever,
-            executionMode = executionMode,
-        )
-    }
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = OPENAI,
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
 
     override fun createImageModel(
         settings: OpenAiSettings,
@@ -106,24 +85,55 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
         .logResponses(log.isTraceEnabled)
         .build()
 
-    private fun createSecondaryChatModel(settings: OpenAiSettings): ChatModel {
+    override fun createStreamingModel(settings: OpenAiSettings): StreamingChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val modelName = AppConfig.models[OPENAI].utilityModel
-            .ifBlank { settings.defaultModel }
+        val telemetry = AppContext.getInstance().telemetry
+
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .apiKey(safeApiKey(settings.apiKey))
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isDebugEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, OPENAI.name.lowercase())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: OpenAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .apiKey(safeApiKey(settings.apiKey))
+            .modelName(AppConfig.models[OPENAI].utilityModel.ifBlank { settings.defaultModel })
+            .timeout(Duration.ofSeconds(AppConfig.models[OPENAI].utilityModelTimeoutSeconds))
+            .build()
+    }
+
+    override fun createModel(settings: OpenAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(modelName)
-            .timeout(Duration.ofSeconds(AppConfig.models[OPENAI].utilityModelTimeoutSeconds))
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isDebugEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, OPENAI.name.lowercase())))
             .build()
     }
 
     override fun createUtilityClient(
         settings: OpenAiSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     override fun supportsEmbedding(): Boolean = true

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers.openaicompatible
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.model.openai.OpenAiChatModel
@@ -66,35 +67,17 @@ class OpenAiCompatibleModelFactory : ChatModelFactory<OpenAiCompatibleSettings> 
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        val apiKey = settings.apiKey.ifBlank { "not-needed" }
-
-        val chatModel = OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(apiKey))
-            .modelName(settings.defaultModel)
-            .temperature(AppConfig.chat.samplingTemperature)
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OPENAI_COMPATIBLE.providerKey())))
-            .build()
-
-        return AiServiceBuilder.buildChatClient(
-            sessionId = sessionId,
-            settings = settings,
-            provider = ModelProvider.OPENAI_COMPATIBLE,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
-            chatMemory = chatMemory,
-            toolProvider = toolProvider,
-            retriever = retriever,
-            executionMode = executionMode,
-        )
-    }
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = ModelProvider.OPENAI_COMPATIBLE,
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
 
     override fun createImageModel(settings: OpenAiCompatibleSettings): ImageModel {
         val apiKey = settings.apiKey.ifBlank { "not-needed" }
@@ -108,23 +91,53 @@ class OpenAiCompatibleModelFactory : ChatModelFactory<OpenAiCompatibleSettings> 
             .build()
     }
 
-    private fun createSecondaryChatModel(settings: OpenAiCompatibleSettings): ChatModel {
+    override fun createStreamingModel(settings: OpenAiCompatibleSettings): StreamingChatModel {
         val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].utilityModel
-            .ifBlank { settings.defaultModel }
         val apiKey = settings.apiKey.ifBlank { "not-needed" }
+        val telemetry = AppContext.getInstance().telemetry
+
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey(safeApiKey(apiKey))
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OPENAI_COMPATIBLE.providerKey())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: OpenAiCompatibleSettings): ChatModel {
+        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
+        val apiKey = settings.apiKey.ifBlank { "not-needed" }
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey(safeApiKey(apiKey))
+            .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].utilityModel.ifBlank { settings.defaultModel })
+            .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].utilityModelTimeoutSeconds))
+            .build()
+    }
+
+    override fun createModel(settings: OpenAiCompatibleSettings): ChatModel {
+        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
+        val apiKey = settings.apiKey.ifBlank { "not-needed" }
+        val telemetry = AppContext.getInstance().telemetry
 
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
             .apiKey(safeApiKey(apiKey))
-            .modelName(modelName)
-            .timeout(Duration.ofSeconds(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].utilityModelTimeoutSeconds))
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OPENAI_COMPATIBLE.providerKey())))
             .build()
     }
 
     override fun createUtilityClient(settings: OpenAiCompatibleSettings): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 
     override fun supportsEmbedding(): Boolean = true

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers.xai
 import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.image.ImageModel
 import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiImageModel
@@ -52,39 +53,17 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient {
-        val telemetry = AppContext.getInstance().telemetry
-
-        // Configure HTTP client with proxy (external service)
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-
-        val chatModel =
-            OpenAiStreamingChatModel
-                .builder()
-                .httpClientBuilder(jdkHttpClientBuilder)
-                .apiKey(safeApiKey(settings.apiKey))
-                .baseUrl(settings.baseUrl)
-                .modelName(settings.defaultModel)
-                .temperature(AppConfig.chat.samplingTemperature)
-                .logger(log)
-                .logRequests(log.isDebugEnabled)
-                .logResponses(log.isTraceEnabled)
-                .listeners(listOf(TelemetryChatModelListener(telemetry, XAI.name.lowercase())))
-                .build()
-
-        return AiServiceBuilder.buildChatClient(
-            sessionId = sessionId,
-            settings = settings,
-            provider = XAI,
-            chatModel = chatModel,
-            secondaryChatModel = createSecondaryChatModel(settings),
-            chatMemory = chatMemory,
-            toolProvider = toolProvider,
-            retriever = retriever,
-            executionMode = executionMode,
-        )
-    }
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = XAI,
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
 
     override fun createImageModel(
         settings: XAiSettings,
@@ -97,25 +76,54 @@ class XAiModelFactory : ChatModelFactory<XAiSettings> {
         .logResponses(log.isTraceEnabled)
         .build()
 
-    private fun createSecondaryChatModel(settings: XAiSettings): ChatModel {
+    override fun createStreamingModel(settings: XAiSettings): StreamingChatModel {
         val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
-        val modelName = AppConfig.models[XAI].utilityModel
-            .ifBlank { settings.defaultModel }
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .apiKey(safeApiKey(settings.apiKey))
+            .baseUrl(settings.baseUrl)
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, XAI.name.lowercase())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: XAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(jdkHttpClientBuilder)
+            .baseUrl(settings.baseUrl)
+            .apiKey(safeApiKey(settings.apiKey))
+            .modelName(AppConfig.models[XAI].utilityModel.ifBlank { settings.defaultModel })
+            .timeout(Duration.ofSeconds(AppConfig.models[XAI].utilityModelTimeoutSeconds))
+            .build()
+    }
+
+    override fun createModel(settings: XAiSettings): ChatModel {
+        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
+        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
+        val telemetry = AppContext.getInstance().telemetry
 
         return OpenAiChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(modelName)
-            .timeout(Duration.ofSeconds(AppConfig.models[XAI].utilityModelTimeoutSeconds))
+            .modelName(settings.defaultModel)
+            .temperature(AppConfig.chat.samplingTemperature)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, XAI.name.lowercase())))
             .build()
     }
 
     override fun createUtilityClient(
         settings: XAiSettings,
     ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryChatModel(settings))
+        .chatModel(createSecondaryModel(settings))
         .build()
 }

--- a/shared/src/main/kotlin/io/askimo/core/util/ProxyUtil.kt
+++ b/shared/src/main/kotlin/io/askimo/core/util/ProxyUtil.kt
@@ -193,11 +193,6 @@ object ProxyUtil {
                     log.error("Failed to configure SOCKS5 proxy: ${e.message}", e)
                 }
             }
-
-            else -> {
-                // ProxyType.NONE - already handled with early return above
-                log.debug("Proxy disabled (else branch - should not reach here)")
-            }
         }
 
         return builder


### PR DESCRIPTION
- add AgentExecutor and extend ChatModelFactory with dedicated model builders
- separate bare ChatModel and StreamingChatModel creation from chat client wiring
- standardize secondary model creation across providers for utility workloads
- update all provider factories to use the new createSecondaryModel contract
- simplify shared factory logic and remove redundant proxy fallback logging
- bump project version to 1.2.27-SNAPSHOT