### PR TITLE
build: integrate Detekt and apply static analysis fixes across codebase

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.graalvm.native) apply false
     alias(libs.plugins.shadow) apply false
+    alias(libs.plugins.detekt) apply false
 }
 
 group = property("projectGroup") as String
@@ -49,6 +50,30 @@ subprojects {
     apply(plugin = "com.diffplug.spotless")
 
     plugins.withId("org.jetbrains.kotlin.jvm") {
+        apply(plugin = "io.gitlab.arturbosch.detekt")
+
+        configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
+            buildUponDefaultConfig = true
+            config.setFrom(rootProject.file("detekt.yml"))
+            dependencies {
+                "detektPlugins"(project(":detekt-rules"))
+            }
+        }
+
+        tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+            reports {
+                xml.required.set(true)
+                html.required.set(true)
+                txt.required.set(false)
+                sarif.required.set(false)
+            }
+            // Always re-analyse — never serve a cached report
+            outputs.upToDateWhen { false }
+            // Always succeed so XML is written even when findings exist.
+            // The root-level `detekt` task reads the XML and decides pass/fail.
+            ignoreFailures = true
+        }
+
         configure<com.diffplug.gradle.spotless.SpotlessExtension> {
             kotlin {
                 ktlint().editorConfigOverride(
@@ -70,6 +95,171 @@ subprojects {
                 leadingTabsToSpaces(4)
                 endWithNewline()
             }
+        }
+    }
+}
+
+// ── Detekt aggregated reports ─────────────────────────────────────────────
+// Usage:
+//   ./gradlew detekt            — analyse all modules, write merged XML + HTML, fail if errors
+//   ./gradlew openDetektReport  — open the merged HTML in the browser
+
+/** Builds a single-page HTML from a list of detekt findings. */
+fun buildDetektHtml(
+    findings: List<Map<String, String>>,
+    errorCount: Int,
+    warningCount: Int,
+): String {
+    fun badge(count: Int, color: String) =
+        """<span style="background:$color;color:#fff;padding:2px 10px;border-radius:12px;font-weight:bold;">$count</span>"""
+
+    fun section(title: String, color: String, items: List<Map<String, String>>) = buildString {
+        if (items.isEmpty()) return@buildString
+        val byRule = items.groupBy { it["rule"] ?: "unknown" }.toSortedMap()
+        append("""<h2 style="color:$color;margin-top:32px">$title (${items.size})</h2>""")
+        byRule.forEach { (rule, ruleItems) ->
+            append("""<details open><summary style="cursor:pointer;font-weight:bold;padding:6px 0">""")
+            append("""[$rule] &nbsp;${badge(ruleItems.size, color)}</summary>""")
+            append("""<table style="width:100%;border-collapse:collapse;margin:8px 0 16px 0">""")
+            append("""<tr style="background:#f0f0f0"><th style="text-align:left;padding:6px 8px">File</th>""")
+            append("""<th style="text-align:center;padding:6px 8px;width:60px">Line</th>""")
+            append("""<th style="text-align:left;padding:6px 8px">Message</th></tr>""")
+            ruleItems.forEach { f ->
+                val file = f["file"] ?: ""
+                val line = f["line"] ?: "?"
+                val msg = f["message"] ?: ""
+                append("""<tr style="border-top:1px solid #ddd">""")
+                append("""<td style="padding:5px 8px;font-family:monospace;font-size:13px">$file</td>""")
+                append("""<td style="padding:5px 8px;text-align:center">$line</td>""")
+                append("""<td style="padding:5px 8px;font-size:13px">$msg</td></tr>""")
+            }
+            append("</table></details>")
+        }
+    }
+
+    return """<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>Detekt Report</title>
+<style>body{font-family:sans-serif;max-width:1200px;margin:0 auto;padding:24px}
+summary::-webkit-details-marker{color:#888}</style>
+</head><body>
+<h1>Detekt Aggregated Report</h1>
+<p>Generated: ${java.time.LocalDateTime.now()}</p>
+<div style="display:flex;gap:24px;margin:16px 0">
+  <div style="padding:16px 24px;background:#fff0f0;border-radius:8px;text-align:center">
+    <div style="font-size:36px;font-weight:bold;color:#cc0000">$errorCount</div>
+    <div style="color:#666">Errors</div>
+  </div>
+  <div style="padding:16px 24px;background:#fffbe6;border-radius:8px;text-align:center">
+    <div style="font-size:36px;font-weight:bold;color:#b8860b">$warningCount</div>
+    <div style="color:#666">Warnings</div>
+  </div>
+  <div style="padding:16px 24px;background:#f0f0f0;border-radius:8px;text-align:center">
+    <div style="font-size:36px;font-weight:bold;color:#333">${errorCount + warningCount}</div>
+    <div style="color:#666">Total</div>
+  </div>
+</div>
+${section("Errors", "#cc0000", findings.filter { it["severity"] == "error" })}
+${section("Warnings", "#b8860b", findings.filter { it["severity"] == "warning" })}
+${if (findings.isEmpty()) "<p style='color:#008800;font-size:20px'>✅ No findings — clean code!</p>" else ""}
+</body></html>"""
+}
+
+/** Parses a Checkstyle-format XML file produced by detekt and returns a list of finding maps. */
+fun parseDetektXml(xmlFile: java.io.File): List<Map<String, String>> {
+    if (!xmlFile.exists()) return emptyList()
+    return try {
+        val doc = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder().parse(xmlFile)
+        val nodes = doc.getElementsByTagName("error")
+        (0 until nodes.length).map { i ->
+            val node = nodes.item(i)
+            val attrs = node.attributes
+            val filePath = node.parentNode?.attributes?.getNamedItem("name")?.nodeValue ?: "unknown"
+            mapOf(
+                "severity" to (attrs.getNamedItem("severity")?.nodeValue ?: "unknown"),
+                "rule"     to (attrs.getNamedItem("source")?.nodeValue?.substringAfterLast(".") ?: "unknown"),
+                "file"     to filePath.substringAfter("/kotlin/").ifBlank { filePath },
+                "line"     to (attrs.getNamedItem("line")?.nodeValue ?: "?"),
+                "message"  to (attrs.getNamedItem("message")?.nodeValue ?: ""),
+            )
+        }
+    } catch (e: Exception) {
+        emptyList()
+    }
+}
+
+// Root-level `detekt` task — single command that runs analysis on every subproject,
+// merges all XML reports into one, generates a single HTML, prints a summary, and fails if errors.
+// Usage: ./gradlew detekt
+tasks.register("detekt") {
+    group = "verification"
+    description = "Runs detekt on all subprojects, generates a merged report, and fails if errors exist."
+
+    dependsOn(subprojects.mapNotNull { sub -> sub.tasks.findByName("detekt") })
+    outputs.upToDateWhen { false }
+
+    doLast {
+        // ── 1. Collect + merge all subproject XML reports ──────────────────
+        val mergedXmlDir = layout.buildDirectory.dir("reports/detekt").get().asFile.also { it.mkdirs() }
+        val mergedXmlFile = mergedXmlDir.resolve("detekt.xml")
+
+        val fileBlocks = StringBuilder()
+        subprojects.forEach { sub ->
+            val xml = sub.layout.buildDirectory.file("reports/detekt/detekt.xml").get().asFile
+            if (!xml.exists()) return@forEach
+            try {
+                val content = xml.readText()
+                val fileRegex = Regex("<file[^/].*?</file>", RegexOption.DOT_MATCHES_ALL)
+                fileRegex.findAll(content).forEach { fileBlocks.append(it.value).append("\n") }
+            } catch (e: Exception) {
+                logger.warn("Could not read ${xml.path}: ${e.message}")
+            }
+        }
+        mergedXmlFile.writeText(
+            """<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">$fileBlocks</checkstyle>""",
+        )
+
+        // ── 2. Parse merged XML ────────────────────────────────────────────
+        val findings = parseDetektXml(mergedXmlFile)
+        val errors   = findings.filter { it["severity"] == "error" }
+        val warnings = findings.filter { it["severity"] == "warning" }
+
+        // ── 3. Generate single merged HTML report ──────────────────────────
+        val htmlFile = mergedXmlDir.resolve("detekt.html")
+        htmlFile.writeText(buildDetektHtml(findings, errors.size, warnings.size))
+
+        // ── 4. Print console summary ───────────────────────────────────────
+        println("\n======================================================")
+        println("  Detekt Aggregated Report Summary")
+        println("======================================================")
+        println("  Errors   : ${errors.size}")
+        println("  Warnings : ${warnings.size}")
+        println("  Total    : ${findings.size}")
+        println("======================================================\n")
+
+        if (errors.isNotEmpty()) {
+            println("--- ERRORS (${errors.size}) ---")
+            errors.groupBy { it["rule"] ?: "?" }.toSortedMap().forEach { (rule, items) ->
+                println("  [$rule] x${items.size}")
+                items.take(3).forEach { println("    ${it["file"]}:${it["line"]}") }
+                if (items.size > 3) println("    ... and ${items.size - 3} more")
+            }
+            println()
+        }
+
+        if (warnings.isNotEmpty()) {
+            println("--- WARNINGS (${warnings.size}) ---")
+            warnings.groupBy { it["rule"] ?: "?" }.toSortedMap().forEach { (rule, items) ->
+                println("  [$rule] x${items.size}")
+            }
+            println()
+        }
+
+        println("Report: file://${htmlFile.absolutePath}")
+
+        if (errors.isNotEmpty()) {
+            throw GradleException("Detekt found ${errors.size} error(s) that must be fixed. See report above.")
         }
     }
 }

--- a/cli/src/test/kotlin/io/askimo/tools/fs/LocalFsToolsTest.kt
+++ b/cli/src/test/kotlin/io/askimo/tools/fs/LocalFsToolsTest.kt
@@ -168,12 +168,12 @@ class LocalFsToolsTest {
         assertEquals(3L, rPage1["count"])
         val page1 = rPage1["files"] as List<*>
         assertEquals(2, page1.size)
-        val cursor = rPage1["nextCursor"] as String?
+        val cursor = rPage1["nextCursor"] as? String
         assertNotNull(cursor)
         val rPage2 = parseToolResponse(LocalFsTools.filesByType(tmp.toString(), category = "image", recursive = true, limit = 2, cursor = cursor))
         val page2 = rPage2["files"] as List<*>
         assertEquals(1, page2.size)
-        val nextCursor2 = rPage2["nextCursor"] as String?
+        val nextCursor2 = rPage2["nextCursor"] as? String
         assertTrue(nextCursor2 == null || nextCursor2 == "", "No next cursor after final page")
     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -238,7 +238,7 @@ fun chatView(
                         is IndexingInProgressEvent -> {
                             ragIndexingStatus = "inprogress"
                             ragIndexingPercentage = if (event.totalFiles > 0) {
-                                (event.filesIndexed * 100 / event.totalFiles)
+                                event.filesIndexed * 100 / event.totalFiles
                             } else {
                                 0
                             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/FileViewerPane.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/FileViewerPane.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import io.askimo.core.logging.currentFileLogger
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.themedTooltip
@@ -57,6 +58,8 @@ import java.awt.Desktop
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 import java.io.File
+
+private val log = currentFileLogger()
 
 /** Maximum file size (512 KB) the viewer will load into memory. */
 private const val MAX_PREVIEW_BYTES = 512 * 1024L
@@ -344,7 +347,7 @@ private fun openFileExternally(path: String) {
             Desktop.getDesktop().open(file)
         }
     } catch (e: Exception) {
-        e.printStackTrace()
+        log.warn("Failed to open file externally: {}", path, e)
     }
 }
 
@@ -354,7 +357,7 @@ private fun copyTextToClipboard(text: String) {
         val clipboard = Toolkit.getDefaultToolkit().systemClipboard
         clipboard.setContents(StringSelection(text), null)
     } catch (e: Exception) {
-        e.printStackTrace()
+        log.warn("Failed to copy text to clipboard", e)
     }
 }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/RagSourcesTree.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/RagSourcesTree.kt
@@ -63,6 +63,7 @@ import io.askimo.core.chat.domain.KnowledgeSourceConfig
 import io.askimo.core.chat.domain.LocalFilesKnowledgeSourceConfig
 import io.askimo.core.chat.domain.LocalFoldersKnowledgeSourceConfig
 import io.askimo.core.chat.domain.UrlKnowledgeSourceConfig
+import io.askimo.core.logging.currentFileLogger
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.themedTooltip
@@ -71,6 +72,8 @@ import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 import java.io.File
 import java.net.URI
+
+private val log = currentFileLogger()
 
 /**
  * Tree view component for displaying RAG knowledge sources.
@@ -780,13 +783,11 @@ private fun loadFolderChildren(folderPath: String): List<TreeNode> {
 private fun openInFileBrowser(path: String) {
     try {
         val file = File(path)
-        if (file.exists()) {
-            if (Desktop.isDesktopSupported()) {
-                Desktop.getDesktop().open(file)
-            }
+        if (file.exists() && Desktop.isDesktopSupported()) {
+            Desktop.getDesktop().open(file)
         }
     } catch (e: Exception) {
-        e.printStackTrace()
+        log.warn("Failed to open file in browser: {}", path, e)
     }
 }
 
@@ -797,13 +798,11 @@ private fun openContainingFolder(filePath: String) {
     try {
         val file = File(filePath)
         val parentFolder = file.parentFile
-        if (parentFolder?.exists() == true) {
-            if (Desktop.isDesktopSupported()) {
-                Desktop.getDesktop().open(parentFolder)
-            }
+        if (parentFolder?.exists() == true && Desktop.isDesktopSupported()) {
+            Desktop.getDesktop().open(parentFolder)
         }
     } catch (e: Exception) {
-        e.printStackTrace()
+        log.warn("Failed to open containing folder: {}", filePath, e)
     }
 }
 
@@ -816,7 +815,7 @@ private fun openInBrowser(url: String) {
             Desktop.getDesktop().browse(URI(url))
         }
     } catch (e: Exception) {
-        e.printStackTrace()
+        log.warn("Failed to open URL in browser: {}", url, e)
     }
 }
 
@@ -829,6 +828,6 @@ private fun copyToClipboard(text: String) {
         val stringSelection = StringSelection(text)
         clipboard.setContents(stringSelection, null)
     } catch (e: Exception) {
-        e.printStackTrace()
+        log.warn("Failed to copy to clipboard", e)
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/ThemePreferences.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/ThemePreferences.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.logging.LogLevel
 import io.askimo.core.logging.LoggingService
+import io.askimo.core.logging.currentFileLogger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +17,8 @@ import java.util.Locale
 import java.util.prefs.Preferences
 
 object ThemePreferences {
+    private val log = currentFileLogger()
+
     /**
      * Maximum width for the main content area (chat messages, settings panels, etc.).
      * Keeping this consistent prevents lines from becoming too long on wide displays.
@@ -68,6 +71,7 @@ object ThemePreferences {
         val fontSize = try {
             FontSize.valueOf(fontSizeName)
         } catch (e: IllegalArgumentException) {
+            log.debug("Unknown FontSize '{}', falling back to MEDIUM", fontSizeName, e)
             FontSize.MEDIUM
         }
         return FontSettings(fontFamily, fontSize)
@@ -81,7 +85,8 @@ object ThemePreferences {
             // User has explicitly set a locale, use it
             return try {
                 Locale.forLanguageTag(savedLocaleTag)
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                log.debug("Invalid saved locale tag '{}', falling back to English", savedLocaleTag, e)
                 Locale.ENGLISH
             }
         }
@@ -107,7 +112,8 @@ object ThemePreferences {
         val levelName = prefs.get(LOG_LEVEL_KEY, LogLevel.INFO.name)
         val level = try {
             LogLevel.valueOf(levelName)
-        } catch (_: IllegalArgumentException) {
+        } catch (e: IllegalArgumentException) {
+            log.debug("Unknown LogLevel '{}', falling back to INFO", levelName, e)
             LogLevel.INFO
         }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
@@ -88,6 +88,7 @@ import io.askimo.ui.common.ui.util.FileDialogUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.commonmark.ext.autolink.AutolinkExtension
 import org.commonmark.ext.gfm.tables.TableBlock
 import org.commonmark.ext.gfm.tables.TableBody
@@ -115,7 +116,6 @@ import java.io.ByteArrayInputStream
 import java.net.URI
 import java.util.Base64
 import javax.imageio.ImageIO
-import javax.swing.SwingUtilities
 import kotlin.time.Duration.Companion.milliseconds
 import org.commonmark.node.Text as MarkdownText
 
@@ -278,7 +278,7 @@ private fun renderParagraph(paragraph: Paragraph) {
                     if (content.isNotBlank() && isMathContent) {
                         // Check for overlap with existing matches
                         val overlaps = latexMatches.any { (existingStart, existingEnd, _) ->
-                            start in existingStart until existingEnd || existingStart in start until (j + 2)
+                            start in existingStart until existingEnd || existingStart in start until j + 2
                         }
 
                         if (!overlaps) {
@@ -868,16 +868,16 @@ private fun renderBlockQuote(blockQuote: BlockQuote, viewportTopY: Float? = null
 /**
  * Reusable download button overlay for images.
  * Styled to match the copy button from code blocks.
+ * [onClick] is a plain lambda — the caller is responsible for launching any coroutine work.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun imageDownloadButton(
     isVisible: Boolean,
-    onDownload: suspend () -> Unit,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (isVisible) {
-        val coroutineScope = rememberCoroutineScope()
         Box(
             modifier = modifier
                 .background(
@@ -885,9 +885,7 @@ private fun imageDownloadButton(
                     shape = MaterialTheme.shapes.small,
                 )
                 .pointerHoverIcon(PointerIcon.Hand)
-                .clickable {
-                    coroutineScope.launch(Dispatchers.IO) { onDownload() }
-                }
+                .clickable { onClick() }
                 .padding(6.dp),
             contentAlignment = Alignment.Center,
         ) {
@@ -907,6 +905,8 @@ private fun renderImage(image: Image) {
     val context = LocalPlatformContext.current
     val destination = image.destination
     var isHovered by remember { mutableStateOf(false) }
+    // Scope lives as long as this composable, so downloads survive the hover button disappearing
+    val coroutineScope = rememberCoroutineScope()
 
     Column(
         modifier = Modifier
@@ -953,7 +953,7 @@ private fun renderImage(image: Image) {
 
                         imageDownloadButton(
                             isVisible = isHovered,
-                            onDownload = { downloadImage(imageData = imageBytes) },
+                            onClick = { coroutineScope.launch { downloadImage(imageData = imageBytes) } },
                             modifier = Modifier
                                 .align(Alignment.BottomStart)
                                 .padding(start = 6.dp, bottom = 6.dp),
@@ -988,7 +988,7 @@ private fun renderImage(image: Image) {
 
                 imageDownloadButton(
                     isVisible = isHovered,
-                    onDownload = { downloadImage(imageUrl = destination) },
+                    onClick = { coroutineScope.launch { downloadImage(imageUrl = destination) } },
                     modifier = Modifier
                         .align(Alignment.BottomStart)
                         .padding(start = 6.dp, bottom = 6.dp),
@@ -1251,8 +1251,8 @@ private fun buildInlineContent(
                                 if (content.contains(Regex("[a-zA-Z\\\\^_{}=+\\-*/()]"))) {
                                     // Check for overlap
                                     val overlaps = mathRanges.any { (range, _, _) ->
-                                        start in range || (j + 1) in range ||
-                                            range.first in start..(j + 1) || range.last in start..(j + 1)
+                                        start in range || j + 1 in range ||
+                                            range.first in start..j + 1 || range.last in start..j + 1
                                     }
 
                                     if (!overlaps) {
@@ -1635,113 +1635,99 @@ private fun extractVideoUrl(paragraph: Paragraph): String? {
  * Parse chart data from JSON code block or Mermaid diagram.
  * Returns MermaidChartData if the JSON/Mermaid is a valid diagram specification, null otherwise.
  */
-private fun parseChartData(code: String, language: String?): MermaidChartData? {
-    // Handle Mermaid diagrams
-    if (language?.lowercase() == "mermaid") {
+private fun parseChartData(code: String, language: String?): MermaidChartData? = when (language?.lowercase()) {
+    "mermaid" -> {
         val cleanedCode = code.trim()
         if (cleanedCode.isEmpty()) {
-            return null
+            null
+        } else {
+            val title = when {
+                cleanedCode.contains("sequenceDiagram") -> "Sequence Diagram"
+                cleanedCode.contains("classDiagram") -> "Class Diagram"
+                cleanedCode.contains("stateDiagram") -> "State Diagram"
+                cleanedCode.contains("erDiagram") -> "ER Diagram"
+                cleanedCode.contains("gantt") -> "Gantt Chart"
+                cleanedCode.contains("pie") -> "Pie Chart"
+                cleanedCode.contains("journey") -> "User Journey"
+                cleanedCode.startsWith("graph") || cleanedCode.startsWith("flowchart") -> "Flowchart"
+                else -> "Mermaid Diagram"
+            }
+            MermaidChartData(title = title, diagram = cleanedCode, theme = "default")
         }
+    }
 
-        // Extract title from the diagram if possible, or use a default
-        val title = when {
-            cleanedCode.contains("sequenceDiagram") -> "Sequence Diagram"
-            cleanedCode.contains("classDiagram") -> "Class Diagram"
-            cleanedCode.contains("stateDiagram") -> "State Diagram"
-            cleanedCode.contains("erDiagram") -> "ER Diagram"
-            cleanedCode.contains("gantt") -> "Gantt Chart"
-            cleanedCode.contains("pie") -> "Pie Chart"
-            cleanedCode.contains("journey") -> "User Journey"
-            cleanedCode.startsWith("graph") || cleanedCode.startsWith("flowchart") -> "Flowchart"
-            else -> "Mermaid Diagram"
+    "json" -> {
+        val cleanedCode = code.trim()
+            .replace("```json", "")
+            .replace("```", "")
+            .trim()
+        if (cleanedCode.isEmpty() || cleanedCode.length < 20) {
+            null
+        } else {
+            try {
+                json.decodeFromString<MermaidChartData>(cleanedCode)
+            } catch (e: Exception) {
+                log.trace("Failed to parse Mermaid diagram data (may be incomplete): ${e.message}")
+                null
+            }
         }
-
-        return MermaidChartData(
-            title = title,
-            diagram = cleanedCode,
-            theme = "default",
-        )
     }
 
-    // Handle JSON charts
-    if (language != "json") return null
-
-    // Clean and normalize the JSON
-    val cleanedCode = code.trim()
-        .replace("```json", "")
-        .replace("```", "")
-        .trim()
-
-    // Skip if the JSON looks obviously incomplete
-    if (cleanedCode.isEmpty() || cleanedCode.length < 20) {
-        return null
-    }
-
-    // Simply try to parse the JSON - if it's valid and complete, it will parse successfully
-    return try {
-        json.decodeFromString<MermaidChartData>(cleanedCode)
-    } catch (e: Exception) {
-        // JSON is either incomplete (still streaming) or invalid
-        log.trace("Failed to parse Mermaid diagram data (may be incomplete): ${e.message}")
-        null
-    }
+    else -> null
 }
 
 /**
  * Downloads an image using a file chooser dialog.
  * Supports both byte arrays (base64 images) and URLs.
  */
-private fun downloadImage(
+private suspend fun downloadImage(
     imageData: ByteArray? = null,
     imageUrl: String? = null,
     defaultFileName: String = "image.png",
 ) {
-    SwingUtilities.invokeLater {
-        kotlinx.coroutines.runBlocking {
-            try {
-                val (extension, fileName) = when {
-                    imageUrl != null -> {
-                        val urlFileName = imageUrl.substringAfterLast('/').substringBefore('?').ifEmpty { defaultFileName }
-                        val ext = urlFileName.substringAfterLast('.', "png")
-                        ext to urlFileName
-                    }
+    try {
+        val (extension, fileName) = if (imageUrl != null) {
+            val urlFileName = imageUrl.substringAfterLast('/').substringBefore('?').ifEmpty { defaultFileName }
+            val ext = urlFileName.substringAfterLast('.', "png")
+            ext to urlFileName
+        } else {
+            "png" to defaultFileName
+        }
 
-                    else -> "png" to defaultFileName
+        // FileKit.openFileSaver handles its own thread dispatch internally
+        val file = FileDialogUtils.pickSavePath(
+            suggestedName = fileName.substringBeforeLast('.', fileName),
+            extension = extension,
+            title = "Save Image",
+        ) ?: run {
+            log.debug("Save image dialog cancelled")
+            return
+        }
+
+        // Write the file on an IO thread so we never block the EDT
+        withContext(Dispatchers.IO) {
+            when {
+                imageData != null -> {
+                    file.writeBytes(imageData)
+                    log.info("Image saved to: {}", file.absolutePath)
                 }
 
-                val file = FileDialogUtils.pickSavePath(
-                    suggestedName = fileName.substringBeforeLast('.', fileName),
-                    extension = extension,
-                    title = "Save Image",
-                ) ?: run {
-                    log.debug("Save image dialog cancelled")
-                    return@runBlocking
-                }
-
-                // Save the image based on source type
-                when {
-                    imageData != null -> {
-                        file.writeBytes(imageData)
-                        log.info("Image saved to: {}", file.absolutePath)
-                    }
-
-                    imageUrl != null -> {
-                        val url = URI(imageUrl).toURL()
-                        url.openStream().use { input ->
-                            file.outputStream().use { output ->
-                                input.copyTo(output)
-                            }
+                imageUrl != null -> {
+                    val url = URI(imageUrl).toURL()
+                    url.openStream().use { input ->
+                        file.outputStream().use { output ->
+                            input.copyTo(output)
                         }
-                        log.info("Image downloaded and saved to: {}", file.absolutePath)
                     }
-
-                    else -> {
-                        log.error("No image data or URL provided")
-                    }
+                    log.info("Image downloaded and saved to: {}", file.absolutePath)
                 }
-            } catch (e: Exception) {
-                log.error("Failed to save image", e)
+
+                else -> {
+                    log.error("No image data or URL provided")
+                }
             }
         }
+    } catch (e: Exception) {
+        log.error("Failed to save image", e)
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
@@ -686,13 +686,13 @@ private fun diagramImage(
         }
     }
 
+    val verticalScrollState = rememberScrollState()
+    val horizontalScrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+
     if (imageBitmap != null) {
         val scaledWidth = (imageBitmap.width * zoomLevel).dp
         val scaledHeight = (imageBitmap.height * zoomLevel).dp
-
-        val verticalScrollState = rememberScrollState()
-        val horizontalScrollState = rememberScrollState()
-        val coroutineScope = rememberCoroutineScope()
 
         Box(modifier = modifier) {
             Box(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/util/FileDialogUtils.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/util/FileDialogUtils.kt
@@ -201,12 +201,11 @@ object FileDialogUtils {
      *
      * @param suggestedName Default file name shown in the dialog (without extension).
      * @param extension     File extension without dot, e.g. `"pdf"`.
-     * @param title         Dialog title (kept for call-site compatibility; not passed to FileKit 0.13+).
      */
     suspend fun pickSavePath(
         suggestedName: String,
         extension: String,
-        title: String,
+        title: String = "",
     ): File? = FileKit.openFileSaver(
         suggestedName = suggestedName,
         extension = extension,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
@@ -656,9 +656,10 @@ private fun agenticStepRow(
         }
     }
 
-    val copyableOutput: String? = when (event) {
-        is PlanStepEvent.Completed -> event.output?.toString()?.trim()?.takeIf { it.isNotBlank() }
-        else -> null
+    val copyableOutput: String? = if (event is PlanStepEvent.Completed) {
+        event.output?.toString()?.trim()?.takeIf { it.isNotBlank() }
+    } else {
+        null
     }
 
     Column(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
@@ -1198,7 +1199,11 @@ private fun planInputField(
                     value = value,
                     onValueChange = onValueChange,
                     label = { Text(input.label + if (input.required) " *" else "") },
-                    placeholder = if (input.hint.isNotBlank()) ({ Text(input.hint) }) else null,
+                    placeholder = if (input.hint.isNotBlank()) {
+                        { Text(input.hint) }
+                    } else {
+                        null
+                    },
                     isError = error != null,
                     supportingText = error?.let { { Text(it) } },
                     modifier = Modifier.fillMaxWidth(),
@@ -1213,7 +1218,11 @@ private fun planInputField(
                     value = value,
                     onValueChange = onValueChange,
                     label = { Text(input.label + if (input.required) " *" else "") },
-                    placeholder = if (input.hint.isNotBlank()) ({ Text(input.hint) }) else null,
+                    placeholder = if (input.hint.isNotBlank()) {
+                        { Text(input.hint) }
+                    } else {
+                        null
+                    },
                     isError = error != null,
                     supportingText = error?.let { { Text(it) } },
                     modifier = Modifier.fillMaxWidth(),
@@ -1228,7 +1237,11 @@ private fun planInputField(
                     value = value,
                     onValueChange = onValueChange,
                     label = { Text(input.label + if (input.required) " *" else "") },
-                    placeholder = if (input.hint.isNotBlank()) ({ Text(input.hint) }) else null,
+                    placeholder = if (input.hint.isNotBlank()) {
+                        { Text(input.hint) }
+                    } else {
+                        null
+                    },
                     isError = error != null,
                     supportingText = error?.let { { Text(it) } },
                     modifier = Modifier.fillMaxWidth(),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanPdfExporter.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanPdfExporter.kt
@@ -103,7 +103,7 @@ internal object PlanPdfExporter {
         document.close()
 
         val bytes = bos.toByteArray()
-        if (bytes.isEmpty()) throw IllegalStateException("PDF rendering produced 0 bytes")
+        if (bytes.isEmpty()) error("PDF rendering produced 0 bytes")
         FileOutputStream(targetFile).use { it.write(bytes) }
         log.debug("PDF written: {} bytes -> {}", bytes.size, targetFile.absolutePath)
     }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansGalleryView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansGalleryView.kt
@@ -254,8 +254,16 @@ fun plansGalleryView(
                             planCard(
                                 plan = plan,
                                 onSelect = { onSelectPlan(plan) },
-                                onDelete = if (!plan.builtIn) ({ viewModel.deletePlan(plan.id) }) else null,
-                                onEdit = if (!plan.builtIn) ({ onEditPlan(plan.id) }) else null,
+                                onDelete = if (!plan.builtIn) {
+                                    { viewModel.deletePlan(plan.id) }
+                                } else {
+                                    null
+                                },
+                                onEdit = if (!plan.builtIn) {
+                                    { onEditPlan(plan.id) }
+                                } else {
+                                    null
+                                },
                                 onDuplicate = { onDuplicatePlan(plan.id) },
                                 modifier = Modifier.weight(1f),
                             )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
@@ -62,6 +62,9 @@ import kotlin.collections.plus
 private object NewProjectDialog
 private val log = logger<NewProjectDialog>()
 
+/** Number of seconds to wait before auto-dismissing the success screen. */
+private const val SUCCESS_COUNTDOWN_SECONDS = 5
+
 /**
  * Dialog for creating a new project with name, description, and optional knowledge sources.
  */
@@ -78,7 +81,7 @@ fun newProjectDialog(
     var nameError by remember { mutableStateOf<String?>(null) }
     var showSuccess by remember { mutableStateOf(false) }
     var createdProjectName by remember { mutableStateOf("") }
-    var countdown by remember { mutableStateOf(5) }
+    var countdown by remember { mutableStateOf(SUCCESS_COUNTDOWN_SECONDS) }
 
     val scope = rememberCoroutineScope()
     val dialogState = rememberDialogState()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
@@ -464,7 +464,6 @@ private fun sessionCard(
                         onDismissRequest = { showMenu = false },
                     ) {
                         SessionActionMenu.projectViewMenu(
-                            sessionId = session.id,
                             currentProjectId = currentProject.id,
                             currentProjectName = currentProject.name,
                             availableProjects = allProjects,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionActionMenu.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionActionMenu.kt
@@ -193,7 +193,6 @@ object SessionActionMenu {
      */
     @Composable
     fun projectViewMenu(
-        sessionId: String,
         currentProjectId: String,
         currentProjectName: String,
         availableProjects: List<Project>,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.askimo.core.chat.domain.SessionMemory
+import io.askimo.core.logging.currentFileLogger
 import io.askimo.core.util.JsonUtils
 import io.askimo.core.util.JsonUtils.prettyJson
 import io.askimo.ui.common.components.secondaryButton
@@ -49,6 +50,8 @@ import io.askimo.ui.common.theme.AppComponents
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
+
+private val log = currentFileLogger()
 
 /**
  * Dialog to display session memory information including memory messages and summary.
@@ -353,7 +356,8 @@ private fun memoryMessageItem(messageJson: String) {
             val type = jsonElement.jsonObject["type"]?.toString()?.trim('"') ?: "unknown"
             val createdAt = jsonElement.jsonObject["createdAt"]?.toString()?.trim('"') ?: ""
             Triple(content, type, createdAt)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            log.debug("Failed to parse memory message JSON: {}", messageJson, e)
             null
         }
     }
@@ -426,6 +430,7 @@ private fun parseMemoryMessages(memoryMessages: String): List<String> {
             emptyList()
         }
     } catch (e: Exception) {
+        log.debug("Failed to parse memory messages JSON: {}", memoryMessages, e)
         emptyList()
     }
 }
@@ -441,7 +446,7 @@ private fun formatJson(text: String): String {
         val jsonElement = JsonUtils.json.parseToJsonElement(text)
         prettyJson.encodeToString(JsonElement.serializer(), jsonElement)
     } catch (e: Exception) {
-        // If it's not valid JSON, return as-is
+        log.debug("Text is not valid JSON, returning as-is", e)
         text
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsViewModel.kt
@@ -42,6 +42,8 @@ class SessionsViewModel(
     private val log = logger<SessionsViewModel>()
     companion object {
         const val MAX_SIDEBAR_SESSIONS = 50
+
+        const val MAX_FILENAME_LENGTH = 255
     }
 
     var pagedSessions by mutableStateOf<Pageable<ChatSession>?>(null)
@@ -473,7 +475,7 @@ class SessionsViewModel(
                 val file = File(fullPath)
                 val filename = file.name
 
-                if (filename.length > 255) {
+                if (filename.length > MAX_FILENAME_LENGTH) {
                     errorMessage = LocalizationManager.getString("file.name.too.long")
                     return@launch
                 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NotificationComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NotificationComponents.kt
@@ -180,7 +180,7 @@ fun notificationPopup(
     val minHeight = 120.dp
 
     val dynamicHeight = remember(events.size) {
-        val contentHeight = 60.dp + (estimatedItemHeight * events.size.toFloat())
+        val contentHeight = 60.dp + estimatedItemHeight * events.size.toFloat()
         when {
             contentHeight < minHeight -> minHeight
             contentHeight > maxHeight -> maxHeight
@@ -301,7 +301,7 @@ fun notificationPopup(
                     }
                 }
 
-                if ((estimatedItemHeight * events.size.toFloat()) > maxHeight) {
+                if (estimatedItemHeight * events.size.toFloat() > maxHeight) {
                     VerticalScrollbar(
                         adapter = rememberScrollbarAdapter(listState),
                         modifier = Modifier

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/SplashScreen.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/SplashScreen.kt
@@ -39,7 +39,7 @@ fun splashScreen(isConnecting: Boolean = false) {
     val bitmap = remember {
         Image.makeFromEncoded(
             object {}.javaClass.getResourceAsStream("/images/askimo_512.png")?.readBytes()
-                ?: throw IllegalStateException("askimo_512.png not found"),
+                ?: error("askimo_512.png not found"),
         ).toComposeImageBitmap()
     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/util/TimeFormatUtils.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/util/TimeFormatUtils.kt
@@ -24,9 +24,9 @@ private data class DurationComponents(
 
 private fun decompose(ms: Long): DurationComponents = DurationComponents(
     days = ms / 86400000,
-    hours = (ms % 86400000) / 3600000,
-    minutes = (ms % 3600000) / 60000,
-    seconds = (ms % 60000) / 1000,
+    hours = ms % 86400000 / 3600000,
+    minutes = ms % 3600000 / 60000,
+    seconds = ms % 60000 / 1000,
     millis = ms % 1000,
 )
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -210,7 +210,7 @@ fun main() {
         val icon = BitmapPainter(
             Image.makeFromEncoded(
                 object {}.javaClass.getResourceAsStream("/images/askimo_512.png")?.readBytes()
-                    ?: throw IllegalStateException("Icon not found"),
+                    ?: error("Icon not found"),
             ).toComposeImageBitmap(),
         )
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutDialog.kt
@@ -74,7 +74,7 @@ fun aboutDialog(
                             onClick = {
                                 try {
                                     Desktop.getDesktop().browse(URI("https://askimo.chat"))
-                                } catch (e: Exception) {
+                                } catch (_: Exception) {
                                     // Silently fail if browser cannot be opened
                                 }
                             },

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
@@ -326,7 +326,7 @@ private fun openUrl(url: String) {
         if (Desktop.isDesktopSupported()) {
             Desktop.getDesktop().browse(URI(url))
         }
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         // Silently fail if browser cannot be opened
     }
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
@@ -475,8 +475,6 @@ fun providerSelectionDialog(
                                                         colors = AppComponents.outlinedTextFieldColors(),
                                                     )
                                                 }
-
-                                                else -> {}
                                             }
                                         }
                                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
@@ -105,7 +105,7 @@ fun settingsViewWithSidebar(
                         BitmapPainter(
                             Image.makeFromEncoded(
                                 object {}.javaClass.getResourceAsStream("/images/askimo_logo_64.png")?.readBytes()
-                                    ?: throw IllegalStateException("Icon not found"),
+                                    ?: error("Icon not found"),
                             ).toComposeImageBitmap(),
                         )
                     },

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -230,7 +230,7 @@ private fun expandedNavigationSidebar(
                         BitmapPainter(
                             Image.makeFromEncoded(
                                 object {}.javaClass.getResourceAsStream("/images/askimo_logo_64.png")?.readBytes()
-                                    ?: throw IllegalStateException("Icon not found"),
+                                    ?: error("Icon not found"),
                             ).toComposeImageBitmap(),
                         )
                     },
@@ -424,7 +424,7 @@ private fun collapsedNavigationSidebar(
             BitmapPainter(
                 Image.makeFromEncoded(
                     object {}.javaClass.getResourceAsStream("/images/askimo_logo_64.png")?.readBytes()
-                        ?: throw IllegalStateException("Icon not found"),
+                        ?: error("Icon not found"),
                 ).toComposeImageBitmap(),
             )
         }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+    compileOnly(libs.detekt.api)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(platform(libs.junit.bom))
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/detekt-rules/src/main/kotlin/io/askimo/detekt/AskimoRuleSetProvider.kt
+++ b/detekt-rules/src/main/kotlin/io/askimo/detekt/AskimoRuleSetProvider.kt
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+class AskimoRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: String = "askimo"
+
+    override fun instance(config: Config): RuleSet = RuleSet(
+        id = ruleSetId,
+        rules = listOf(
+            RememberCoroutineScopeInConditionalComposable(config),
+        ),
+    )
+}

--- a/detekt-rules/src/main/kotlin/io/askimo/detekt/RememberCoroutineScopeInConditionalComposable.kt
+++ b/detekt-rules/src/main/kotlin/io/askimo/detekt/RememberCoroutineScopeInConditionalComposable.kt
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.detekt
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+/**
+ * Flags `rememberCoroutineScope()` calls that appear inside a conditionally rendered
+ * Composable block (i.e. inside the `then` or `else` branch of an `if` expression
+ * within a `@Composable` function).
+ *
+ * When the condition becomes `false` the composable is removed from the composition
+ * and its scope is immediately cancelled. Any coroutines launched in that scope —
+ * such as file-dialog or download operations — are killed before they can complete.
+ *
+ * **Wrong:**
+ * ```kotlin
+ * @Composable
+ * fun downloadButton(isVisible: Boolean, onDownload: suspend () -> Unit) {
+ *     if (isVisible) {
+ *         val scope = rememberCoroutineScope()   // cancelled when isVisible turns false
+ *         Button(onClick = { scope.launch { onDownload() } }) { … }
+ *     }
+ * }
+ * ```
+ *
+ * **Correct:** hoist the scope to the parent composable so it lives as long as the
+ * parent, independent of the visibility condition.
+ * ```kotlin
+ * @Composable
+ * fun downloadButton(isVisible: Boolean, onClick: () -> Unit) {
+ *     if (isVisible) {
+ *         Button(onClick = onClick) { … }   // scope owned by caller
+ *     }
+ * }
+ * ```
+ */
+class RememberCoroutineScopeInConditionalComposable(config: Config = Config.empty) : Rule(config) {
+
+    override val issue = Issue(
+        id = "RememberCoroutineScopeInConditionalComposable",
+        severity = Severity.Warning,
+        description = "`rememberCoroutineScope()` is called inside a conditional block. " +
+            "When the condition becomes false the composable is removed and its scope is " +
+            "cancelled, killing any in-flight coroutines (e.g. open file dialogs or downloads). " +
+            "Hoist `rememberCoroutineScope()` to the parent composable and pass a plain " +
+            "lambda instead of a `suspend` lambda.",
+        debt = Debt.TWENTY_MINS,
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+
+        if (expression.calleeExpression?.text != "rememberCoroutineScope") return
+
+        // Walk up to find if we are inside an if-branch
+        val ifExpression = expression.getParentOfType<KtIfExpression>(strict = true) ?: return
+
+        // Make sure the containing function is a @Composable
+        val containingFunction = expression.getParentOfType<KtNamedFunction>(strict = true) ?: return
+        val isComposable = containingFunction.annotationEntries.any { it.shortName?.asString() == "Composable" }
+        if (!isComposable) return
+
+        // Confirm this call is inside the then/else body of the if, not just anywhere above it
+        val thenBranch = ifExpression.then
+        val elseBranch = ifExpression.`else`
+        val isInsideBranch = (thenBranch != null && thenBranch.textRange.contains(expression.textRange)) ||
+            (elseBranch != null && elseBranch.textRange.contains(expression.textRange))
+
+        if (isInsideBranch) {
+            report(
+                CodeSmell(
+                    issue = issue,
+                    entity = Entity.from(expression),
+                    message = "`rememberCoroutineScope()` inside an `if` branch in " +
+                        "`${containingFunction.name}`. The scope will be cancelled when the " +
+                        "condition becomes false. Hoist the scope to the parent composable.",
+                ),
+            )
+        }
+    }
+}

--- a/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,2 @@
+io.askimo.detekt.AskimoRuleSetProvider
+

--- a/detekt-rules/src/test/kotlin/io/askimo/detekt/RememberCoroutineScopeInConditionalComposableTest.kt
+++ b/detekt-rules/src/test/kotlin/io/askimo/detekt/RememberCoroutineScopeInConditionalComposableTest.kt
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.detekt
+
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RememberCoroutineScopeInConditionalComposableTest {
+
+    private val rule = RememberCoroutineScopeInConditionalComposable()
+
+    // ── should flag ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `flags rememberCoroutineScope inside if-then branch of a Composable`() {
+        val findings = rule.lint(
+            """
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+
+            @Composable
+            fun DownloadButton(isVisible: Boolean) {
+                if (isVisible) {
+                    val scope = rememberCoroutineScope()
+                }
+            }
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size)
+        assertTrue(findings.first().issue.id == "RememberCoroutineScopeInConditionalComposable")
+    }
+
+    @Test
+    fun `flags rememberCoroutineScope inside if-else branch of a Composable`() {
+        val findings = rule.lint(
+            """
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+
+            @Composable
+            fun MyComponent(show: Boolean) {
+                if (show) {
+                    // nothing
+                } else {
+                    val scope = rememberCoroutineScope()
+                }
+            }
+            """.trimIndent(),
+        )
+        assertEquals(1, findings.size)
+    }
+
+    // ── should NOT flag ──────────────────────────────────────────────────────
+
+    @Test
+    fun `does not flag rememberCoroutineScope at top level of Composable`() {
+        val findings = rule.lint(
+            """
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+
+            @Composable
+            fun MyComponent(isVisible: Boolean) {
+                val scope = rememberCoroutineScope()
+                if (isVisible) {
+                    // scope hoisted correctly
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.isEmpty())
+    }
+
+    @Test
+    fun `does not flag rememberCoroutineScope in non-Composable function`() {
+        val findings = rule.lint(
+            """
+            import kotlinx.coroutines.CoroutineScope
+            import kotlinx.coroutines.Dispatchers
+
+            fun plainFunction(isVisible: Boolean) {
+                if (isVisible) {
+                    val scope = CoroutineScope(Dispatchers.IO)
+                }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.isEmpty())
+    }
+
+    @Test
+    fun `does not flag rememberCoroutineScope called inside if condition itself`() {
+        // Edge case: call is in the condition expression, not the branch body
+        val findings = rule.lint(
+            """
+            import androidx.compose.runtime.Composable
+            import androidx.compose.runtime.rememberCoroutineScope
+
+            @Composable
+            fun MyComponent() {
+                val scope = rememberCoroutineScope()
+                if (scope.isActive) { }
+            }
+            """.trimIndent(),
+        )
+        assertTrue(findings.isEmpty())
+    }
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,679 @@
+build:
+  maxIssues: 0
+  weights:
+    info: 0
+    hint: 0
+    warning: 0
+    error: 1
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Custom Askimo rules
+# ─────────────────────────────────────────────────────────────────────────────
+askimo:
+  RememberCoroutineScopeInConditionalComposable:
+    active: true
+    severity: error
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Comments
+# ─────────────────────────────────────────────────────────────────────────────
+comments:
+  active: true
+  severity: warning        # documentation issues are conventions, not logic bugs
+  AbsentOrWrongFileLicense:
+    active: false          # Handled by Spotless licenseHeaderFile
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  DeprecatedBlockTag:
+    active: true
+  EndOfSentenceFormat:
+    active: false
+  KDocReferencesNonPublicProperty:
+    active: true
+  OutdatedDocumentation:
+    active: true
+  UndocumentedPublicClass:
+    active: false          # Too noisy for a desktop/UI codebase
+  UndocumentedPublicFunction:
+    active: false
+  UndocumentedPublicProperty:
+    active: false
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Complexity
+# ─────────────────────────────────────────────────────────────────────────────
+complexity:
+  active: true
+  severity: warning        # complexity is a maintainability concern, not a correctness one
+  CognitiveComplexMethod:
+    active: true
+    threshold: 20          # slightly relaxed for UI/state-heavy code
+    ignoreAnnotated: ['Composable']   # Composable UI trees are inherently complex
+  ComplexCondition:
+    active: true
+    threshold: 5
+  ComplexInterface:
+    active: false
+  CyclomaticComplexMethod:
+    active: true
+    threshold: 15
+    ignoreAnnotated: ['Composable']   # UI trees are inherently complex
+  LabeledExpression:
+    active: true
+  LargeClass:
+    active: true
+    threshold: 600         # desktop files are large; Gradle build scripts excluded
+    excludes: ['**/build.gradle.kts', '**/desktop/build.gradle.kts']
+    ignoreAnnotated: ['Composable']   # UI files naturally grow large
+  LongMethod:
+    active: true
+    threshold: 80
+    excludes: ['**/build.gradle.kts']
+    ignoreAnnotated: ['Composable']   # Composable functions are inherently long UI trees
+  LongParameterList:
+    active: true
+    functionThreshold: 8
+    constructorThreshold: 8
+    ignoreDefaultParameters: true
+    ignoreDataClasses: true
+    ignoreAnnotated: ['Composable']   # Compose functions commonly have many params
+  MethodOverloading:
+    active: false
+  NamedArguments:
+    active: false
+  NestedBlockDepth:
+    active: true
+    threshold: 5
+  NestedScopeFunctions:
+    active: true
+    threshold: 3
+  ReplaceSafeCallChainWithRun:
+    active: true
+  StringLiteralDuplication:
+    active: false          # Too many false positives in UI/i18n code
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 60
+    thresholdInClasses: 30
+    thresholdInObjects: 30
+    thresholdInInterfaces: 15
+    thresholdInEnums: 10
+    ignoreDeprecated: true
+    ignorePrivate: true
+    ignoreAnnotated: ['Composable']
+    excludes: ['**/build.gradle.kts']
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Coroutines
+# ─────────────────────────────────────────────────────────────────────────────
+coroutines:
+  active: true
+  severity: error          # coroutine misuse causes cancellation leaks and race conditions
+  GlobalCoroutineUsage:
+    active: true           # ban GlobalScope — use structured concurrency
+    severity: error
+  InjectDispatcher:
+    active: true           # dispatchers should be injected, not hardcoded
+    severity: warning      # testability concern rather than runtime failure
+    dispatcherNames: ['IO', 'Default', 'Unconfined']
+  RedundantSuspendModifier:
+    active: true
+    severity: warning
+  SleepInsteadOfDelay:
+    active: true
+    severity: error        # Thread.sleep blocks the coroutine thread pool
+  SuspendFunSwallowedCancellation:
+    active: true
+    severity: error
+  SuspendFunWithCoroutineScopeReceiver:
+    active: true
+    severity: error
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Empty blocks
+# ─────────────────────────────────────────────────────────────────────────────
+empty-blocks:
+  active: true
+  severity: warning        # empty blocks are usually dead code, not runtime bugs
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|ignored|expected'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: true
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exceptions
+# ─────────────────────────────────────────────────────────────────────────────
+exceptions:
+  active: true
+  severity: error          # silencing or mishandling exceptions hides real failures
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+    severity: error
+  InstanceOfCheckForException:
+    active: true
+    severity: warning
+  NotImplementedDeclaration:
+    active: true
+    severity: warning
+  ObjectExtendsThrowable:
+    active: true
+    severity: warning
+  PrintStackTrace:
+    active: true
+    severity: error        # leaks stack traces to stdout instead of structured logging
+  RethrowCaughtException:
+    active: true
+    severity: warning
+  ReturnFromFinally:
+    active: true
+    severity: error
+  SwallowedException:
+    active: true
+    severity: error
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Tests.kt', '**/*Spec.kt', '**/*TestBase.kt']
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
+    allowedExceptionNameRegex: '_|ignored|expected'
+  ThrowingExceptionFromFinally:
+    active: true
+    severity: error
+  ThrowingExceptionInMain:
+    active: false          # CLI main functions intentionally throw
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+    severity: warning
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Spec.kt']
+  ThrowingNewInstanceOfSameException:
+    active: true
+    severity: warning
+  TooGenericExceptionCaught:
+    active: true
+    severity: warning        # masks unexpected failures
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'NullPointerException'
+      - 'IndexOutOfBoundsException'
+      - 'RuntimeException'
+      - 'Throwable'
+    allowedExceptionNameRegex: '_|ignored|expected'
+    excludes: ['**/test/**', '**/*Test.kt']
+  TooGenericExceptionThrown:
+    active: true
+    severity: error
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Tests.kt', '**/*Spec.kt', '**/*TestBase.kt']
+    exceptionNames:
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Naming
+# ─────────────────────────────────────────────────────────────────────────────
+naming:
+  active: true
+  severity: warning        # naming is a readability convention
+  BooleanPropertyNaming:
+    active: true
+    allowedPattern: '^(is|has|are|can|should|was|will|use)[A-Z].*'
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '[A-Z][_A-Z0-9]*'
+  ForbiddenClassName:
+    active: false
+  FunctionMaxLength:
+    active: false
+  FunctionMinLength:
+    active: false
+  FunctionNaming:
+    active: true
+    functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
+    excludeClassPattern: '$^'
+    ignoreAnnotated: ['Composable']  # Composable functions are PascalCase by convention
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+  InvalidPackageDeclaration:
+    active: true
+  LambdaParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*|_'
+  MatchingDeclarationName:
+    active: true
+    mustBeFirst: true
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverridden: true
+  NoNameShadowing:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: true
+  ObjectPropertyNaming:
+    active: true
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+  VariableMinLength:
+    active: true
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Performance
+# ─────────────────────────────────────────────────────────────────────────────
+performance:
+  active: true
+  severity: warning        # performance hints are advisory
+  ArrayPrimitive:
+    active: true
+  CouldBeSequence:
+    active: true
+    threshold: 3
+  ForEachOnRange:
+    active: true
+  SpreadOperator:
+    active: true
+    excludes:
+      - '**/test/**'
+      - '**/*Test.kt'
+  UnnecessaryPartOfBinaryExpression:
+    active: true
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Potential bugs
+# ─────────────────────────────────────────────────────────────────────────────
+potential-bugs:
+  active: true
+  severity: error          # default: potential bugs are errors
+  AvoidReferentialEquality:
+    active: true
+    severity: error
+    forbiddenTypePatterns:
+      - 'kotlin.String'
+  CastToNullableType:
+    active: true
+    severity: error
+  Deprecation:
+    active: false          # Too noisy with third-party libraries
+  DontDowncastCollectionTypes:
+    active: true
+    severity: error
+  DoubleMutabilityForCollection:
+    active: true
+    severity: warning
+  ElseCaseInsteadOfExhaustiveWhen:
+    active: true
+    severity: error
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+    severity: error
+  EqualsWithHashCodeExist:
+    active: true
+    severity: error
+  ExitOutsideMain:
+    active: true
+    severity: error
+    excludes: ['**/cli/**']   # CLI is allowed to call exitProcess
+  HasPlatformType:
+    active: true
+    severity: warning
+  IgnoredReturnValue:
+    active: true
+    severity: error
+    restrictToConfig: true
+    returnValueAnnotations: ['CheckResult', 'CheckReturnValue']
+  ImplicitDefaultLocale:
+    active: true
+    severity: warning
+  ImplicitUnitReturnType:
+    active: true
+    severity: warning
+    allowExplicitReturnType: true
+  InvalidRange:
+    active: true
+    severity: error
+  IteratorHasNextCallsNextMethod:
+    active: true
+    severity: error
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+    severity: error
+  LateinitUsage:
+    active: false          # Koin inject uses lateinit
+  MapGetWithNotNullAssertionOperator:
+    active: true
+    severity: error
+  MissingPackageDeclaration:
+    active: true
+    severity: error
+    excludes: ['**/*.kts']
+  NullCheckOnMutableProperty:
+    active: true
+    severity: error
+  NullableToStringCall:
+    active: true
+    severity: warning
+  PropertyUsedBeforeDeclaration:
+    active: true
+    severity: error
+  UnconditionalJumpStatementInLoop:
+    active: true
+    severity: error
+  UnnecessaryNotNullCheck:
+    active: true
+    severity: warning
+  UnnecessaryNotNullOperator:
+    active: true
+    severity: warning
+  UnnecessarySafeCall:
+    active: true
+    severity: warning
+  UnreachableCode:
+    active: true
+    severity: error
+  UnsafeCallOnNullableType:
+    active: true
+    severity: error
+    excludes: ['**/test/**', '**/*Test.kt']
+  UnsafeCast:
+    active: true
+    severity: error
+  UnusedUnaryOperator:
+    active: true
+    severity: warning
+  UselessPostfixExpression:
+    active: true
+    severity: error
+  WrongEqualsTypeParameter:
+    active: true
+    severity: error
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Style
+# ─────────────────────────────────────────────────────────────────────────────
+style:
+  active: true
+  severity: warning        # style issues are coding-convention, not logic bugs
+  AlsoCouldBeApply:
+    active: true
+  BracesOnIfStatements:
+    active: false          # Handled by ktlint
+  BracesOnWhenStatements:
+    active: false
+  CanBeNonNullable:
+    active: true
+  CascadingCallWrapping:
+    active: false
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: true
+  DataClassContainsFunctions:
+    active: false
+  DataClassShouldBeImmutable:
+    active: true
+  DestructuringDeclarationWithTooManyEntries:
+    active: true
+    maxDestructuringEntries: 5
+  EqualsNullCall:
+    active: true
+    severity: error        # equalsNullCall is a correctness bug (obj.equals(null) vs obj == null)
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: true
+  ExplicitItLambdaParameter:
+    active: true
+  ExpressionBodySyntax:
+    active: false          # matter of taste; don't enforce
+  ForbiddenAnnotation:
+    active: false
+  ForbiddenComment:
+    active: true
+    comments:
+      - reason: 'Use a GitHub issue instead of a FIXME comment.'
+        value: 'FIXME:'
+      - reason: 'STOPSHIP comments must be resolved before release.'
+        value: 'STOPSHIP:'
+    allowedPatterns: ''
+  ForbiddenImport:
+    active: true
+    severity: error        # banned imports violate architectural constraints
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Tests.kt', '**/*Spec.kt', '**/*TestBase.kt']
+    imports:
+      - reason: 'Use kotlinx.coroutines.GlobalScope alternatives with structured concurrency.'
+        value: 'kotlinx.coroutines.GlobalScope'
+      - reason: 'Use kotlin.io.println only in CLI main; avoid in library/UI code.'
+        value: 'java.io.PrintStream'
+  ForbiddenMethodCall:
+    active: false
+  ForbiddenSuppress:
+    active: false
+  ForbiddenVoid:
+    active: true
+    ignoreOverridden: true
+    ignoreUsageInGenerics: true
+  FunctionOnlyReturningConstant:
+    active: true
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 2
+  MagicNumber:
+    active: false
+    ignoreNumbers: ['-1', '0', '1', '2', '100', '1000']
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: true
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: true
+    ignoreNamedArgument: true
+    ignoreEnums: true
+    ignoreRanges: true
+    ignoreExtensionFunctions: true
+  MandatoryBracesLoops:
+    active: false
+  MaxChainedCallsOnSameLine:
+    active: false
+  MaxLineLength:
+    active: false          # Handled by ktlint / .editorconfig
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: true
+  MultilineRawStringIndentation:
+    active: false
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: false          # Handled by Spotless
+  NoTabs:
+    active: false          # Handled by Spotless
+  NullableBooleanCheck:
+    active: true
+    severity: error        # nullable boolean checks are subtle correctness bugs
+  ObjectLiteralToLambda:
+    active: true
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  PreferToOverPairSyntax:
+    active: true
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
+    active: true
+  RedundantVisibilityModifierRule:
+    active: false
+  ReturnCount:
+    active: true
+    max: 4
+    excludedFunctions: ['equals']
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: true
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: false          # Using kotlinx.serialization, not Java Serializable
+  SpacingBetweenPackageAndImports:
+    active: false          # Handled by ktlint
+  StringShouldBeRawString:
+    active: false
+  ThrowsCount:
+    active: true
+    max: 3
+    excludeGuardClauses: true
+  TrailingWhitespace:
+    active: false          # Handled by Spotless
+  TrimMultilineRawString:
+    active: true
+  UnderscoresInNumericLiterals:
+    active: true
+    acceptableLength: 5
+    allowNonStandardGrouping: false
+  UnnecessaryAbstractClass:
+    active: true
+  UnnecessaryAnnotationUseSiteTarget:
+    active: true
+  UnnecessaryApply:
+    active: true
+  UnnecessaryBackticks:
+    active: true
+  UnnecessaryBracesAroundTrailingLambda:
+    active: true
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryInnerClass:
+    active: true
+  UnnecessaryLet:
+    active: true
+  UnnecessaryParentheses:
+    active: true
+  UntilInsteadOfRangeTo:
+    active: true
+  UnusedImports:
+    active: false          # ktlint handles this
+  UnusedParameter:
+    active: true
+    allowedNames: '_|ignored|expected'
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    allowedNames: '_|ignored|expected'
+  UnusedPrivateProperty:
+    active: true
+    allowedNames: '_|ignored|expected'
+  UseAnyOrNoneInsteadOfFind:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseCheckNotNull:
+    active: true
+    severity: error        # incorrect null handling is a logic bug
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Tests.kt', '**/*Spec.kt', '**/*TestBase.kt']
+  UseCheckOrError:
+    active: true
+    severity: error
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Tests.kt', '**/*Spec.kt', '**/*TestBase.kt']
+  UseDataClass:
+    active: false          # too aggressive for domain model classes with logic
+  UseEmptyCounterpart:
+    active: true
+  UseIfEmptyOrIfBlank:
+    active: true
+  UseIfInsteadOfWhen:
+    active: true
+    ignoreWhenContainingVariableDeclaration: true
+  UseIsNullOrEmpty:
+    active: true
+  UseLet:
+    active: false
+  UseOrEmpty:
+    active: true
+  UseRequire:
+    active: true
+    severity: error
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Tests.kt', '**/*Spec.kt', '**/*TestBase.kt']
+  UseRequireNotNull:
+    active: true
+    severity: error
+    excludes: ['**/test/**', '**/*Test.kt', '**/*Tests.kt', '**/*Spec.kt', '**/*TestBase.kt']
+  UseSumOfInsteadOfFlatMapSize:
+    active: true
+  VarCouldBeVal:
+    active: true
+    severity: error        # unnecessary mutability can cause unintended state changes
+    ignoreLateinitVar: true
+  WildcardImport:
+    active: true
+    excludeImports:
+      - 'java.util.*'
+      - 'kotlinx.android.synthetic.*'
+      - 'androidx.compose.*'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.3.2
+projectVersion=1.3.3
 
 # About information
 author=Askimo

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,9 +143,7 @@ mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 # Detekt
-detekt-cli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
 detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
-detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 
 [bundles]
 langchain4j = [
@@ -231,3 +229,4 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include("cli")
 include("shared")
 include("desktop")
 include("desktop-shared")
+include("detekt-rules")
 
 dependencyResolutionManagement {
     repositories {

--- a/shared/src/main/kotlin/io/askimo/core/backup/BackupManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/backup/BackupManager.kt
@@ -79,9 +79,7 @@ object BackupManager {
      * @throws Exception if restore fails
      */
     fun importBackup(backupFile: Path, createSafetyBackup: Boolean = true) {
-        if (!Files.exists(backupFile)) {
-            throw IllegalArgumentException("Backup file not found: $backupFile")
-        }
+        require(Files.exists(backupFile)) { "Backup file not found: $backupFile" }
 
         if (createSafetyBackup) {
             log.info("Creating safety backup before import...")

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/FileContentExtractor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/FileContentExtractor.kt
@@ -18,7 +18,12 @@ import java.io.FileInputStream
 /**
  * Exception thrown when a file exceeds the maximum allowed size for chat attachments.
  */
-class FileSizeExceededException(val fileSize: Long, val maxAllowedSize: Long) : Exception("File size exceeds the maximum allowed limit of ${formatFileSize(maxAllowedSize)}")
+class FileSizeExceededException(val fileSize: Long, val maxAllowedSize: Long) : RuntimeException("File size exceeds the maximum allowed limit of ${formatFileSize(maxAllowedSize)}")
+
+/**
+ * Exception thrown when a file cannot be parsed (e.g. corrupted PDF or unsupported format variant).
+ */
+class FileParseException(filePath: String, cause: Throwable) : RuntimeException("Failed to parse file: $filePath", cause)
 
 /**
  * Utility for extracting text content from various file types.
@@ -131,7 +136,7 @@ object FileContentExtractor {
             handler.toString().trim()
         }
     } catch (e: TikaException) {
-        throw Exception("Failed to parse file: ${file.path}", e)
+        throw FileParseException(file.path, e)
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
@@ -11,6 +11,7 @@ import org.apache.tika.parser.AutoDetectParser
 import org.apache.tika.sax.BodyContentHandler
 import org.jsoup.Jsoup
 import java.io.ByteArrayInputStream
+import java.io.IOException
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -76,7 +77,7 @@ object UrlContentExtractor {
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
 
         if (response.statusCode() !in 200..299) {
-            throw Exception("Failed to fetch URL: HTTP ${response.statusCode()}")
+            throw IOException("Failed to fetch URL: HTTP ${response.statusCode()}")
         }
 
         val contentType = response.headers().firstValue("Content-Type").orElse("application/octet-stream")
@@ -176,7 +177,7 @@ object UrlContentExtractor {
                 )
             }
         } catch (e: Exception) {
-            throw Exception("Failed to parse content from URL: $url", e)
+            throw IOException("Failed to parse content from URL: $url", e)
         }
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/context/ParamKey.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/ParamKey.kt
@@ -65,7 +65,7 @@ enum class ParamKey(
         try {
             setValue(params, providerSettings, value)
         } catch (e: Exception) {
-            throw IllegalArgumentException("❌ Failed to set '$key': expected type $type. ${e.message}")
+            throw IllegalArgumentException("❌ Failed to set '$key': expected type $type. ${e.message}", e)
         }
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -186,7 +186,7 @@ class DatabaseManager private constructor(
                 stmt.executeUpdate(
                     "ALTER TABLE projects ADD COLUMN synced_at TEXT",
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
         }
@@ -231,7 +231,7 @@ class DatabaseManager private constructor(
                 stmt.executeUpdate(
                     "ALTER TABLE chat_sessions ADD COLUMN synced_at TEXT",
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
         }
@@ -264,7 +264,7 @@ class DatabaseManager private constructor(
                     ALTER TABLE chat_messages ADD COLUMN is_edited INTEGER DEFAULT 0
                     """,
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists, ignore the error
             }
 
@@ -275,7 +275,7 @@ class DatabaseManager private constructor(
                     ALTER TABLE chat_messages ADD COLUMN is_failed INTEGER DEFAULT 0
                     """,
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists, ignore the error
             }
 
@@ -287,7 +287,7 @@ class DatabaseManager private constructor(
                 stmt.executeUpdate(
                     "ALTER TABLE chat_messages ADD COLUMN synced_at TEXT",
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
 
@@ -382,21 +382,21 @@ class DatabaseManager private constructor(
             // Migration: Drop unique index on name if it exists (for existing databases)
             try {
                 stmt.executeUpdate("DROP INDEX IF EXISTS chat_directives_name")
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Ignore - index might not exist
             }
 
             // Migration: Add updated_at column if it doesn't exist (for existing databases)
             try {
                 stmt.executeUpdate("ALTER TABLE chat_directives ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00'")
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
 
             // Migration: Add deleted_at column if it doesn't exist (for existing databases)
             try {
                 stmt.executeUpdate("ALTER TABLE chat_directives ADD COLUMN deleted_at TEXT")
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
 
@@ -405,7 +405,7 @@ class DatabaseManager private constructor(
             // Non-null = ISO-8601 timestamp of the last successful push for this row.
             try {
                 stmt.executeUpdate("ALTER TABLE chat_directives ADD COLUMN synced_at TEXT")
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
         }

--- a/shared/src/main/kotlin/io/askimo/core/db/SQLiteLocalDateTimeColumnType.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/SQLiteLocalDateTimeColumnType.kt
@@ -54,13 +54,13 @@ class SQLiteLocalDateTimeColumnType :
     private fun parseDateTime(value: String): LocalDateTime = try {
         // Try SQLite's ISO-8601 format first (most common)
         LocalDateTime.parse(value, SQLITE_DATETIME_FORMATTER)
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         try {
             // Fallback to Exposed's space-separated format
             val fractionLength = value.substringAfterLast('.', "").length
             val formatter = exposedDateTimeFormatter(fractionLength)
             LocalDateTime.parse(value, formatter)
-        } catch (e2: Exception) {
+        } catch (_: Exception) {
             // Last resort: try ISO_LOCAL_DATE_TIME
             LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
         }

--- a/shared/src/main/kotlin/io/askimo/core/i18n/LocalizationManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/i18n/LocalizationManager.kt
@@ -162,7 +162,7 @@ object LocalizationManager {
                 // (which adds thousand separators like "2,025" instead of "2025")
                 val stringArgs = args.map { it.toString() }.toTypedArray()
                 MessageFormat(message, currentLocale).format(stringArgs)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 message
             }
         }
@@ -233,7 +233,7 @@ object LocalizationManager {
                     properties.load(reader)
                 }
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             // Silently ignore missing files — not all layers are required
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpInstance.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpInstance.kt
@@ -47,7 +47,7 @@ data class McpInstance(
         resolver: TemplateResolver,
     ): StdioMcpConnector {
         val stdioConfig = definition.stdioConfig
-            ?: throw IllegalStateException("STDIO config missing for ${definition.id}")
+            ?: error("STDIO config missing for ${definition.id}")
 
         val resolvedCommand = resolver.resolveList(stdioConfig.commandTemplate)
         val resolvedEnv = resolver.resolveMap(stdioConfig.envTemplate)
@@ -76,7 +76,7 @@ data class McpInstance(
         resolver: TemplateResolver,
     ): HttpMcpConnector {
         val httpConfig = definition.httpConfig
-            ?: throw IllegalStateException("HTTP config missing for ${definition.id}")
+            ?: error("HTTP config missing for ${definition.id}")
 
         val resolvedUrl = resolver.resolve(httpConfig.urlTemplate)
         val resolvedHeaders = resolver.resolveMap(httpConfig.headersTemplate)

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
@@ -82,10 +82,8 @@ class PlanExecutor(private val chatModel: ChatModel) {
             .filter { it.required && inputs[it.key].isNullOrBlank() }
             .map { it.key }
 
-        if (missing.isNotEmpty()) {
-            throw IllegalArgumentException(
-                "Plan '${plan.id}' is missing required inputs: ${missing.joinToString()}",
-            )
+        require(missing.isEmpty()) {
+            "Plan '${plan.id}' is missing required inputs: ${missing.joinToString()}"
         }
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
@@ -242,7 +242,7 @@ class PlanService(
         )
 
         val raw = response.aiMessage().text().trim()
-        if (raw.isBlank()) throw IllegalStateException("Model returned empty response")
+        check(raw.isNotBlank()) { "Model returned empty response" }
 
         // Strip accidental markdown code fences (```yaml ... ``` or ``` ... ```)
         val cleaned = raw

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -237,7 +237,7 @@ fun ChatClient.sendStreamingMessageWithCallback(
 
                     if (errorOccurred) {
                         val errorDetails = capturedError?.message ?: "Unknown streaming error"
-                        throw RuntimeException("Streaming error occurred: $errorDetails", capturedError)
+                        throw IllegalStateException("Streaming error occurred: $errorDetails", capturedError)
                     }
 
                     // === STAGE 2: Post-response - Detect follow-up opportunities ===
@@ -272,7 +272,7 @@ fun ChatClient.sendStreamingMessageWithCallback(
         }
 
         // Should never reach here, but for completeness
-        throw IllegalStateException("Failed to send message after ${maxContextRetries + 1} context retries")
+        error("Failed to send message after ${maxContextRetries + 1} context retries")
     } finally {
         // Always clear ThreadLocal to prevent memory leaks
         ChatContext.clear()

--- a/shared/src/main/kotlin/io/askimo/core/providers/DefaultMessageResolver.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/DefaultMessageResolver.kt
@@ -21,7 +21,7 @@ object DefaultMessageResolver {
                         props.load(reader)
                     }
                 }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             // Properties not found - return empty properties
         }
         props

--- a/shared/src/main/kotlin/io/askimo/core/rag/ProjectIndexer.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/ProjectIndexer.kt
@@ -494,7 +494,7 @@ class ProjectIndexer(
                 e.message?.contains("model not found", ignoreCase = true) == true
             ) {
                 log.error("Embedding model not found: ${e.message}")
-                throw ModelNotFoundException("Embedding model not found: ${e.message}")
+                throw ModelNotFoundException("Embedding model not found: ${e.message}", e)
             } else {
                 throw e
             }

--- a/shared/src/main/kotlin/io/askimo/core/rag/filter/FileSizeFilter.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/filter/FileSizeFilter.kt
@@ -21,7 +21,7 @@ class FileSizeFilter(private val maxBytes: Long = AppConfig.indexing.maxFileByte
 
         return try {
             Files.size(path) > maxBytes
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             false
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/rag/filter/FilterChain.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/filter/FilterChain.kt
@@ -84,7 +84,7 @@ class FilterChain(filters: List<IndexingFilter>) {
             } else {
                 path.fileName.toString()
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             path.fileName.toString()
         }
 

--- a/shared/src/main/kotlin/io/askimo/core/rag/filter/GitignoreFilter.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/filter/GitignoreFilter.kt
@@ -192,7 +192,7 @@ class GitignoreParser(private val rootPath: Path) {
     fun shouldIgnore(path: Path, isDirectory: Boolean): Boolean {
         val absoluteRelativePath = try {
             rootPath.relativize(path).toString().replace('\\', '/')
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             return false
         }
 
@@ -204,7 +204,7 @@ class GitignoreParser(private val rootPath: Path) {
             // Get the directory where this .gitignore is located (relative to root)
             val patternDir = try {
                 rootPath.relativize(pattern.gitignorePath).toString().replace('\\', '/')
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 ""
             }
 

--- a/shared/src/main/kotlin/io/askimo/core/rag/watching/FileWatcher.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/watching/FileWatcher.kt
@@ -147,7 +147,7 @@ class FileWatcher(
                 } catch (e: InterruptedException) {
                     log.debug("File watcher interrupted for project $projectId")
                     break
-                } catch (e: ClosedWatchServiceException) {
+                } catch (_: ClosedWatchServiceException) {
                     // WatchService was closed (project deleted or stopped watching)
                     log.debug("File watcher closed for project $projectId")
                     break

--- a/shared/src/main/kotlin/io/askimo/core/service/UpdateChecker.kt
+++ b/shared/src/main/kotlin/io/askimo/core/service/UpdateChecker.kt
@@ -101,7 +101,7 @@ class UpdateChecker(
 
     private fun formatReleaseDate(isoDate: String): String = try {
         isoDate.substringBefore('T')
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         isoDate
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/tools/ToolProviderImpl.kt
+++ b/shared/src/main/kotlin/io/askimo/core/tools/ToolProviderImpl.kt
@@ -71,7 +71,7 @@ class ToolProviderImpl(
                             val clazz = Class.forName(className as String)
                             val kotlinClass = clazz.kotlin
                             val objectInstance = kotlinClass.objectInstance
-                                ?: throw IllegalStateException("Class '$className' is not a Kotlin object")
+                                ?: error("Class '$className' is not a Kotlin object")
                             val toolMethod = clazz.methods.find { it.name == methodName }
                                 ?: throw NoSuchMethodException("Method '$methodName' not found in class '$className'")
 

--- a/shared/src/main/kotlin/io/askimo/tools/fs/LocalFsTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/fs/LocalFsTools.kt
@@ -130,7 +130,7 @@ object LocalFsTools {
                                 }
                             }
                         }
-                    } catch (e: Exception) {
+                    } catch (_: Exception) {
                         // Skip directories we can't read
                     }
                 }
@@ -403,11 +403,11 @@ object LocalFsTools {
             patterns.forEachIndexed { index, pattern ->
                 val matcher = try {
                     dir.fileSystem.getPathMatcher("glob:$pattern")
-                } catch (e: Exception) {
+                } catch (_: Exception) {
                     // If pattern is invalid as glob, treat as literal filename
                     try {
                         dir.fileSystem.getPathMatcher("glob:*$pattern*")
-                    } catch (e2: Exception) {
+                    } catch (_: Exception) {
                         // Skip this pattern if it can't be processed
                         return@forEachIndexed
                     }
@@ -445,7 +445,7 @@ object LocalFsTools {
                                         allFiles[rel.toString()] = relevanceScore
                                     }
                                 }
-                            } catch (e: Exception) {
+                            } catch (_: Exception) {
                                 // Skip this file if there's an error processing it
                             }
                         }
@@ -582,7 +582,7 @@ object LocalFsTools {
             // Explicitly close output stream to prevent Windows file handle leaks
             try {
                 process.outputStream.close()
-            } catch (e: Exception) { /* ignore */ }
+            } catch (_: Exception) { /* ignore */ }
 
             val success = exitCode == 0
             if (success) {
@@ -673,26 +673,26 @@ object LocalFsTools {
 
                 val output = try {
                     process.inputStream.bufferedReader().use { it.readText() }
-                } catch (e: Exception) {
+                } catch (_: Exception) {
                     ""
                 }
 
                 val error = try {
                     process.errorStream.bufferedReader().use { it.readText() }
-                } catch (e: Exception) {
+                } catch (_: Exception) {
                     ""
                 }
 
                 val exitCode = try {
                     process.waitFor()
-                } catch (e: Exception) {
+                } catch (_: Exception) {
                     -1 // Default exit code if we can't get the real one
                 }
 
                 // Explicitly close output stream to release file handles
                 try {
                     process.outputStream.close()
-                } catch (e: Exception) { /* ignore */ }
+                } catch (_: Exception) { /* ignore */ }
 
                 ToolResponseBuilder.successWithData(
                     output = "Process finished with exit code $exitCode",
@@ -862,7 +862,7 @@ object LocalFsTools {
                                     matches += matchInfo
                                 }
                             }
-                        } catch (e: Exception) {
+                        } catch (_: Exception) {
                             // Skip files that can't be read (permissions, etc.)
                             return@fileLoop
                         }
@@ -1008,7 +1008,7 @@ object LocalFsTools {
                             stream.read(buffer)
                         }
                     }
-                } catch (e: Exception) { /* ignore */ }
+                } catch (_: Exception) { /* ignore */ }
 
                 try {
                     process.errorStream.use { stream ->
@@ -1017,17 +1017,17 @@ object LocalFsTools {
                             stream.read(buffer)
                         }
                     }
-                } catch (e: Exception) { /* ignore */ }
+                } catch (_: Exception) { /* ignore */ }
 
                 try {
                     process.outputStream.close()
-                } catch (e: Exception) { /* ignore */ }
+                } catch (_: Exception) { /* ignore */ }
 
                 // Give Windows a moment to release file handles
                 if (System.getProperty("os.name").lowercase().contains("windows")) {
                     Thread.sleep(100)
                 }
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Ignore cleanup errors
             }
         }

--- a/shared/src/main/kotlin/io/askimo/tools/git/GitTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/git/GitTools.kt
@@ -145,7 +145,7 @@ class GitTools {
         val code = p.waitFor()
         val text = out.toString(StandardCharsets.UTF_8)
         if (code != 0) {
-            throw IllegalStateException("Command failed: ${cmd.joinToString(" ")} ($code)\n$text")
+            error("Command failed: ${cmd.joinToString(" ")} ($code)\n$text")
         }
         return text
     }
@@ -200,7 +200,7 @@ class GitTools {
                     }
                 }.trim()
 
-            throw IllegalStateException(msg)
+            error(msg)
         }
 
         return text

--- a/tools/git/pre-commit
+++ b/tools/git/pre-commit
@@ -16,10 +16,22 @@ fi
 git add -u
 
 echo "✅ Spotless formatting applied."
+
+echo "🔍 Running detekt static analysis..."
+./gradlew detekt
+
+# Check if detekt failed (errors found)
+if [ $? -ne 0 ]; then
+    echo "❌ Detekt found errors! Please fix them before committing."
+    echo "💡 Open the HTML report for details (path shown above)."
+    exit 1
+fi
+
+echo "✅ Detekt passed."
 EOF
 
 # Make the hook executable
 chmod +x .git/hooks/pre-commit
 
 echo "✅ Pre-commit hook installed successfully!"
-echo "📝 The hook will run './gradlew spotlessApply' before each commit."
+echo "📝 The hook will run './gradlew spotlessApply' and './gradlew detekt' before each commit."


### PR DESCRIPTION
- Setup Detekt Gradle plugin and add a root `detekt.yml` configuration.
- Create a new `detekt-rules` module for custom static analysis rules.
- Implement a custom rule to detect `rememberCoroutineScope` usage inside conditional composables.
- Update the pre-commit hook to enforce Detekt checks before committing.
- Refactor codebase to address Detekt findings, including replacing `printStackTrace` with proper logging, using Kotlin precondition functions (require/check/error), and renaming unused exception variables.