### PR TITLE
refactor(filekit): replace native file dialogs with FileKit across UI

### DIFF
--- a/desktop-shared/build.gradle.kts
+++ b/desktop-shared/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation(libs.openpdf)
     // Word export
     implementation(libs.poi.ooxml)
+    // FileKit — consistent native file/folder picker on all platforms
+    implementation(libs.filekit.compose)
     testImplementation(kotlin("test"))
 }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -92,11 +93,10 @@ import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.util.Platform
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.java.KoinJavaComponent
 import java.awt.Cursor
-import java.awt.FileDialog
-import java.awt.Frame
 import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.collections.minus
@@ -222,45 +222,46 @@ fun chatInputField(
     }
 
     val selectFileTitle = stringResource("chat.select.file")
+    val scope = rememberCoroutineScope()
     val openFileDialog = {
-        val fileChooser = FileDialog(null as Frame?, selectFileTitle, FileDialog.LOAD)
-        fileChooser.isMultipleMode = true
-        fileChooser.setFilenameFilter(FileDialogUtils.createSupportedFileFilter())
-        fileChooser.isVisible = true
-        val selectedFiles = fileChooser.files
-        if (selectedFiles != null && selectedFiles.isNotEmpty()) {
-            try {
-                val maxFileSizeBytes = AppConfig.indexing.maxFileBytes
-                val invalidFiles = selectedFiles.filter { it.length() > maxFileSizeBytes }
+        scope.launch {
+            val paths = FileDialogUtils.pickFilePaths(selectFileTitle)
+            if (paths.isNotEmpty()) {
+                try {
+                    val maxFileSizeBytes = AppConfig.indexing.maxFileBytes
+                    val files = paths.map { java.io.File(it) }
+                    val invalidFiles = files.filter { it.length() > maxFileSizeBytes }
 
-                if (invalidFiles.isNotEmpty()) {
-                    val firstInvalidFile = invalidFiles.first()
-                    EventBus.post(
-                        AppErrorEvent(
-                            title = "File Too Large",
-                            message = "File '${firstInvalidFile.name}' is too large (${formatFileSize(firstInvalidFile.length())}). Maximum allowed size is ${formatFileSize(maxFileSizeBytes)}.",
-                        ),
-                    )
-                } else {
-                    val newAttachments = selectedFiles.map { file ->
-                        FileAttachmentDTO(
-                            id = UUID.randomUUID().toString(),
-                            messageId = "",
-                            sessionId = sessionId ?: "",
-                            fileName = file.name,
-                            mimeType = file.extension,
-                            size = file.length(),
-                            createdAt = LocalDateTime.now(),
-                            content = null,
-                            filePath = file.absolutePath,
+                    if (invalidFiles.isNotEmpty()) {
+                        val firstInvalidFile = invalidFiles.first()
+                        EventBus.post(
+                            AppErrorEvent(
+                                title = "File Too Large",
+                                message = "File '${firstInvalidFile.name}' is too large (${formatFileSize(firstInvalidFile.length())}). Maximum allowed size is ${formatFileSize(maxFileSizeBytes)}.",
+                            ),
                         )
+                    } else {
+                        val newAttachments = files.map { file ->
+                            FileAttachmentDTO(
+                                id = UUID.randomUUID().toString(),
+                                messageId = "",
+                                sessionId = sessionId ?: "",
+                                fileName = file.name,
+                                mimeType = file.extension,
+                                size = file.length(),
+                                createdAt = LocalDateTime.now(),
+                                content = null,
+                                filePath = file.absolutePath,
+                            )
+                        }
+                        onAttachmentsChange(attachments + newAttachments)
                     }
-                    onAttachmentsChange(attachments + newAttachments)
+                } catch (e: Exception) {
+                    log.error("Error adding file attachments: ${e.message}", e)
                 }
-            } catch (e: Exception) {
-                log.error("Error adding file attachments: ${e.message}", e)
             }
         }
+        Unit
     }
 
     Column(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -91,16 +92,16 @@ import io.askimo.ui.common.theme.LocalBackgroundActive
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.TooltipPlacement
 import io.askimo.ui.common.ui.themedTooltip
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.service.AvatarService
 import io.askimo.ui.session.manageDirectivesDialog
 import io.askimo.ui.session.newDirectiveDialog
 import io.askimo.ui.session.sessionActionsMenu
 import io.askimo.ui.session.sessionMemoryDialog
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.context.GlobalContext
-import java.awt.FileDialog
-import java.awt.Frame
 import java.io.File
 import java.time.LocalDateTime
 
@@ -147,6 +148,7 @@ fun chatView(
     val project = state.project
 
     // Internal state management for ChatView
+    val scope = rememberCoroutineScope()
     var inputText by remember(initialInputText) { mutableStateOf(initialInputText) }
     var attachments by remember(initialAttachments) { mutableStateOf(initialAttachments) }
     var editingMessage by remember(initialEditingMessage) { mutableStateOf(initialEditingMessage) }
@@ -700,6 +702,13 @@ fun chatView(
                                     manageDirectivesDialog(
                                         directives = availableDirectives,
                                         onDismiss = { showManageDirectivesDialog = false },
+                                        onAdd = { name, content, applyToCurrent ->
+                                            val newDirective = directiveService.createDirective(name, content)
+                                            availableDirectives = directiveService.listAllDirectives()
+                                            if (applyToCurrent) {
+                                                actions.setDirective(newDirective.id)
+                                            }
+                                        },
                                         onUpdate = { id, newName, newContent ->
                                             directiveService.updateDirective(id, newName, newContent)
                                             availableDirectives = directiveService.listAllDirectives()
@@ -832,14 +841,14 @@ fun chatView(
             // Download attachment handler
             val saveDialogTitle = stringResource("attachment.save.file")
             val downloadAttachment: (FileAttachmentDTO) -> Unit = { attachment ->
-                val fileChooser = FileDialog(null as Frame?, saveDialogTitle, FileDialog.SAVE)
-                fileChooser.file = attachment.fileName
-                fileChooser.isVisible = true
-                val selectedFile = fileChooser.file
-                val selectedDir = fileChooser.directory
-                if (selectedFile != null && selectedDir != null) {
-                    val targetFile = File(selectedDir, selectedFile)
-                    // Copy the attachment file to the selected location
+                scope.launch {
+                    val nameWithoutExt = attachment.fileName.substringBeforeLast('.', attachment.fileName)
+                    val ext = attachment.fileName.substringAfterLast('.', "")
+                    val targetFile = FileDialogUtils.pickSavePath(
+                        suggestedName = nameWithoutExt,
+                        extension = ext,
+                        title = saveDialogTitle,
+                    ) ?: return@launch
                     attachment.filePath?.let { filePath ->
                         val sourceFile = File(filePath)
                         if (sourceFile.exists()) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -7,11 +7,13 @@ package io.askimo.ui.common.theme
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -200,18 +202,10 @@ object AppComponents {
     fun secondaryIconColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
 
     @Composable
-    fun disabledIconColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-
-    @Composable
     fun tertiaryIconColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
 
     @Composable
     fun secondaryTextColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-
-    @Composable
-    fun tertiaryTextColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-
-    // ── Themed Composable Wrappers ────────────────────────────────────────────
 
     @Composable
     fun dropdownMenu(
@@ -226,7 +220,7 @@ object AppComponents {
                 surfaceContainer = MaterialTheme.colorScheme.surface,
             ),
         ) {
-            androidx.compose.material3.DropdownMenu(
+            DropdownMenu(
                 expanded = expanded,
                 onDismissRequest = onDismissRequest,
                 offset = offset,
@@ -262,7 +256,7 @@ object AppComponents {
                 surfaceContainerHigh = MaterialTheme.colorScheme.surface,
             ),
         ) {
-            androidx.compose.material3.AlertDialog(
+            AlertDialog(
                 onDismissRequest = onDismissRequest,
                 confirmButton = confirmButton,
                 modifier = modifier,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
@@ -83,6 +83,7 @@ import io.askimo.core.util.JsonUtils.json
 import io.askimo.tools.chart.MermaidChartData
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -110,13 +111,10 @@ import org.commonmark.node.SoftLineBreak
 import org.commonmark.node.StrongEmphasis
 import org.commonmark.parser.Parser
 import java.io.ByteArrayInputStream
-import java.io.File
 import java.net.URI
 import java.util.Base64
 import javax.imageio.ImageIO
-import javax.swing.JFileChooser
 import javax.swing.SwingUtilities
-import javax.swing.filechooser.FileNameExtensionFilter
 import org.commonmark.node.Text as MarkdownText
 
 private val log = currentFileLogger()
@@ -1671,30 +1669,25 @@ private fun downloadImage(
     defaultFileName: String = "image.png",
 ) {
     SwingUtilities.invokeLater {
-        try {
-            // Determine file extension and default name
-            val (extension, fileName) = when {
-                imageUrl != null -> {
-                    val urlFileName = imageUrl.substringAfterLast('/').substringBefore('?').ifEmpty { defaultFileName }
-                    val ext = urlFileName.substringAfterLast('.', "png")
-                    ext to urlFileName
+        kotlinx.coroutines.runBlocking {
+            try {
+                val (extension, fileName) = when {
+                    imageUrl != null -> {
+                        val urlFileName = imageUrl.substringAfterLast('/').substringBefore('?').ifEmpty { defaultFileName }
+                        val ext = urlFileName.substringAfterLast('.', "png")
+                        ext to urlFileName
+                    }
+
+                    else -> "png" to defaultFileName
                 }
 
-                else -> "png" to defaultFileName
-            }
-
-            val fileChooser = JFileChooser()
-            fileChooser.dialogTitle = "Save Image"
-            val filterDescription = "${extension.uppercase()} Image"
-            fileChooser.fileFilter = FileNameExtensionFilter(filterDescription, extension)
-            fileChooser.selectedFile = File(fileName)
-
-            val result = fileChooser.showSaveDialog(null)
-            if (result == JFileChooser.APPROVE_OPTION) {
-                var file = fileChooser.selectedFile
-                // Ensure proper extension
-                if (!file.name.endsWith(".$extension", ignoreCase = true)) {
-                    file = File(file.absolutePath + ".$extension")
+                val file = FileDialogUtils.pickSavePath(
+                    suggestedName = fileName.substringBeforeLast('.', fileName),
+                    extension = extension,
+                    title = "Save Image",
+                ) ?: run {
+                    log.debug("Save image dialog cancelled")
+                    return@runBlocking
                 }
 
                 // Save the image based on source type
@@ -1718,11 +1711,9 @@ private fun downloadImage(
                         log.error("No image data or URL provided")
                     }
                 }
-            } else {
-                log.debug("Save image dialog cancelled")
+            } catch (e: Exception) {
+                log.error("Failed to save image", e)
             }
-        } catch (e: Exception) {
-            log.error("Failed to save image", e)
         }
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
@@ -66,18 +66,18 @@ import androidx.compose.ui.window.rememberWindowState
 import io.askimo.core.logging.currentFileLogger
 import io.askimo.tools.chart.MermaidChartData
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.service.MermaidCliNotAvailableException
 import io.askimo.ui.service.MermaidSvgService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.slf4j.Logger
 import java.awt.Desktop
 import java.io.File
 import java.net.URI
-import javax.swing.JFileChooser
-import javax.swing.filechooser.FileNameExtensionFilter
 import org.jetbrains.skia.Image as SkiaImage
 
 private val log = currentFileLogger()
@@ -500,19 +500,13 @@ private fun mermaidSetupInstructions(
  * Shows a file chooser dialog and saves the image data as PNG.
  */
 private fun downloadDiagramAsPng(imageData: ByteArray, log: Logger) {
-    val fileChooser = JFileChooser()
-    fileChooser.dialogTitle = "Save Diagram"
-    fileChooser.fileFilter = FileNameExtensionFilter("PNG Image", "png")
-    fileChooser.selectedFile = File("mermaid-diagram.png")
-
-    val result = fileChooser.showSaveDialog(null)
-    if (result == JFileChooser.APPROVE_OPTION) {
+    runBlocking {
+        val file = FileDialogUtils.pickSavePath(
+            suggestedName = "mermaid-diagram",
+            extension = "png",
+            title = "Save Diagram",
+        ) ?: return@runBlocking
         try {
-            var file = fileChooser.selectedFile
-            // Ensure .png extension
-            if (!file.name.endsWith(".png", ignoreCase = true)) {
-                file = File(file.absolutePath + ".png")
-            }
             file.writeBytes(imageData)
             log.debug("Diagram saved to: {}", file.absolutePath)
         } catch (e: Exception) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/util/FileDialogUtils.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/util/FileDialogUtils.kt
@@ -5,42 +5,80 @@
 package io.askimo.ui.common.ui.util
 
 import io.askimo.core.chat.util.FileTypeSupport
-import java.awt.FileDialog
-import java.awt.Frame
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import io.github.vinceglb.filekit.dialogs.openFileSaver
+import io.github.vinceglb.filekit.path
 import java.io.File
-import java.io.FilenameFilter
 
 /**
- * Utilities for working with file dialogs.
+ * Utilities for working with file/folder pickers via FileKit.
+ *
+ * FileKit uses the native OS dialog on every platform:
+ *  - macOS  → NSOpenPanel / NSSavePanel
+ *  - Windows → IFileOpenDialog / IFileSaveDialog
+ *  - Linux   → GTK file chooser (xdg-portal / AWT fallback)
+ *
+ * All helpers are `suspend` functions — call them from a coroutine scope
+ * (e.g. `LaunchedEffect`, a `CoroutineScope` button click handler, or `rememberCoroutineScope`).
  */
 object FileDialogUtils {
-    /**
-     * Creates a filename filter that accepts all supported files (text + images).
-     * This allows users to attach both text files (for RAG/content extraction) and images (for vision).
-     */
-    fun createSupportedFileFilter(): FilenameFilter = FilenameFilter { _, name ->
-        val extension = FileTypeSupport.getExtension(name)
-        FileTypeSupport.isSupported(extension)
-    }
 
     /**
-     * Opens a native folder selection dialog and returns the selected folder path.
-     * Uses java.awt.FileDialog with apple.awt.fileDialogForDirectories on macOS
-     * for a true native folder picker experience.
+     * Opens a native folder picker and returns the selected directory path, or null if cancelled.
+     */
+    suspend fun pickFolderPath(title: String): String? = FileKit.openDirectoryPicker()?.path
+
+    /**
+     * Opens a native single-file picker filtered to [extensions] and returns the
+     * selected file path, or null if cancelled.
+     * Pass null to [extensions] to allow all supported file types.
+     */
+    suspend fun pickFilePath(
+        title: String,
+        extensions: List<String>? = FileTypeSupport.supportedExtensions(),
+    ): String? = FileKit.openFilePicker(
+        type = FileKitType.File(extensions ?: emptyList()),
+    )?.path
+
+    /**
+     * Opens a native multi-file picker filtered to [extensions] and returns a list
+     * of selected file paths (empty if cancelled).
+     * Pass null to [extensions] to allow all supported file types.
+     */
+    suspend fun pickFilePaths(
+        title: String,
+        extensions: List<String>? = FileTypeSupport.supportedExtensions(),
+    ): List<String> = FileKit.openFilePicker(
+        type = FileKitType.File(extensions ?: emptyList()),
+        mode = FileKitMode.Multiple(),
+    )?.map { it.path } ?: emptyList()
+
+    /**
+     * Opens a native image-file picker and returns the selected file path, or null if cancelled.
+     */
+    suspend fun pickImagePath(title: String): String? = FileKit.openFilePicker(
+        type = FileKitType.Image,
+    )?.path
+
+    /**
+     * Opens a native save dialog and returns the target [File], or null if cancelled.
      *
-     * @param title The title of the folder selection dialog
-     * @return The absolute path of the selected folder, or null if cancelled
+     * @param suggestedName Default file name shown in the dialog (without extension).
+     * @param extension     File extension without dot, e.g. `"pdf"`.
+     * @param title         Dialog title (kept for call-site compatibility; not passed to FileKit 0.13+).
      */
-    fun chooseFolderPath(title: String): String? {
-        val dialog = FileDialog(null as Frame?, title, FileDialog.LOAD)
-        System.setProperty("apple.awt.fileDialogForDirectories", "true")
-        dialog.isVisible = true
-        System.setProperty("apple.awt.fileDialogForDirectories", "false")
-
-        return if (dialog.file != null) {
-            File(dialog.directory, dialog.file).absolutePath
-        } else {
-            null
-        }
-    }
+    suspend fun pickSavePath(
+        suggestedName: String,
+        extension: String,
+        title: String,
+    ): File? = FileKit.openFileSaver(
+        suggestedName = suggestedName,
+        extension = extension,
+        dialogSettings = FileKitDialogSettings.createDefault(),
+    )?.let { File(it.path) }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
@@ -93,13 +93,11 @@ import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.markdownText
 import io.askimo.ui.common.ui.themedTooltip
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.plan.PlanExportService.ExportFormat
 import io.askimo.ui.plan.PlanExportService.ExportMode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.awt.FileDialog
-import java.awt.Frame
-import java.io.File
 import kotlin.time.Duration.Companion.milliseconds
 
 // Characters revealed per tick during the simulated-streaming animation.
@@ -1074,7 +1072,7 @@ private fun resultPanel(
                                     text = { Text(stringResource("plans.export.result.pdf")) },
                                     onClick = {
                                         exportMenuExpanded = false
-                                        triggerExport(viewModel, planName, ExportMode.RESULT_ONLY, ExportFormat.PDF)
+                                        coroutineScope.launch { triggerExport(viewModel, planName, ExportMode.RESULT_ONLY, ExportFormat.PDF) }
                                     },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                 )
@@ -1082,7 +1080,7 @@ private fun resultPanel(
                                     text = { Text(stringResource("plans.export.result.word")) },
                                     onClick = {
                                         exportMenuExpanded = false
-                                        triggerExport(viewModel, planName, ExportMode.RESULT_ONLY, ExportFormat.WORD)
+                                        coroutineScope.launch { triggerExport(viewModel, planName, ExportMode.RESULT_ONLY, ExportFormat.WORD) }
                                     },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                 )
@@ -1091,7 +1089,7 @@ private fun resultPanel(
                                     text = { Text(stringResource("plans.export.fullrun.pdf")) },
                                     onClick = {
                                         exportMenuExpanded = false
-                                        triggerExport(viewModel, planName, ExportMode.FULL_RUN, ExportFormat.PDF)
+                                        coroutineScope.launch { triggerExport(viewModel, planName, ExportMode.FULL_RUN, ExportFormat.PDF) }
                                     },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                 )
@@ -1099,7 +1097,7 @@ private fun resultPanel(
                                     text = { Text(stringResource("plans.export.fullrun.word")) },
                                     onClick = {
                                         exportMenuExpanded = false
-                                        triggerExport(viewModel, planName, ExportMode.FULL_RUN, ExportFormat.WORD)
+                                        coroutineScope.launch { triggerExport(viewModel, planName, ExportMode.FULL_RUN, ExportFormat.WORD) }
                                     },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                 )
@@ -1132,7 +1130,7 @@ private fun resultPanel(
     }
 }
 
-private fun triggerExport(
+private suspend fun triggerExport(
     viewModel: PlansViewModel,
     planName: String,
     mode: ExportMode,
@@ -1143,15 +1141,11 @@ private fun triggerExport(
         ExportFormat.WORD -> "docx"
     }
 
-    val dialog = FileDialog(null as Frame?, "Export Plan", FileDialog.SAVE)
-    dialog.file = "${planName.replace(" ", "_")}.$extension"
-    dialog.isVisible = true // blocks the EDT until the user dismisses
-
-    val dir = dialog.directory ?: return
-    val file = dialog.file ?: return
-    val targetFile = File(dir, file).let {
-        if (it.extension.lowercase() == extension) it else File("${it.absolutePath}.$extension")
-    }
+    val targetFile = FileDialogUtils.pickSavePath(
+        suggestedName = planName.replace(" ", "_"),
+        extension = extension,
+        title = "Export Plan",
+    ) ?: return
     viewModel.exportPlan(targetFile, mode, format) { _ -> }
 }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddReferenceMaterialDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/AddReferenceMaterialDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,6 +38,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import kotlinx.coroutines.launch
 import java.util.UUID
 import kotlin.collections.plus
 
@@ -52,6 +54,7 @@ fun addReferenceMaterialDialog(
     var knowledgeSources by remember { mutableStateOf<List<KnowledgeSourceItem>>(emptyList()) }
     var showAddSourceMenu by remember { mutableStateOf(false) }
     var showUrlInputDialog by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
 
     val browseFolderTitle = stringResource("project.new.dialog.folder.browse")
     val browseFileTitle = stringResource("project.new.dialog.file.browse")
@@ -66,10 +69,12 @@ fun addReferenceMaterialDialog(
 
     // Handle adding a source based on type
     fun handleAddSource(typeInfo: KnowledgeSourceItem.TypeInfo) {
-        val newSources = sourceBrowser.handleAddSource(typeInfo) {
-            showUrlInputDialog = true
+        scope.launch {
+            val newSources = sourceBrowser.handleAddSource(typeInfo) {
+                showUrlInputDialog = true
+            }
+            knowledgeSources = knowledgeSources + newSources
         }
-        knowledgeSources = knowledgeSources + newSources
     }
 
     Dialog(onDismissRequest = onDismiss) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/EditProjectDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/EditProjectDialog.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,6 +62,7 @@ import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.UUID
 import kotlin.collections.plus
@@ -174,6 +176,7 @@ private fun editProjectForm(
     var knowledgeSources by remember { mutableStateOf(initialSources) }
     var showAddSourceMenu by remember { mutableStateOf(false) }
     var showUrlInputDialog by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
 
     var nameError by remember { mutableStateOf<String?>(null) }
     val focusRequester = remember { FocusRequester() }
@@ -192,10 +195,12 @@ private fun editProjectForm(
 
     // Handle adding a source based on type
     fun handleAddSource(typeInfo: KnowledgeSourceItem.TypeInfo) {
-        val newSources = sourceBrowser.handleAddSource(typeInfo) {
-            showUrlInputDialog = true
+        scope.launch {
+            val newSources = sourceBrowser.handleAddSource(typeInfo) {
+                showUrlInputDialog = true
+            }
+            knowledgeSources = knowledgeSources + newSources
         }
-        knowledgeSources = knowledgeSources + newSources
     }
 
     // Extract save logic to reuse in button and Enter key handler

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/KnowledgeSourceBrowser.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/KnowledgeSourceBrowser.kt
@@ -5,66 +5,51 @@
 package io.askimo.ui.project
 
 import io.askimo.ui.common.ui.util.FileDialogUtils
-import java.awt.FileDialog
-import java.awt.Frame
 import java.util.UUID
 
 /**
- * Helper class for browsing and adding knowledge sources (folders, files, URLs)
+ * Helper class for browsing and adding knowledge sources (folders, files, URLs).
  */
 class KnowledgeSourceBrowser(
     private val browseFolderTitle: String,
     private val browseFileTitle: String,
 ) {
     /**
-     * Browse for a folder and return a KnowledgeSourceItem.Folder if selected
+     * Browse for a folder and return a [KnowledgeSourceItem.Folder] if selected.
      */
-    fun browseForFolder(): KnowledgeSourceItem.Folder? {
-        val folderPath = FileDialogUtils.chooseFolderPath(browseFolderTitle)
-        return if (folderPath != null) {
+    suspend fun browseForFolder(): KnowledgeSourceItem.Folder? {
+        val folderPath = FileDialogUtils.pickFolderPath(browseFolderTitle)
+        return folderPath?.let {
             KnowledgeSourceItem.Folder(
                 id = UUID.randomUUID().toString(),
-                path = folderPath,
-                isValid = validateFolder(folderPath),
+                path = it,
+                isValid = validateFolder(it),
             )
-        } else {
-            null
         }
     }
 
     /**
-     * Browse for files and return a list of KnowledgeSourceItem.File
+     * Browse for files and return a list of [KnowledgeSourceItem.File].
      */
-    fun browseForFiles(): List<KnowledgeSourceItem.File> {
-        val dialog = FileDialog(null as Frame?, browseFileTitle, FileDialog.LOAD)
-        dialog.isMultipleMode = true
-        dialog.setFilenameFilter(FileDialogUtils.createSupportedFileFilter())
-        dialog.isVisible = true
-
-        return dialog.files?.map { file ->
-            KnowledgeSourceItem.File(
-                id = UUID.randomUUID().toString(),
-                path = file.absolutePath,
-                isValid = validateFile(file.absolutePath),
-            )
-        } ?: emptyList()
+    suspend fun browseForFiles(): List<KnowledgeSourceItem.File> = FileDialogUtils.pickFilePaths(browseFileTitle).map { path ->
+        KnowledgeSourceItem.File(
+            id = UUID.randomUUID().toString(),
+            path = path,
+            isValid = validateFile(path),
+        )
     }
 
     /**
-     * Handle adding sources based on type info
-     * Returns a list of new sources to add (empty list for URL type, which needs separate dialog)
+     * Handle adding sources based on type info.
+     * Returns a list of new sources to add (empty list for URL type, which needs separate dialog).
      */
-    fun handleAddSource(
+    suspend fun handleAddSource(
         typeInfo: KnowledgeSourceItem.TypeInfo,
         onShowUrlDialog: () -> Unit,
     ): List<KnowledgeSourceItem> = when (typeInfo) {
-        KnowledgeSourceItem.TypeInfo.FOLDER -> {
-            browseForFolder()?.let { listOf(it) } ?: emptyList()
-        }
+        KnowledgeSourceItem.TypeInfo.FOLDER -> browseForFolder()?.let { listOf(it) } ?: emptyList()
 
-        KnowledgeSourceItem.TypeInfo.FILE -> {
-            browseForFiles()
-        }
+        KnowledgeSourceItem.TypeInfo.FILE -> browseForFiles()
 
         KnowledgeSourceItem.TypeInfo.URL -> {
             onShowUrlDialog()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/McpToolsDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/McpToolsDialog.kt
@@ -62,13 +62,11 @@ import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.java.KoinJavaComponent.get
-import java.awt.FileDialog
-import java.awt.Frame
-import java.io.File
 import java.util.concurrent.TimeoutException
 
 @Composable
@@ -453,19 +451,14 @@ private suspend fun exportToolsToJson(
     dialogTitle: String,
 ): Result<String> = withContext(Dispatchers.IO) {
     runCatching {
-        val fileDialog = FileDialog(null as Frame?, dialogTitle, FileDialog.SAVE).apply {
-            file = "${instanceName.replace(" ", "_")}_tools.json"
-        }
-        fileDialog.isVisible = true
-
-        val fileName = fileDialog.file ?: return@runCatching Result.failure<String>(
+        val suggestedName = "${instanceName.replace(" ", "_")}_tools"
+        val targetFile = FileDialogUtils.pickSavePath(
+            suggestedName = suggestedName,
+            extension = "json",
+            title = dialogTitle,
+        ) ?: return@runCatching Result.failure<String>(
             IllegalStateException("Export cancelled"),
         ).getOrThrow()
-        val directory = fileDialog.directory ?: return@runCatching Result.failure<String>(
-            IllegalStateException("Export cancelled"),
-        ).getOrThrow()
-
-        val targetFile = File(directory, fileName)
 
         val json = buildString {
             appendLine("[")

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
@@ -55,9 +55,6 @@ import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.util.FileDialogUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.awt.FileDialog
-import java.awt.Frame
-import java.io.File
 import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.collections.plus
@@ -104,17 +101,10 @@ fun newProjectDialog(
         }
     }
 
-    // Browse for folder using FileDialog
+    // Browse for folder
     fun browseForFolder() {
-        val dialog = FileDialog(null as Frame?, browseFolderTitle, FileDialog.LOAD)
-
-        // macOS: Enable folder selection
-        System.setProperty("apple.awt.fileDialogForDirectories", "true")
-        dialog.isVisible = true
-        System.setProperty("apple.awt.fileDialogForDirectories", "false")
-
-        if (dialog.file != null) {
-            val folderPath = File(dialog.directory, dialog.file).absolutePath
+        scope.launch {
+            val folderPath = FileDialogUtils.pickFolderPath(browseFolderTitle) ?: return@launch
             knowledgeSources = knowledgeSources + KnowledgeSourceItem.Folder(
                 id = UUID.randomUUID().toString(),
                 path = folderPath,
@@ -123,19 +113,17 @@ fun newProjectDialog(
         }
     }
 
-    // Browse for files using FileDialog
+    // Browse for files
     fun browseForFiles() {
-        val dialog = FileDialog(null as Frame?, browseFileTitle, FileDialog.LOAD)
-        dialog.isMultipleMode = true
-        dialog.setFilenameFilter(FileDialogUtils.createSupportedFileFilter())
-        dialog.isVisible = true
-
-        dialog.files?.forEach { file ->
-            knowledgeSources = knowledgeSources + KnowledgeSourceItem.File(
-                id = UUID.randomUUID().toString(),
-                path = file.absolutePath,
-                isValid = validateFile(file.absolutePath),
-            )
+        scope.launch {
+            val paths = FileDialogUtils.pickFilePaths(browseFileTitle)
+            paths.forEach { path ->
+                knowledgeSources = knowledgeSources + KnowledgeSourceItem.File(
+                    id = UUID.randomUUID().toString(),
+                    path = path,
+                    isValid = validateFile(path),
+                )
+            }
         }
     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/service/AvatarService.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/service/AvatarService.kt
@@ -4,10 +4,12 @@
  */
 package io.askimo.ui.service
 
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import io.askimo.core.logging.logger
 import io.askimo.core.util.AskimoHome
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import java.io.File
 import java.net.URI
 import java.net.http.HttpClient
@@ -16,6 +18,8 @@ import java.net.http.HttpResponse
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.time.Duration
+import kotlin.io.path.Path
+import kotlin.io.path.exists
 import org.jetbrains.skia.Image as SkiaImage
 
 /**
@@ -179,6 +183,34 @@ class AvatarService {
     fun invalidateUserAvatarCache() {
         cachedUserAvatarPainter = null
         cachedUserAvatarPath = null
+    }
+
+    /**
+     * Opens the native image picker, copies the selected image into the user avatars directory,
+     * and returns the saved path + decoded [ImageBitmap]. Returns null if cancelled or on error.
+     *
+     * This is the single canonical implementation used by UserProfileDialog,
+     * WelcomeProfileDialog, and AppearanceSettingsSection.
+     */
+    suspend fun pickAndSaveUserAvatar(): Pair<String, ImageBitmap>? {
+        val sourcePath = FileDialogUtils.pickImagePath("Select Avatar Image")
+            ?.let { Path(it) }
+            ?.takeIf { it.exists() }
+            ?: return null
+
+        return try {
+            val userDataDir = AskimoHome.base().resolve("avatars")
+            Files.createDirectories(userDataDir)
+            val ext = sourcePath.fileName.toString().substringAfterLast(".")
+            val destPath = userDataDir.resolve("user_avatar_${System.currentTimeMillis()}.$ext")
+            Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING)
+            invalidateUserAvatarCache()
+            val bitmap = SkiaImage.makeFromEncoded(destPath.toFile().readBytes()).toComposeImageBitmap()
+            destPath.toString() to bitmap
+        } catch (e: Exception) {
+            log.warn("Failed to save user avatar", e)
+            null
+        }
     }
 
     /**

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
@@ -56,8 +56,8 @@ import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.export.ExportFormat
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import java.io.File
-import javax.swing.JFileChooser
 
 /**
  * Combined export session dialog that allows users to select export format and file location.
@@ -98,23 +98,17 @@ fun exportSessionDialog(
         }
     }
 
-    // Native file chooser
+    // Native file chooser via FileKit
     if (showFileBrowser) {
         LaunchedEffect(Unit) {
-            val fileChooser = JFileChooser().apply {
-                dialogTitle = fileChooserTitle
-                selectedFile = File(filePath)
-                fileSelectionMode = JFileChooser.FILES_ONLY
-            }
-
-            val result = fileChooser.showSaveDialog(null)
-            if (result == JFileChooser.APPROVE_OPTION) {
-                var selectedPath = fileChooser.selectedFile.absolutePath
-                // Ensure correct extension
-                if (!selectedPath.endsWith(".${selectedFormat.extension}")) {
-                    selectedPath = "${selectedPath.substringBeforeLast('.')}.${selectedFormat.extension}"
-                }
-                filePath = selectedPath
+            val baseName = File(filePath).nameWithoutExtension
+            val target = FileDialogUtils.pickSavePath(
+                suggestedName = baseName,
+                extension = selectedFormat.extension,
+                title = fileChooserTitle,
+            )
+            if (target != null) {
+                filePath = target.absolutePath
             }
             showFileBrowser = false
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
@@ -16,12 +16,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -53,6 +54,7 @@ import io.askimo.ui.common.ui.themedTooltip
 fun manageDirectivesDialog(
     directives: List<ChatDirective>,
     onDismiss: () -> Unit,
+    onAdd: (name: String, content: String, applyToCurrent: Boolean) -> Unit,
     onUpdate: (id: String, newName: String, newContent: String) -> Unit,
     onDelete: (id: String) -> Unit,
 ) {
@@ -60,6 +62,13 @@ fun manageDirectivesDialog(
     var editName by remember { mutableStateOf("") }
     var editContent by remember { mutableStateOf("") }
     var editError by remember { mutableStateOf<String?>(null) }
+
+    var isAdding by remember { mutableStateOf(false) }
+    var newName by remember { mutableStateOf("") }
+    var newContent by remember { mutableStateOf("") }
+    var newApplyToCurrent by remember { mutableStateOf(false) }
+    var newNameError by remember { mutableStateOf<String?>(null) }
+    var newContentError by remember { mutableStateOf<String?>(null) }
 
     // Pre-load error messages in composable context
     val nameRequiredError = stringResource("directive.edit.name.required")
@@ -102,7 +111,7 @@ fun manageDirectivesDialog(
                 HorizontalDivider()
 
                 // Directives list
-                if (directives.isEmpty()) {
+                if (directives.isEmpty() && !isAdding) {
                     Text(
                         text = stringResource("directive.manage.empty"),
                         style = MaterialTheme.typography.bodyMedium,
@@ -153,6 +162,7 @@ fun manageDirectivesDialog(
                                                         editName = directive.name
                                                         editContent = directive.content
                                                         editError = null
+                                                        isAdding = false
                                                     },
                                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                                 ) {
@@ -224,11 +234,6 @@ fun manageDirectivesDialog(
                                                         editError = null
                                                     },
                                                 ) {
-                                                    Icon(
-                                                        Icons.Default.Close,
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(16.dp),
-                                                    )
                                                     Text(stringResource("settings.cancel"))
                                                 }
 
@@ -247,11 +252,6 @@ fun manageDirectivesDialog(
                                                         }
                                                     },
                                                 ) {
-                                                    Icon(
-                                                        Icons.Default.Check,
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(16.dp),
-                                                    )
                                                     Text(stringResource("settings.save"))
                                                 }
                                             }
@@ -282,15 +282,135 @@ fun manageDirectivesDialog(
                     }
                 }
 
-                // Close button at bottom
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    secondaryButton(
-                        onClick = onDismiss,
+                HorizontalDivider()
+
+                // Add directive section
+                if (isAdding) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
-                        Text(stringResource("action.close"))
+                        Text(
+                            text = stringResource("directive.new.title"),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Text(
+                            text = stringResource("directive.new.guidelines"),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        OutlinedTextField(
+                            value = newName,
+                            onValueChange = {
+                                newName = it
+                                newNameError = null
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            label = { Text(stringResource("directive.edit.name.label")) },
+                            placeholder = { Text(stringResource("directive.new.name.placeholder")) },
+                            singleLine = true,
+                            isError = newNameError != null,
+                            supportingText = newNameError?.let { { Text(it) } },
+                            colors = AppComponents.outlinedTextFieldColors(),
+                        )
+                        OutlinedTextField(
+                            value = newContent,
+                            onValueChange = {
+                                newContent = it
+                                newContentError = null
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(150.dp),
+                            label = { Text(stringResource("directive.edit.content.label")) },
+                            placeholder = { Text(stringResource("directive.new.content.placeholder")) },
+                            maxLines = 8,
+                            isError = newContentError != null,
+                            supportingText = newContentError?.let { { Text(it) } },
+                            colors = AppComponents.outlinedTextFieldColors(),
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Checkbox(
+                                checked = newApplyToCurrent,
+                                onCheckedChange = { newApplyToCurrent = it },
+                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                            )
+                            Text(
+                                text = stringResource("directive.new.apply.current"),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            secondaryButton(
+                                onClick = {
+                                    isAdding = false
+                                    newName = ""
+                                    newContent = ""
+                                    newApplyToCurrent = false
+                                    newNameError = null
+                                    newContentError = null
+                                },
+                            ) {
+                                Text(stringResource("settings.cancel"))
+                            }
+                            primaryButton(
+                                onClick = {
+                                    var hasError = false
+                                    if (newName.isBlank()) {
+                                        newNameError = nameRequiredError
+                                        hasError = true
+                                    }
+                                    if (newContent.isBlank()) {
+                                        newContentError = contentRequiredError
+                                        hasError = true
+                                    }
+                                    if (!hasError) {
+                                        onAdd(newName.trim(), newContent.trim(), newApplyToCurrent)
+                                        isAdding = false
+                                        newName = ""
+                                        newContent = ""
+                                        newApplyToCurrent = false
+                                        newNameError = null
+                                        newContentError = null
+                                    }
+                                },
+                            ) {
+                                Text(stringResource("directive.new.create"))
+                            }
+                        }
+                    }
+                } else {
+                    // Bottom bar: Add button + Close
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        primaryButton(
+                            onClick = {
+                                isAdding = true
+                                editingDirective = null
+                            },
+                        ) {
+                            Icon(
+                                Icons.Default.Add,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                            )
+                            Text(stringResource("directive.new.title"))
+                        }
+                        secondaryButton(onClick = onDismiss) {
+                            Text(stringResource("action.close"))
+                        }
                     }
                 }
             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AppearanceSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AppearanceSettingsSection.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -67,10 +68,10 @@ import io.askimo.ui.common.theme.ThemeMode
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.asyncImage
 import io.askimo.ui.common.ui.clickableCard
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.service.AvatarService
 import io.askimo.ui.service.BackgroundImageService
-import java.awt.FileDialog
-import java.awt.Frame
+import kotlinx.coroutines.launch
 import java.io.File
 import org.jetbrains.skia.Image as SkiaImage
 
@@ -418,6 +419,7 @@ private fun avatarSetting(
     onSelectAvatar: (String) -> Unit,
     onRemoveAvatar: () -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = AppComponents.surfaceVariantCardColors(),
@@ -476,23 +478,9 @@ private fun avatarSetting(
             ) {
                 primaryButton(
                     onClick = {
-                        val fileDialog = FileDialog(
-                            null as Frame?,
-                            "Select Avatar",
-                            FileDialog.LOAD,
-                        )
-                        fileDialog.setFilenameFilter { _, name ->
-                            name.lowercase().endsWith(".png") ||
-                                name.lowercase().endsWith(".jpg") ||
-                                name.lowercase().endsWith(".jpeg") ||
-                                name.lowercase().endsWith(".gif") ||
-                                name.lowercase().endsWith(".bmp")
-                        }
-                        fileDialog.isVisible = true
-                        val selectedFile = fileDialog.file
-                        val selectedDir = fileDialog.directory
-                        if (selectedFile != null && selectedDir != null) {
-                            onSelectAvatar(File(selectedDir, selectedFile).absolutePath)
+                        scope.launch {
+                            val path = FileDialogUtils.pickImagePath("Select Avatar")
+                            if (path != null) onSelectAvatar(path)
                         }
                     },
                 ) {
@@ -634,6 +622,7 @@ private fun backgroundImageCustomOption(
     onRemove: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val scope = rememberCoroutineScope()
     val browseLabel = stringResource("settings.background.image.browse")
 
     val painter = remember(current) {
@@ -649,13 +638,9 @@ private fun backgroundImageCustomOption(
 
     Card(
         onClick = {
-            val dialog = FileDialog(null as Frame?, browseLabel, FileDialog.LOAD)
-            dialog.file = "*.jpg;*.jpeg;*.png;*.webp;*.bmp"
-            dialog.isVisible = true
-            val file = dialog.file
-            val dir = dialog.directory
-            if (file != null && dir != null) {
-                onFilePicked(File(dir, file).absolutePath)
+            scope.launch {
+                val path = FileDialogUtils.pickImagePath(browseLabel)
+                if (path != null) onFilePicked(path)
             }
         },
         modifier = modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -127,6 +127,7 @@ import io.askimo.ui.common.theme.appBackground
 import io.askimo.ui.common.theme.createCustomTypography
 import io.askimo.ui.common.theme.detectMacOSDarkMode
 import io.askimo.ui.common.ui.util.CustomUriHandler
+import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.plan.PlansViewModel
 import io.askimo.ui.plan.planDetailView
 import io.askimo.ui.plan.plansGalleryView
@@ -166,7 +167,6 @@ import org.koin.core.context.startKoin
 import org.koin.core.parameter.parametersOf
 import java.awt.Cursor
 import java.awt.Desktop
-import java.io.File
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -175,7 +175,6 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
-import javax.swing.JFileChooser
 import kotlin.system.exitProcess
 
 private val log = currentFileLogger()
@@ -222,8 +221,8 @@ fun main() {
         val isMaximized = ThemePreferences.isWindowMaximized()
 
         val windowState = rememberWindowState(
-            width = 1920.dp,
-            height = 1080.dp,
+            width = if (savedWidth > 0) savedWidth.dp else 1920.dp,
+            height = if (savedHeight > 0) savedHeight.dp else 1080.dp,
             position = if (savedX >= 0 && savedY >= 0) {
                 WindowPosition(savedX.dp, savedY.dp)
             } else {
@@ -378,30 +377,21 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                 }
                 val defaultFileName = "askimo_backup_$timestamp.zip"
 
-                val fileChooser = JFileChooser().apply {
-                    dialogTitle = LocalizationManager.getString("backup.export.title")
-                    selectedFile = File(System.getProperty("user.home"), defaultFileName)
-                    fileSelectionMode = JFileChooser.FILES_ONLY
+                val backupFile = FileDialogUtils.pickSavePath(
+                    suggestedName = defaultFileName.substringBeforeLast('.'),
+                    extension = "zip",
+                    title = LocalizationManager.getString("backup.export.title"),
+                ) ?: return@launch
+
+                val savedFile = withContext(Dispatchers.IO) {
+                    BackupManager.exportBackup(Paths.get(backupFile.absolutePath))
                 }
 
-                val result = fileChooser.showSaveDialog(null)
-                if (result == JFileChooser.APPROVE_OPTION) {
-                    var selectedPath = fileChooser.selectedFile.absolutePath
-                    // Ensure .zip extension
-                    if (!selectedPath.endsWith(".zip")) {
-                        selectedPath = "$selectedPath.zip"
-                    }
-
-                    val backupFile = withContext(Dispatchers.IO) {
-                        BackupManager.exportBackup(Paths.get(selectedPath))
-                    }
-
-                    errorDialogState = ErrorDialogState(
-                        show = true,
-                        title = LocalizationManager.getString("backup.export.success.title"),
-                        message = LocalizationManager.getString("backup.export.success.message", backupFile.toString()),
-                    )
-                }
+                errorDialogState = ErrorDialogState(
+                    show = true,
+                    title = LocalizationManager.getString("backup.export.success.title"),
+                    message = LocalizationManager.getString("backup.export.success.message", savedFile.toString()),
+                )
             } catch (e: Exception) {
                 errorDialogState = ErrorDialogState(
                     show = true,
@@ -416,19 +406,13 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
     fun importBackup() {
         scope.launch {
             try {
-                val fileChooser = JFileChooser().apply {
-                    dialogTitle = LocalizationManager.getString("backup.import.title")
-                    fileSelectionMode = JFileChooser.FILES_ONLY
-                    currentDirectory = File(System.getProperty("user.home"))
-                }
+                val selectedPath = FileDialogUtils.pickFilePath(
+                    title = LocalizationManager.getString("backup.import.title"),
+                    extensions = listOf("zip"),
+                ) ?: return@launch
 
-                val result = fileChooser.showOpenDialog(null)
-                if (result == JFileChooser.APPROVE_OPTION) {
-                    val selectedPath = fileChooser.selectedFile.absolutePath
-
-                    pendingImportBackupPath = Paths.get(selectedPath)
-                    showImportBackupConfirm = true
-                }
+                pendingImportBackupPath = Paths.get(selectedPath)
+                showImportBackupConfirm = true
             } catch (e: Exception) {
                 errorDialogState = ErrorDialogState(
                     show = true,

--- a/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,18 +52,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.askimo.core.user.domain.UserProfile
-import io.askimo.core.util.AskimoHome
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
-import java.awt.FileDialog
-import java.awt.Frame
+import io.askimo.ui.service.AvatarService
+import kotlinx.coroutines.launch
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
-import kotlin.io.path.Path
-import kotlin.io.path.exists
 import org.jetbrains.skia.Image as SkiaImage
 
 /**
@@ -118,6 +114,8 @@ fun userProfileDialog(
     }
 
     // Avatar handling
+    val scope = rememberCoroutineScope()
+    val avatarService = remember { AvatarService() }
     var avatarPath by remember { mutableStateOf(profile.preferences["avatarPath"]) }
     var avatarImage by remember { mutableStateOf<ImageBitmap?>(null) }
 
@@ -188,36 +186,10 @@ fun userProfileDialog(
                                 .background(MaterialTheme.colorScheme.primaryContainer)
                                 .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape)
                                 .clickable {
-                                    val fileDialog = FileDialog(null as Frame?, "Select Avatar Image", FileDialog.LOAD)
-                                    fileDialog.setFilenameFilter { _, name ->
-                                        name.lowercase().endsWith(".png") ||
-                                            name.lowercase().endsWith(".jpg") ||
-                                            name.lowercase().endsWith(".jpeg") ||
-                                            name.lowercase().endsWith(".gif")
-                                    }
-                                    fileDialog.isVisible = true
-                                    val selectedFile = fileDialog.file
-                                    val selectedDir = fileDialog.directory
-
-                                    if (selectedFile != null && selectedDir != null) {
-                                        val sourcePath = Path("$selectedDir$selectedFile")
-                                        if (sourcePath.exists()) {
-                                            // Copy to app data directory
-                                            val userDataDir = AskimoHome.base().resolve("avatars")
-                                            Files.createDirectories(userDataDir)
-                                            val destPath = userDataDir.resolve("user_avatar_${System.currentTimeMillis()}.${sourcePath.fileName.toString().substringAfterLast(".")}")
-                                            Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING)
-
-                                            avatarPath = destPath.toString()
-
-                                            // Load image
-                                            try {
-                                                val bytes = destPath.toFile().readBytes()
-                                                avatarImage = SkiaImage.makeFromEncoded(bytes).toComposeImageBitmap()
-                                            } catch (_: Exception) {
-                                                // Failed to load image
-                                            }
-                                        }
+                                    scope.launch {
+                                        val (path, bitmap) = avatarService.pickAndSaveUserAvatar() ?: return@launch
+                                        avatarPath = path
+                                        avatarImage = bitmap
                                     }
                                 }
                                 .pointerHoverIcon(PointerIcon.Hand),

--- a/desktop/src/main/kotlin/io/askimo/desktop/user/WelcomeProfileDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/user/WelcomeProfileDialog.kt
@@ -34,12 +34,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.layout.ContentScale
@@ -48,18 +48,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.askimo.core.user.domain.UserProfile
-import io.askimo.core.util.AskimoHome
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
-import java.awt.FileDialog
-import java.awt.Frame
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
-import kotlin.io.path.Path
-import kotlin.io.path.exists
-import org.jetbrains.skia.Image as SkiaImage
+import io.askimo.ui.service.AvatarService
+import kotlinx.coroutines.launch
 
 /**
  * Welcome dialog shown on first run to collect basic user profile information.
@@ -76,6 +70,8 @@ fun welcomeProfileDialog(
     var selectedInterests by remember { mutableStateOf<Set<String>>(emptySet()) }
 
     // Avatar handling
+    val scope = rememberCoroutineScope()
+    val avatarService = remember { AvatarService() }
     var avatarPath by remember { mutableStateOf<String?>(null) }
     var avatarImage by remember { mutableStateOf<ImageBitmap?>(null) }
 
@@ -133,34 +129,10 @@ fun welcomeProfileDialog(
                                 .background(MaterialTheme.colorScheme.primaryContainer)
                                 .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
                                 .clickable {
-                                    val fileDialog = FileDialog(null as Frame?, "Select Avatar Image", FileDialog.LOAD)
-                                    fileDialog.setFilenameFilter { _, name ->
-                                        name.lowercase().endsWith(".png") ||
-                                            name.lowercase().endsWith(".jpg") ||
-                                            name.lowercase().endsWith(".jpeg") ||
-                                            name.lowercase().endsWith(".gif")
-                                    }
-                                    fileDialog.isVisible = true
-                                    val selectedFile = fileDialog.file
-                                    val selectedDir = fileDialog.directory
-
-                                    if (selectedFile != null && selectedDir != null) {
-                                        val sourcePath = Path("$selectedDir$selectedFile")
-                                        if (sourcePath.exists()) {
-                                            val userDataDir = AskimoHome.base().resolve("avatars")
-                                            Files.createDirectories(userDataDir)
-                                            val destPath = userDataDir.resolve("user_avatar_${System.currentTimeMillis()}.${sourcePath.fileName.toString().substringAfterLast(".")}")
-                                            Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING)
-
-                                            avatarPath = destPath.toString()
-
-                                            try {
-                                                val bytes = destPath.toFile().readBytes()
-                                                avatarImage = SkiaImage.makeFromEncoded(bytes).toComposeImageBitmap()
-                                            } catch (_: Exception) {
-                                                // Failed to load image
-                                            }
-                                        }
+                                    scope.launch {
+                                        val (path, bitmap) = avatarService.pickAndSaveUserAvatar() ?: return@launch
+                                        avatarPath = path
+                                        avatarImage = bitmap
                                     }
                                 }
                                 .pointerHoverIcon(PointerIcon.Hand),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.3.0-SNAPSHOT
+projectVersion=1.3.0
 
 # About information
-author=Hai Nguyen
+author=Askimo
 licenseId=AGPLv3
 homepage=https://github.com/haiphucnguyen/askimo
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ pty4j = "0.13.12"
 jediterm = "3.64"
 openpdf = "2.2.2"
 poi = "5.4.0"
+filekit = "0.13.0"
 
 [libraries]
 # JLine
@@ -92,6 +93,9 @@ openpdf = { module = "com.github.librepdf:openpdf", version.ref = "openpdf" }
 
 # Word Export (Apache POI)
 poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
+
+# FileKit — native file/folder picker
+filekit-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
 
 # Logging
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
@@ -207,6 +211,10 @@ jediterm = [
     "pty4j",
     "jediterm-ui",
     "jediterm-core"
+]
+
+filekit = [
+    "filekit-compose"
 ]
 
 [plugins]

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/FileTypeSupport.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/FileTypeSupport.kt
@@ -133,4 +133,10 @@ object FileTypeSupport {
      * @return true if the filename is in CONFIG_EXTENSIONS
      */
     fun isConfigFile(fileName: String): Boolean = fileName.lowercase() in CONFIG_EXTENSIONS
+
+    /**
+     * Returns the list of all supported file extensions (text + images).
+     * Convenience accessor for file picker extension filters.
+     */
+    fun supportedExtensions(): List<String> = ALL_SUPPORTED_EXTENSIONS.toList()
 }


### PR DESCRIPTION
- Add FileDialogUtils with pickSavePath, pickFilePaths, pickImagePath using FileKit
- Update UI dialogs (ChatInputField, ChatView, PlanDetailView, AddReferenceMaterialDialog, EditProjectDialog, etc.) to use FileDialogUtils
- Replace java.awt.FileDialog imports with FileKitDialogSettings and FileKitMode
- Add FileKit dependency in libs.versions.toml and update gradle properties (projectVersion, author)
- Adjust attachment, image, background, avatar, and session export handling to use new dialog utilities
- Remove legacy file dialog code, improve error handling, and use coroutine scopes for async operations