### PR TITLE
refactor(rag): fix mismatch in indexing logic and enable cancellation

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/intent/DetectUserIntentCommandTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/intent/DetectUserIntentCommandTest.kt
@@ -563,10 +563,9 @@ class DetectUserIntentCommandTest {
                 tools,
             )
 
-            // Should include first match from INTENT_BASED and BOTH (find returns first match)
-            // Only the first tool of category VISUALIZE is added
-            assertEquals(1, result.tools.size)
+            assertEquals(2, result.tools.size)
             assertTrue(result.tools.any { it.specification.name() == "chart1" })
+            assertTrue(result.tools.any { it.specification.name() == "chart3" })
             assertTrue(result.tools.none { it.specification.name() == "chart2" })
         }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -369,38 +369,6 @@ fun chatInputField(
             }
 
             Column {
-                // Main input row with text field and send button
-                // Resize handle sits above the row so it doesn't affect button alignment.
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(8.dp)
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
-                        .pointerHoverIcon(
-                            PointerIcon(Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR)),
-                        )
-                        .pointerInput(Unit) {
-                            detectVerticalDragGestures { change, dragAmount ->
-                                change.consume()
-                                val newHeight = textFieldHeight - dragAmount.toDp()
-                                textFieldHeight = newHeight.coerceIn(defaultTextFieldHeight, maxTextFieldHeight)
-                                manuallyResized = true
-                            }
-                        },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    // Visual grip indicator
-                    Box(
-                        modifier = Modifier
-                            .width(40.dp)
-                            .height(4.dp)
-                            .background(
-                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                                RoundedCornerShape(2.dp),
-                            ),
-                    )
-                }
-
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
@@ -408,6 +376,38 @@ fun chatInputField(
                     Column(
                         modifier = Modifier.weight(1f),
                     ) {
+                        // Resize handle — scoped to the text field column only so it
+                        // doesn't overlap the send button.
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(8.dp)
+                                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                                .pointerHoverIcon(
+                                    PointerIcon(Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR)),
+                                )
+                                .pointerInput(Unit) {
+                                    detectVerticalDragGestures { change, dragAmount ->
+                                        change.consume()
+                                        val newHeight = textFieldHeight - dragAmount.toDp()
+                                        textFieldHeight = newHeight.coerceIn(defaultTextFieldHeight, maxTextFieldHeight)
+                                        manuallyResized = true
+                                    }
+                                },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            // Visual grip indicator
+                            Box(
+                                modifier = Modifier
+                                    .width(40.dp)
+                                    .height(4.dp)
+                                    .background(
+                                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                        RoundedCornerShape(2.dp),
+                                    ),
+                            )
+                        }
+
                         // Text field
                         OutlinedTextField(
                             value = inputText,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.3.0
+projectVersion=1.3.1
 
 # About information
 author=Askimo

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ResourceSegmentRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ResourceSegmentRepository.kt
@@ -116,4 +116,14 @@ class ResourceSegmentRepository(
         projectId: String,
         filePath: Path,
     ): Int = removeSegmentMappingsForResource(projectId, filePath.toString())
+
+    /**
+     * Remove ALL segment mappings for an entire project.
+     * Used when the project index is fully cleared (e.g. re-index or embedding model change).
+     */
+    fun removeAllSegmentMappingsForProject(projectId: String): Int = transaction(database) {
+        ResourceSegmentsTable.deleteWhere {
+            ResourceSegmentsTable.projectId eq projectId
+        }
+    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/intent/DetectUserIntentCommand.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/DetectUserIntentCommand.kt
@@ -46,13 +46,9 @@ object DetectUserIntentCommand {
 
         // ── Layer 1: keyword classifier ───────────────────────────────────
         val keywordCategories = detectionChain.detectAll(userMessage)
-        val keywordTools = keywordCategories.mapNotNull { category ->
-            if (category == ToolCategory.EXECUTE) {
-                allTools.filter { it.category == category }
-            } else {
-                listOfNotNull(allTools.find { it.category == category })
-            }
-        }.flatten()
+        val keywordTools = keywordCategories.flatMap { category ->
+            allTools.filter { it.category == category }
+        }
 
         // ── Layer 2: vector similarity ────────────────────────────────────
         val keywordToolNames = keywordTools.map { it.specification.name() }.toSet()
@@ -64,7 +60,19 @@ object DetectUserIntentCommand {
             }
             .map { (tool, _) -> tool }
 
-        val allMatched = (keywordTools + vectorOnlyTools)
+        // ── Layer 3: MCP fallback ─────────────────────────────────────────
+        // If neither keyword nor vector detection produced any matches, but MCP tools are
+        // available, include all of them as candidates and let the LLM decide which (if any)
+        // to invoke. This mirrors how ChatGPT/Claude behave: they always send the full tool
+        // list to the model and rely on the model's function-calling logic.
+        val fallbackMcpTools = if (keywordTools.isEmpty() && vectorOnlyTools.isEmpty() && mcpTools.isNotEmpty()) {
+            log.debug("No intent signal detected — falling back to all {} MCP tools", mcpTools.size)
+            mcpTools.filter { (it.strategy and ToolStrategy.INTENT_BASED) != 0 }
+        } else {
+            emptyList()
+        }
+
+        val allMatched = (keywordTools + vectorOnlyTools + fallbackMcpTools)
             .distinctBy { it.specification.name() }
 
         // ── Confidence ────────────────────────────────────────────────────
@@ -84,12 +92,16 @@ object DetectUserIntentCommand {
             vectorOnlyTools.isNotEmpty() -> 55
 
             // weak-to-moderate semantic signal
+            fallbackMcpTools.isNotEmpty() -> 30
+
             else -> 0
         }
 
         val reasoning = buildString {
             if (allMatched.isEmpty()) {
                 append("No specific tool intent detected")
+            } else if (fallbackMcpTools.isNotEmpty() && keywordTools.isEmpty() && vectorOnlyTools.isEmpty()) {
+                append("No intent signal detected — including all ${fallbackMcpTools.size} MCP tool(s) as fallback candidates")
             } else {
                 append("Detected intent from user keywords: ")
                 append(allMatched.joinToString { it.category.name })
@@ -100,9 +112,10 @@ object DetectUserIntentCommand {
         }
 
         log.debug(
-            "Intent detection: keyword={}, vector={}, total={}, confidence={}",
+            "Intent detection: keyword={}, vector={}, fallback={}, total={}, confidence={}",
             keywordTools.size,
             vectorOnlyTools.size,
+            fallbackMcpTools.size,
             allMatched.size,
             confidence,
         )

--- a/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
@@ -130,16 +130,7 @@ fun ChatMessage.getTextContent(): String = when (this) {
 fun ChatMessage.stripImages(): ChatMessage = when (this) {
     is AiMessage -> {
         val strippedText = text()?.let { MemoryMessage.stripBase64Images(it) }
-        // Preserve tool execution requests — they must not be lost when stripping images
-        if (hasToolExecutionRequests()) {
-            if (strippedText != null) {
-                AiMessage.from(strippedText, toolExecutionRequests())
-            } else {
-                AiMessage.from(toolExecutionRequests())
-            }
-        } else {
-            AiMessage.from(strippedText ?: "")
-        }
+        toBuilder().text(strippedText).build()
     }
 
     is UserMessage -> {
@@ -158,11 +149,7 @@ fun ChatMessage.stripImages(): ChatMessage = when (this) {
                 content
             }
         }
-        if (name() != null) {
-            UserMessage.from(name(), sanitisedContents)
-        } else {
-            UserMessage.from(sanitisedContents)
-        }
+        toBuilder().contents(sanitisedContents).build()
     }
 
     is SystemMessage -> SystemMessage.from(MemoryMessage.stripBase64Images(text()))

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -99,7 +99,7 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
             .temperature(AppConfig.chat.samplingTemperature)
             .logger(log)
             .logRequests(log.isDebugEnabled)
-            .logResponses(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
             .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OLLAMA.name.lowercase())))
             .build()
     }
@@ -132,7 +132,7 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
             .temperature(AppConfig.chat.samplingTemperature)
             .logger(log)
             .logRequests(log.isDebugEnabled)
-            .logResponses(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
             .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OLLAMA.name.lowercase())))
             .build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/rag/ProjectIndexer.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/ProjectIndexer.kt
@@ -13,6 +13,7 @@ import io.askimo.core.analytics.AnalyticsEvents
 import io.askimo.core.chat.domain.KnowledgeSourceConfig
 import io.askimo.core.chat.repository.ProjectRepository
 import io.askimo.core.context.AppContext
+import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.error.AppErrorEvent
 import io.askimo.core.event.internal.ProjectDeletedEvent
@@ -89,14 +90,16 @@ class ProjectIndexer(
     }
 
     /**
-     * Remove coordinator and cleanup resources
+     * Remove coordinator and cleanup resources.
      * @param projectId The project ID
+     * @param deleteProjectFolder When true the entire project folder is deleted (project was deleted).
+     *                            When false only index data is cleaned up (re-index scenario).
      */
     private fun removeCoordinator(projectId: String, deleteProjectFolder: Boolean) {
         coordinators.remove(projectId)?.forEach {
             it.clearAll()
             it.close()
-        } // Close all coordinators for this project
+        }
 
         if (deleteProjectFolder) {
             try {
@@ -105,18 +108,44 @@ class ProjectIndexer(
                     projectDir.toFile().deleteRecursively()
                 }
             } catch (e: Exception) {
-                log.error("Failed to delete index files for project $projectId", e)
+                log.error("Failed to delete project folder for project $projectId", e)
             }
         } else {
-            LuceneIndexer.removeInstance(projectId)
-            try {
-                val indexDir = RagUtils.getProjectIndexDir(projectId, createIfNotExists = false)
-                if (indexDir.toFile().exists()) {
-                    indexDir.toFile().deleteRecursively()
-                }
-            } catch (e: Exception) {
-                log.error("Failed to delete index files for project $projectId", e)
+            cleanupIndexData(projectId)
+        }
+    }
+
+    /**
+     * Clean up all index data for a project without deleting the project folder itself.
+     * Covers:
+     *  - Lucene keyword index (in-memory instance + disk files)
+     *  - JVector embedding store (disk files inside the index dir)
+     *  - Database segment mappings
+     *  - index.meta dimension marker
+     *
+     * Used by both re-index and embedding-dimension-mismatch flows.
+     */
+    private fun cleanupIndexData(projectId: String) {
+        // 1. Remove in-memory Lucene instance
+        LuceneIndexer.removeInstance(projectId)
+
+        // 2. Delete index files on disk (jvector + lucene + index.meta)
+        try {
+            val indexDir = RagUtils.getProjectIndexDir(projectId, createIfNotExists = false)
+            if (indexDir.toFile().exists()) {
+                indexDir.toFile().deleteRecursively()
             }
+        } catch (e: Exception) {
+            log.error("Failed to delete index files for project $projectId", e)
+        }
+
+        // 3. Remove segment mappings from the database
+        try {
+            DatabaseManager.getInstance()
+                .getResourceSegmentRepository()
+                .removeAllSegmentMappingsForProject(projectId)
+        } catch (e: Exception) {
+            log.error("Failed to remove segment mappings from database for project $projectId", e)
         }
     }
 
@@ -132,6 +161,9 @@ class ProjectIndexer(
         watchForChanges: Boolean,
     ) {
         val indexingStartMs = System.currentTimeMillis()
+
+        RagUtils.saveEmbeddingDimension(projectId, RagUtils.getDimensionForModel(embeddingModel))
+
         // Create one coordinator per knowledge source using factory
         val projectCoordinators = try {
             knowledgeSources.map { source ->
@@ -192,7 +224,7 @@ class ProjectIndexer(
                 }
             }
 
-            // Sum up total files indexed across all coordinators
+            // Sum up total files indexed across all coordinators (removed saveEmbeddingDimension from here)
             val totalFilesIndexed = projectCoordinators.sumOf { it.progress.value.processedFiles }
 
             val indexDurationMs = System.currentTimeMillis() - indexingStartMs
@@ -239,36 +271,35 @@ class ProjectIndexer(
     }
 
     /**
-     * Handle re-index request event
+     * Handle re-index request event.
+     * Re-index always takes priority — if the project is currently being indexed,
+     * the in-progress indexing is stopped and a fresh re-index is started.
      */
     private suspend fun handleReIndexRequest(event: ProjectReIndexEvent) {
         try {
             val projectId = event.projectId
 
             val existingCoordinators = coordinators[projectId]
-
-            if (existingCoordinators != null && existingCoordinators.all { it.progress.value.isComplete }) {
-                log.debug("Project $projectId already indexed, removing and re-indexing")
-                removeCoordinator(projectId, false)
+            if (existingCoordinators != null &&
+                existingCoordinators.any { it.progress.value.status == IndexStatus.INDEXING }
+            ) {
+                log.info(
+                    "Project $projectId is currently indexing — stopping it, re-index takes priority. Reason: ${event.reason}",
+                )
             }
 
-            if (existingCoordinators != null && existingCoordinators.any { it.progress.value.status == IndexStatus.INDEXING }) {
-                log.debug("Project $projectId is currently being indexed, skipping duplicate re-index request")
-                return
-            }
-
+            // Always stop and clean up regardless of current status — re-index takes priority
             removeCoordinator(projectId, false)
-            log.info("Removed existing coordinators and deleted index files for project $projectId")
+            log.info("Cleaned up existing index data for project $projectId, starting re-index")
 
             val project = try {
                 projectRepository.getProject(projectId)
             } catch (e: Exception) {
-                log.error("Failed to get project $projectId for indexing", e)
+                log.error("Failed to get project $projectId for re-indexing", e)
                 return
             }
 
             if (project != null) {
-                // Create new embedding components for re-indexing
                 val embeddingModel = appContext.getEmbeddingModel()
                 checkEmbeddingModelAvailable(embeddingModel)
 
@@ -339,34 +370,58 @@ class ProjectIndexer(
      * This method receives embedding components from the requester (e.g., ChatSessionService)
      * and uses them directly to create the indexer instance, avoiding duplicate initialization.
      * Uses the same duplicate prevention logic as handleReIndexRequest to prevent race conditions.
+     *
+     * Also detects embedding dimension mismatches (model was changed since last index) and
+     * silently cleans up stale index data before re-indexing with the new model.
      */
     private suspend fun handleIndexingRequest(event: ProjectIndexingRequestedEvent) {
         try {
             val projectId = event.projectId
 
-            // Check for duplicate/in-progress indexing (same as handleReIndexRequest)
-            val existingCoordinators = coordinators[projectId]
-
-            if (existingCoordinators != null && existingCoordinators.all { it.progress.value.isComplete }) {
-                log.debug("Project $projectId already indexed, skipping duplicate request")
-                return
-            }
-
-            if (existingCoordinators != null && existingCoordinators.any { it.progress.value.status == IndexStatus.INDEXING }) {
-                log.debug("Project $projectId is currently being indexed, skipping duplicate request")
-                return
-            }
-
-            // Create embedding model and store if not provided
+            // Create embedding model early so we can check the dimension before anything else
             val embeddingModel = event.embeddingModel ?: run {
                 val model = appContext.getEmbeddingModel()
                 checkEmbeddingModelAvailable(model)
                 model
             }
 
-            val embeddingStore = event.embeddingStore ?: run {
-                RagUtils.getEmbeddingStore(projectId, embeddingModel)
+            // ── Dimension mismatch check ──────────────────────────────────────
+            // If the project was previously indexed with a different embedding model
+            // (detected via stored dimension in index.meta), wipe all stale index data
+            // and let indexing proceed from scratch with the current model.
+            val currentDimension = RagUtils.getDimensionForModel(embeddingModel)
+            val storedDimension = RagUtils.getStoredEmbeddingDimension(projectId)
+            if (storedDimension != null && storedDimension != currentDimension) {
+                log.warn(
+                    "Embedding dimension mismatch for project {} (stored={}, current={}). " +
+                        "Clearing stale index data and re-indexing with the new model.",
+                    projectId,
+                    storedDimension,
+                    currentDimension,
+                )
+                // Close any existing coordinators and wipe everything (Lucene, JVector, DB)
+                coordinators.remove(projectId)?.forEach {
+                    it.clearAll()
+                    it.close()
+                }
+                cleanupIndexData(projectId)
+                // Fall through — indexing will now run with a clean slate
+            } else {
+                // ── Normal duplicate / in-progress guard ─────────────────────
+                val existingCoordinators = coordinators[projectId]
+
+                if (existingCoordinators != null && existingCoordinators.all { it.progress.value.isComplete }) {
+                    log.debug("Project $projectId already indexed, skipping duplicate request")
+                    return
+                }
+
+                if (existingCoordinators != null && existingCoordinators.any { it.progress.value.status == IndexStatus.INDEXING }) {
+                    log.debug("Project $projectId is currently being indexed, skipping duplicate request")
+                    return
+                }
             }
+
+            val embeddingStore = event.embeddingStore ?: RagUtils.getEmbeddingStore(projectId, embeddingModel)
 
             val project = try {
                 projectRepository.getProject(projectId)

--- a/shared/src/main/kotlin/io/askimo/core/rag/RagUtils.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/RagUtils.kt
@@ -15,6 +15,7 @@ import io.askimo.core.logging.logger
 import io.askimo.core.providers.ChatClient
 import io.askimo.core.util.AskimoHome
 import java.nio.file.Path
+import java.util.Properties
 
 /**
  * Utility functions for RAG (Retrieval-Augmented Generation) module.
@@ -67,6 +68,39 @@ object RagUtils {
             .dimension(getDimensionForModel(embeddingModel))
             .persistencePath(jVectorIndexDir.toString())
             .build()
+    }
+
+    /**
+     * Read the stored embedding dimension from index.meta for the given project.
+     * Returns null if the file does not exist or cannot be read.
+     */
+    fun getStoredEmbeddingDimension(projectId: String): Int? {
+        val metaFile = getProjectIndexDir(projectId, createIfNotExists = false)
+            .resolve("index.meta").toFile()
+        if (!metaFile.exists()) return null
+        return try {
+            val props = Properties()
+            metaFile.inputStream().use { props.load(it) }
+            props.getProperty("embeddingDimension")?.toIntOrNull()
+        } catch (e: Exception) {
+            log.warn("Failed to read index.meta for project {}", projectId, e)
+            null
+        }
+    }
+
+    /**
+     * Persist the current embedding dimension to index.meta for the given project.
+     */
+    fun saveEmbeddingDimension(projectId: String, dimension: Int) {
+        val metaFile = getProjectIndexDir(projectId, createIfNotExists = true)
+            .resolve("index.meta").toFile()
+        try {
+            val props = Properties()
+            props.setProperty("embeddingDimension", dimension.toString())
+            metaFile.outputStream().use { props.store(it, "Askimo RAG index metadata") }
+        } catch (e: Exception) {
+            log.warn("Failed to write index.meta for project {}", projectId, e)
+        }
     }
 
     fun enrichContentRetrieverWithLucene(

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFoldersIndexingCoordinator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/LocalFoldersIndexingCoordinator.kt
@@ -65,6 +65,9 @@ class LocalFoldersIndexingCoordinator(
     // File watcher is owned by this coordinator
     private var fileWatcher: FileWatcher? = null
 
+    // Cancellation flag — set to true by close() to stop in-progress indexing
+    @Volatile private var cancelled = false
+
     /**
      * Check if a path should be excluded from indexing using the filter chain.
      * Uses the appropriate project root for context.
@@ -103,6 +106,7 @@ class LocalFoldersIndexingCoordinator(
     suspend fun indexPathsWithProgress(
         paths: List<Path>,
     ): Boolean {
+        cancelled = false
         updateProgress { IndexProgress(status = IndexStatus.INDEXING) }
 
         // Store project roots for filtering context
@@ -183,6 +187,10 @@ class LocalFoldersIndexingCoordinator(
         fileHashes: ConcurrentHashMap<String, String>,
         previousHashes: Map<String, String>,
     ): Boolean {
+        if (cancelled) {
+            log.trace("Indexing cancelled, skipping file: {}", filePath.pathString)
+            return true
+        }
         val startTime = System.currentTimeMillis()
 
         try {
@@ -286,9 +294,13 @@ class LocalFoldersIndexingCoordinator(
 
     /**
      * Close coordinator and cleanup resources.
+     * Setting [cancelled] to true signals any in-progress indexing to stop at the
+     * next file boundary, preventing stale-dimension segments from being written
+     * into a store that is about to be wiped by a re-index.
      */
     override fun close() {
+        cancelled = true
         stopWatching()
-        log.debug("Closed LocalFoldersIndexingCoordinator for project $projectId")
+        log.debug("Closed LocalFoldersIndexingCoordinator for project $projectId (cancelled in-progress indexing)")
     }
 }


### PR DESCRIPTION
- added DatabaseManager import to ProjectIndexer for proper DB connection handling
- updated ProjectIndexer to deduplicate indexing requests and log skipped operations
- introduced a cancellation flag in LocalFoldersIndexingCoordinator to halt in‑progress indexing during cleanup
- extended RagUtils to read and write embedding dimension metadata in index.meta
- implemented removeAllSegmentMappingsForProject in ResourceSegmentRepository to clear index mappings
- enhanced DetectUserIntentCommand to include fallback tool handling and refine debugging output