### PR TITLE
feat: show OpenAI-compatible endpoint info for LMStudio provider

### DIFF
--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -680,6 +680,7 @@ provider.localai.setup.help=💡To use LocalAI, you need to have it running.\n\n
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=The base URL for your LMStudio instance (default: http://localhost:1234)
 provider.lmstudio.setup.help=💡To use LMStudio, you need to have it running locally.\n\n1. Install LMStudio from: https://lmstudio.ai/\n2. Start the local server\n3. Optionally configure the base URL if not using default
+provider.lmstudio.openai.compat.info=Askimo uses OpenAI-compatible endpoints (/v1), not the native LMStudio API (/api/v1/).
 
 # System Resources
 system.memory=Memory

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -683,6 +683,7 @@ provider.localai.setup.help=💡 Für die Nutzung von LocalAI müssen Sie es zue
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=LMStudio Basis-URL (Standard: http://localhost:1234)
 provider.lmstudio.setup.help=💡 So verwenden Sie LMStudio:\n\n1. Installieren: https://lmstudio.ai/\n2. Lokalen Server starten\n3. Basis-URL bei Bedarf ändern
+provider.lmstudio.openai.compat.info=Askimo verwendet OpenAI-kompatible Endpunkte (/v1), nicht die native LMStudio-API (/api/v1/).
 
 # System Resources
 system.memory=Speicher

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -682,6 +682,7 @@ provider.localai.setup.help=💡 Para usar LocalAI, debes ejecutarlo primero.\n\
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=Base URL de LMStudio (por defecto: http://localhost:1234)
 provider.lmstudio.setup.help=💡 Para usar LMStudio:\n\n1. Instálalo desde: https://lmstudio.ai/\n2. Ejecuta el servidor local\n3. Ajusta la URL base si es necesario
+provider.lmstudio.openai.compat.info=Askimo utiliza los endpoints compatibles con OpenAI (/v1), no la API nativa de LMStudio (/api/v1/).
 
 # System Resources
 system.memory=Memoria

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -682,6 +682,7 @@ provider.localai.setup.help=💡 Pour utiliser LocalAI, vous devez l’exécuter
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=Base URL LMStudio (défaut : http://localhost:1234)
 provider.lmstudio.setup.help=💡 Pour utiliser LMStudio :\n\n1. Installez : https://lmstudio.ai/\n2. Lancez le serveur local\n3. Modifier l’URL de base si nécessaire
+provider.lmstudio.openai.compat.info=Askimo utilise les points de terminaison compatibles OpenAI (/v1), pas l’API LMStudio native (/api/v1/).
 
 # System Resources
 system.memory=Mémoire

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -682,6 +682,7 @@ provider.localai.setup.help=💡 LocalAI を使用するには先に実行して
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=LMStudio ベース URL (デフォルト: http://localhost:1234)
 provider.lmstudio.setup.help=💡 LMStudio の利用方法:\n\n1. https://lmstudio.ai/ でインストール\n2. ローカルサーバーを起動\n3. 必要に応じてベース URL を変更
+provider.lmstudio.openai.compat.info=Askimo はネイティブ LMStudio API（/api/v1/）ではなく、OpenAI 互換エンドポイント（/v1）を使用します。
 
 # System Resources
 system.memory=メモリ

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -683,6 +683,7 @@ provider.localai.setup.help=💡 LocalAI를 사용하려면 먼저 실행해야 
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=LMStudio 기본 URL (기본값: http://localhost:1234)
 provider.lmstudio.setup.help=💡 LMStudio 사용 방법:\n\n1. https://lmstudio.ai/ 에서 설치\n2. 로컬 서버 실행\n3. 필요 시 기본 URL 변경
+provider.lmstudio.openai.compat.info=Askimo는 기본 LMStudio API(/api/v1/)가 아닌 OpenAI 호환 엔드포인트(/v1)를 사용합니다.
 
 # System Resources
 system.memory=메모리

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -683,6 +683,7 @@ provider.localai.setup.help=💡 Para usar o LocalAI, execute-o primeiro.\n\n1. 
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=Base URL do LMStudio (padrão: http://localhost:1234)
 provider.lmstudio.setup.help=💡 Para usar o LMStudio:\n\n1. Instale: https://lmstudio.ai/\n2. Inicie o servidor local\n3. Configure o Base URL se necessário
+provider.lmstudio.openai.compat.info=O Askimo usa os endpoints compatíveis com OpenAI (/v1), não a API nativa do LMStudio (/api/v1/).
 
 # System Resources
 system.memory=Memória

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -681,6 +681,7 @@ provider.localai.setup.help=💡 Để dùng LocalAI, cần chạy LocalAI.\n\n1
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=Base URL LMStudio (mặc định http://localhost:1234)
 provider.lmstudio.setup.help=💡 Để dùng LMStudio:\n\n1. Cài từ https://lmstudio.ai/\n2. Chạy server cục bộ\n3. Tùy chọn thay đổi base URL
+provider.lmstudio.openai.compat.info=Askimo sử dụng các endpoint tương thích OpenAI (/v1), không phải API LMStudio gốc (/api/v1/).
 
 # System Resources
 system.memory=Bộ nhớ

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -682,6 +682,7 @@ provider.localai.setup.help=使用 LocalAI 需先运行。\n\n1. 安装并启动
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=LMStudio 基础 URL（默认 http://localhost:1234）
 provider.lmstudio.setup.help=使用 LMStudio：\n\n1. 安装：https://lmstudio.ai/\n2. 启动本地服务\n3. 可选更改基础 URL
+provider.lmstudio.openai.compat.info=Askimo 使用 OpenAI 兼容端点（/v1），而非 LMStudio 原生 API（/api/v1/）。
 
 # System Resources
 system.memory=内存

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -682,6 +682,7 @@ provider.localai.setup.help=💡 若要使用 LocalAI，請先啟動服務。\n\
 # Provider Configuration - LMStudio
 provider.lmstudio.baseurl.description=您的 LMStudio 基本 URL（預設：http://localhost:1234）
 provider.lmstudio.setup.help=💡 若要使用 LMStudio：\n\n1. 安裝：https://lmstudio.ai/\n2. 啟動本機伺服器\n3. 若需要，調整基本 URL
+provider.lmstudio.openai.compat.info=Askimo 使用 OpenAI 相容端點（/v1），而非 LMStudio 原生 API（/api/v1/）。
 
 # System Resources
 system.memory=記憶體

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
@@ -346,106 +346,141 @@ fun providerSelectionDialog(
                             )
 
                             viewModel.providerConfigFields.forEach { field ->
-                                Column(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
-                                ) {
-                                    Text(
-                                        text = field.label + if (field.required) " *" else "",
-                                        style = MaterialTheme.typography.labelLarge,
-                                    )
-                                    Text(
-                                        text = field.description,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-
-                                    when (field) {
-                                        is ProviderConfigField.ApiKeyField -> {
-                                            OutlinedTextField(
-                                                value = viewModel.providerFieldValues[field.name] ?: "",
-                                                onValueChange = { viewModel.updateProviderField(field.name, it) },
-                                                modifier = Modifier.fillMaxWidth(),
-                                                singleLine = true,
-                                                visualTransformation = PasswordVisualTransformation(),
-                                                placeholder = {
-                                                    Text(
-                                                        if (field.hasExistingValue) {
-                                                            stringResource("provider.apikey.stored")
-                                                        } else {
-                                                            stringResource("provider.apikey.enter")
-                                                        },
-                                                    )
-                                                },
-                                                trailingIcon = {
-                                                    Row {
-                                                        if (field.hasExistingValue) {
-                                                            Icon(
-                                                                Icons.Default.CheckCircle,
-                                                                contentDescription = stringResource("provider.apikey.already.stored"),
-                                                                tint = MaterialTheme.colorScheme.onSurface,
-                                                            )
-                                                        }
-                                                        Spacer(modifier = Modifier.width(8.dp))
-                                                        Icon(Icons.Default.Lock, contentDescription = "Password")
-                                                    }
-                                                },
-                                                colors = AppComponents.outlinedTextFieldColors(),
-                                            )
-
-                                            // Security assurance message
-                                            Card(
+                                when (field) {
+                                    is ProviderConfigField.InfoField -> {
+                                        Card(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            colors = CardDefaults.cardColors(
+                                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                            ),
+                                        ) {
+                                            Row(
                                                 modifier = Modifier
                                                     .fillMaxWidth()
-                                                    .padding(top = Spacing.small),
-                                                colors = CardDefaults.cardColors(
-                                                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                                ),
+                                                    .padding(Spacing.medium),
+                                                horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                                                verticalAlignment = Alignment.Top,
                                             ) {
-                                                Column(
-                                                    modifier = Modifier
-                                                        .fillMaxWidth()
-                                                        .padding(Spacing.medium),
-                                                    verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
-                                                ) {
-                                                    Text(
-                                                        text = stringResource("provider.apikey.security.message"),
-                                                        style = MaterialTheme.typography.bodySmall,
-                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                    )
-                                                    linkButton(
-                                                        onClick = {
-                                                            try {
-                                                                Desktop.getDesktop().browse(
-                                                                    URI("https://askimo.chat/security/"),
-                                                                )
-                                                            } catch (_: Exception) {
-                                                                // Silently fail if browser cannot be opened
-                                                            }
-                                                        },
-                                                        modifier = Modifier.padding(0.dp),
-                                                    ) {
-                                                        Text(
-                                                            text = stringResource("provider.apikey.security.link"),
-                                                            style = MaterialTheme.typography.bodySmall,
-                                                        )
-                                                    }
-                                                }
+                                                Icon(
+                                                    Icons.Default.Info,
+                                                    contentDescription = "Info",
+                                                    modifier = Modifier.size(16.dp),
+                                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                )
+                                                Text(
+                                                    text = field.message,
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                )
                                             }
                                         }
+                                    }
 
-                                        is ProviderConfigField.BaseUrlField -> {
-                                            OutlinedTextField(
-                                                value = viewModel.providerFieldValues[field.name] ?: "",
-                                                onValueChange = { viewModel.updateProviderField(field.name, it) },
-                                                modifier = Modifier.fillMaxWidth(),
-                                                singleLine = true,
-                                                placeholder = { Text(stringResource("settings.placeholder.baseurl")) },
-                                                colors = AppComponents.outlinedTextFieldColors(),
+                                    else -> {
+                                        Column(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+                                        ) {
+                                            Text(
+                                                text = field.label + if (field.required) " *" else "",
+                                                style = MaterialTheme.typography.labelLarge,
                                             )
+                                            Text(
+                                                text = field.description,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+
+                                            when (field) {
+                                                is ProviderConfigField.ApiKeyField -> {
+                                                    OutlinedTextField(
+                                                        value = viewModel.providerFieldValues[field.name] ?: "",
+                                                        onValueChange = { viewModel.updateProviderField(field.name, it) },
+                                                        modifier = Modifier.fillMaxWidth(),
+                                                        singleLine = true,
+                                                        visualTransformation = PasswordVisualTransformation(),
+                                                        placeholder = {
+                                                            Text(
+                                                                if (field.hasExistingValue) {
+                                                                    stringResource("provider.apikey.stored")
+                                                                } else {
+                                                                    stringResource("provider.apikey.enter")
+                                                                },
+                                                            )
+                                                        },
+                                                        trailingIcon = {
+                                                            Row {
+                                                                if (field.hasExistingValue) {
+                                                                    Icon(
+                                                                        Icons.Default.CheckCircle,
+                                                                        contentDescription = stringResource("provider.apikey.already.stored"),
+                                                                        tint = MaterialTheme.colorScheme.onSurface,
+                                                                    )
+                                                                }
+                                                                Spacer(modifier = Modifier.width(8.dp))
+                                                                Icon(Icons.Default.Lock, contentDescription = "Password")
+                                                            }
+                                                        },
+                                                        colors = AppComponents.outlinedTextFieldColors(),
+                                                    )
+
+                                                    // Security assurance message
+                                                    Card(
+                                                        modifier = Modifier
+                                                            .fillMaxWidth()
+                                                            .padding(top = Spacing.small),
+                                                        colors = CardDefaults.cardColors(
+                                                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                                        ),
+                                                    ) {
+                                                        Column(
+                                                            modifier = Modifier
+                                                                .fillMaxWidth()
+                                                                .padding(Spacing.medium),
+                                                            verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+                                                        ) {
+                                                            Text(
+                                                                text = stringResource("provider.apikey.security.message"),
+                                                                style = MaterialTheme.typography.bodySmall,
+                                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                            )
+                                                            linkButton(
+                                                                onClick = {
+                                                                    try {
+                                                                        Desktop.getDesktop().browse(
+                                                                            URI("https://askimo.chat/security/"),
+                                                                        )
+                                                                    } catch (_: Exception) {
+                                                                        // Silently fail if browser cannot be opened
+                                                                    }
+                                                                },
+                                                                modifier = Modifier.padding(0.dp),
+                                                            ) {
+                                                                Text(
+                                                                    text = stringResource("provider.apikey.security.link"),
+                                                                    style = MaterialTheme.typography.bodySmall,
+                                                                )
+                                                            }
+                                                        }
+                                                    }
+                                                }
+
+                                                is ProviderConfigField.BaseUrlField -> {
+                                                    OutlinedTextField(
+                                                        value = viewModel.providerFieldValues[field.name] ?: "",
+                                                        onValueChange = { viewModel.updateProviderField(field.name, it) },
+                                                        modifier = Modifier.fillMaxWidth(),
+                                                        singleLine = true,
+                                                        placeholder = { Text(stringResource("settings.placeholder.baseurl")) },
+                                                        colors = AppComponents.outlinedTextFieldColors(),
+                                                    )
+                                                }
+
+                                                else -> {}
+                                            }
                                         }
                                     }
-                                }
+                                } // when (field)
                             }
 
                             // Connection error display

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsViewModel.kt
@@ -191,12 +191,13 @@ class SettingsViewModel(
             providerConfigFields = existingSettings?.getConfigFields(LocalizationManager.messageResolver) ?: emptyList()
 
             // Initialize field values with existing or default values
-            providerFieldValues = providerConfigFields.associate { field ->
+            providerFieldValues = providerConfigFields.mapNotNull { field ->
                 when (field) {
                     is ProviderConfigField.ApiKeyField -> field.name to field.value
                     is ProviderConfigField.BaseUrlField -> field.name to field.value
+                    is ProviderConfigField.InfoField -> null
                 }
-            }
+            }.toMap()
         } else {
             // No provider configured yet
             selectedProvider = null
@@ -236,12 +237,13 @@ class SettingsViewModel(
         providerConfigFields = existingSettings?.getConfigFields(LocalizationManager.messageResolver) ?: emptyList()
 
         // Initialize field values with existing or default values
-        providerFieldValues = providerConfigFields.associate { field ->
+        providerFieldValues = providerConfigFields.mapNotNull { field ->
             when (field) {
                 is ProviderConfigField.ApiKeyField -> field.name to field.value
                 is ProviderConfigField.BaseUrlField -> field.name to field.value
+                is ProviderConfigField.InfoField -> null
             }
-        }
+        }.toMap()
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/ProviderConfigField.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ProviderConfigField.kt
@@ -29,6 +29,14 @@ sealed class ProviderConfigField {
         override val required: Boolean = true,
         val value: String = "",
     ) : ProviderConfigField()
+
+    data class InfoField(
+        override val name: String,
+        override val label: String = "",
+        override val description: String = "",
+        override val required: Boolean = false,
+        val message: String,
+    ) : ProviderConfigField()
 }
 
 /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioSettings.kt
@@ -38,6 +38,10 @@ data class LmStudioSettings(
     override fun getSetupHelpText(messageResolver: (String) -> String): String = messageResolver("provider.lmstudio.setup.help")
 
     override fun getConfigFields(messageResolver: (String) -> String): List<ProviderConfigField> = listOf(
+        ProviderConfigField.InfoField(
+            name = "openai_compat_info",
+            message = messageResolver("provider.lmstudio.openai.compat.info"),
+        ),
         ProviderConfigField.BaseUrlField(
             description = messageResolver("provider.lmstudio.baseurl.description"),
             value = baseUrl,


### PR DESCRIPTION
Fixes #307

## Changes
- Added `InfoField` as a new sealed subclass of `ProviderConfigField`
- Added informational message in `LmStudioSettings` explaining that Askimo uses OpenAI-compatible endpoints (/v1), not the native LMStudio API (/api/v1/)


- Updated `ProviderSelectionDialog` to render `InfoField` as an info card with an icon
- Updated `SettingsViewModel` to skip `InfoField` when building providerFieldValues map
- Added translations in all 10 supported languages

## Screenshots
The info message now appears when the user selects LMStudio as provider.
<img width="1919" height="1199" alt="Captura de ecrã 2026-04-13 155018" src="https://github.com/user-attachments/assets/36b0c87e-8282-4a12-83ba-89a32dc1b830" />