### PR TITLE
feat(plan): enable tool usage within plan execution steps

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.3.3
+projectVersion=1.3.4
 
 # About information
 author=Askimo

--- a/public/github-logo-dark.svg
+++ b/public/github-logo-dark.svg
@@ -1,21 +1,21 @@
 <svg width="1280" height="640" viewBox="0 0 1280 640" xmlns="http://www.w3.org/2000/svg">
     <defs>
-        <!-- Light background gradient -->
+        <!-- Dark background gradient -->
         <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0" stop-color="#F8FAFC"/>
-            <stop offset="0.55" stop-color="#FFFFFF"/>
-            <stop offset="1" stop-color="#F1F5F9"/>
+            <stop offset="0" stop-color="#07090F"/>
+            <stop offset="0.55" stop-color="#0C0C0C"/>
+            <stop offset="1" stop-color="#0A0F1A"/>
         </linearGradient>
 
         <!-- Subtle grid -->
         <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-            <path d="M40 0H0V40" fill="none" stroke="#00000008" stroke-width="1"/>
+            <path d="M40 0H0V40" fill="none" stroke="#FFFFFF10" stroke-width="1"/>
         </pattern>
 
-        <!-- Soft hub glow for light theme -->
+        <!-- Hub glow -->
         <radialGradient id="glow" cx="50%" cy="50%" r="50%">
-            <stop offset="0" stop-color="#6366F133"/>
-            <stop offset="0.55" stop-color="#3B82F622"/>
+            <stop offset="0" stop-color="#7C3AED55"/>
+            <stop offset="0.55" stop-color="#3B82F633"/>
             <stop offset="1" stop-color="#00000000"/>
         </radialGradient>
     </defs>
@@ -26,20 +26,44 @@
 
     <!-- LEFT: Brand & message -->
     <g font-family="Inter, SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif">
-        <text x="70" y="255" font-size="120" font-weight="900" fill="#0F172A" letter-spacing="4">
+        <text x="70" y="255" font-size="120" font-weight="900" fill="#FFFFFF" letter-spacing="4">
             ASKIMO
         </text>
 
-        <text x="74" y="315" font-size="40" font-weight="700" fill="#334155">
-            Desktop + CLI AI hub
+        <text x="74" y="315" font-size="40" font-weight="700" fill="#D8D8D8">
+            AI client with RAG, Plans &amp; MCP
         </text>
 
-        <text x="74" y="365" font-size="34" font-weight="600" fill="#475569">
-            Built-in Knowledge Base • Multi-Provider
+        <text x="74" y="365" font-size="28" font-weight="500" fill="#94A3B8">
+            Multi-provider · Local-first · Privacy by default
         </text>
     </g>
 
-    <!-- RIGHT: HUB SYSTEM (LIGHT MODE) -->
+    <!-- Feature pills -->
+    <g font-family="Inter, SF Pro Display, Arial, sans-serif" font-size="20" font-weight="700" text-anchor="middle" dominant-baseline="middle">
+        <rect x="74" y="400" width="90" height="36" rx="18" fill="#1E1B4B" stroke="#818CF8" stroke-width="2"/>
+        <text x="119" y="418" fill="#C7D2FE">Chat</text>
+
+        <rect x="176" y="400" width="80" height="36" rx="18" fill="#022C22" stroke="#34D399" stroke-width="2"/>
+        <text x="216" y="418" fill="#6EE7B7">RAG</text>
+
+        <rect x="268" y="400" width="94" height="36" rx="18" fill="#431407" stroke="#FB923C" stroke-width="2"/>
+        <text x="315" y="418" fill="#FED7AA">Plans</text>
+
+        <rect x="374" y="400" width="82" height="36" rx="18" fill="#082F49" stroke="#38BDF8" stroke-width="2"/>
+        <text x="415" y="418" fill="#BAE6FD">MCP</text>
+
+        <rect x="468" y="400" width="106" height="36" rx="18" fill="#2E1065" stroke="#C084FC" stroke-width="2"/>
+        <text x="521" y="418" fill="#E9D5FF">Scripts</text>
+
+        <rect x="586" y="400" width="72" height="36" rx="18" fill="#052E16" stroke="#4ADE80" stroke-width="2"/>
+        <text x="622" y="418" fill="#BBF7D0">CLI</text>
+
+        <rect x="670" y="400" width="100" height="36" rx="18" fill="#4C0519" stroke="#FB7185" stroke-width="2"/>
+        <text x="720" y="418" fill="#FECDD3">Vision</text>
+    </g>
+
+    <!-- RIGHT: HUB SYSTEM (DARK MODE) -->
 
     <!-- Ambient glow -->
     <circle cx="980" cy="340" r="260" fill="url(#glow)"/>
@@ -50,7 +74,7 @@
             cy="340"
             r="220"
             fill="none"
-            stroke="#0F172A22"
+            stroke="#FFFFFF22"
             stroke-width="3"
             stroke-dasharray="18 10"
     />
@@ -61,7 +85,7 @@
             cy="340"
             r="195"
             fill="none"
-            stroke="#0F172A55"
+            stroke="#FFFFFF55"
             stroke-width="3"
     />
 
@@ -76,7 +100,7 @@
     />
 
     <!-- Light core -->
-    <circle cx="980" cy="340" r="140" fill="#FFFFFF"/>
+    <circle cx="980" cy="340" r="140" fill="#0B1220"/>
 
     <!-- Provider pills -->
     <g font-family="Inter, SF Pro Display, Arial"
@@ -88,58 +112,58 @@
         <!-- Highlighted -->
         <g>
             <rect x="915" y="95" width="130" height="38" rx="19"
-                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
-            <text x="980" y="114" fill="#0F172A">OpenAI</text>
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="980" y="114" fill="#FFFFFF">OpenAI</text>
         </g>
 
         <g>
             <rect x="1115" y="155" width="150" height="38" rx="19"
-                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
-            <text x="1190" y="174" fill="#0F172A">Anthropic</text>
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="1190" y="174" fill="#FFFFFF">Anthropic</text>
         </g>
 
         <g>
             <rect x="1140" y="310" width="120" height="38" rx="19"
-                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
-            <text x="1200" y="329" fill="#0F172A">Gemini</text>
+                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
+            <text x="1200" y="329" fill="#FFFFFF">Gemini</text>
         </g>
 
         <!-- Secondary -->
         <g>
             <rect x="1090" y="470" width="170" height="38" rx="19"
-                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-            <text x="1175" y="489" fill="#334155">LM Studio</text>
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="1175" y="489" fill="#E0E0E0">LM Studio</text>
         </g>
 
         <g>
             <rect x="915" y="540" width="130" height="38" rx="19"
-                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-            <text x="980" y="559" fill="#334155">Ollama</text>
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="980" y="559" fill="#E0E0E0">Ollama</text>
         </g>
 
         <g>
             <rect x="720" y="470" width="165" height="38" rx="19"
-                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-            <text x="802.5" y="489" fill="#334155">Docker AI</text>
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="802.5" y="489" fill="#E0E0E0">Docker AI</text>
         </g>
 
         <g>
             <rect x="705" y="310" width="140" height="38" rx="19"
-                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-            <text x="775" y="329" fill="#334155">LocalAI</text>
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="775" y="329" fill="#E0E0E0">LocalAI</text>
         </g>
 
         <g>
             <rect x="760" y="155" width="90" height="38" rx="19"
-                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-            <text x="805" y="174" fill="#334155">X</text>
+                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
+            <text x="805" y="174" fill="#E0E0E0">X</text>
         </g>
     </g>
 
-    <!-- Askimo logo (BLACK STROKE, CENTERED) -->
+    <!-- Askimo logo (WHITE STROKE, CENTERED) -->
     <g transform="translate(867.36 227.36) scale(0.22)"
        fill="none"
-       stroke="#0F172A"
+       stroke="#FFFFFF"
        stroke-width="40"
        stroke-linecap="round"
        stroke-linejoin="round">

--- a/public/github-logo-light.svg
+++ b/public/github-logo-light.svg
@@ -1,21 +1,21 @@
 <svg width="1280" height="640" viewBox="0 0 1280 640" xmlns="http://www.w3.org/2000/svg">
     <defs>
-        <!-- Background gradient -->
+        <!-- Light background gradient -->
         <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0" stop-color="#07090F"/>
-            <stop offset="0.55" stop-color="#0C0C0C"/>
-            <stop offset="1" stop-color="#0A0F1A"/>
+            <stop offset="0" stop-color="#F8FAFC"/>
+            <stop offset="0.55" stop-color="#FFFFFF"/>
+            <stop offset="1" stop-color="#F1F5F9"/>
         </linearGradient>
 
         <!-- Subtle grid -->
         <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-            <path d="M40 0H0V40" fill="none" stroke="#FFFFFF10" stroke-width="1"/>
+            <path d="M40 0H0V40" fill="none" stroke="#00000008" stroke-width="1"/>
         </pattern>
 
-        <!-- Hub glow -->
+        <!-- Soft hub glow -->
         <radialGradient id="glow" cx="50%" cy="50%" r="50%">
-            <stop offset="0" stop-color="#7C3AED55"/>
-            <stop offset="0.55" stop-color="#3B82F633"/>
+            <stop offset="0" stop-color="#6366F133"/>
+            <stop offset="0.55" stop-color="#3B82F622"/>
             <stop offset="1" stop-color="#00000000"/>
         </radialGradient>
     </defs>
@@ -26,20 +26,44 @@
 
     <!-- LEFT: Brand & message -->
     <g font-family="Inter, SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif">
-        <text x="70" y="255" font-size="120" font-weight="900" fill="#FFFFFF" letter-spacing="4">
+        <text x="70" y="255" font-size="120" font-weight="900" fill="#0F172A" letter-spacing="4">
             ASKIMO
         </text>
 
-        <text x="74" y="315" font-size="40" font-weight="700" fill="#D8D8D8">
-            Desktop + CLI AI hub
+        <text x="74" y="315" font-size="40" font-weight="700" fill="#334155">
+            AI client with RAG, Plans &amp; MCP
         </text>
 
-        <text x="74" y="365" font-size="34" font-weight="600" fill="#BEBEBE">
-            Built-in Knowledge Base • Multi-Provider
+        <text x="74" y="365" font-size="28" font-weight="500" fill="#64748B">
+            Multi-provider · Local-first · Privacy by default
         </text>
     </g>
 
-    <!-- RIGHT: IMPRESSIVE HUB SYSTEM -->
+    <!-- Feature pills -->
+    <g font-family="Inter, SF Pro Display, Arial, sans-serif" font-size="20" font-weight="700" text-anchor="middle" dominant-baseline="middle">
+        <rect x="74" y="400" width="90" height="36" rx="18" fill="#EEF2FF" stroke="#6366F1" stroke-width="2"/>
+        <text x="119" y="418" fill="#4338CA">Chat</text>
+
+        <rect x="176" y="400" width="80" height="36" rx="18" fill="#ECFDF5" stroke="#10B981" stroke-width="2"/>
+        <text x="216" y="418" fill="#065F46">RAG</text>
+
+        <rect x="268" y="400" width="94" height="36" rx="18" fill="#FFF7ED" stroke="#F97316" stroke-width="2"/>
+        <text x="315" y="418" fill="#9A3412">Plans</text>
+
+        <rect x="374" y="400" width="82" height="36" rx="18" fill="#EFF6FF" stroke="#3B82F6" stroke-width="2"/>
+        <text x="415" y="418" fill="#1E40AF">MCP</text>
+
+        <rect x="468" y="400" width="106" height="36" rx="18" fill="#FDF4FF" stroke="#A855F7" stroke-width="2"/>
+        <text x="521" y="418" fill="#7E22CE">Scripts</text>
+
+        <rect x="586" y="400" width="72" height="36" rx="18" fill="#F0FDF4" stroke="#22C55E" stroke-width="2"/>
+        <text x="622" y="418" fill="#15803D">CLI</text>
+
+        <rect x="670" y="400" width="100" height="36" rx="18" fill="#FFF1F2" stroke="#F43F5E" stroke-width="2"/>
+        <text x="720" y="418" fill="#BE123C">Vision</text>
+    </g>
+
+    <!-- RIGHT: HUB SYSTEM (LIGHT MODE) -->
 
     <!-- Ambient glow -->
     <circle cx="980" cy="340" r="260" fill="url(#glow)"/>
@@ -50,7 +74,7 @@
             cy="340"
             r="220"
             fill="none"
-            stroke="#FFFFFF22"
+            stroke="#0F172A22"
             stroke-width="3"
             stroke-dasharray="18 10"
     />
@@ -61,7 +85,7 @@
             cy="340"
             r="195"
             fill="none"
-            stroke="#FFFFFF55"
+            stroke="#0F172A55"
             stroke-width="3"
     />
 
@@ -75,8 +99,8 @@
             stroke-width="2"
     />
 
-    <!-- Dark core -->
-    <circle cx="980" cy="340" r="140" fill="#0B1220"/>
+    <!-- Light core -->
+    <circle cx="980" cy="340" r="140" fill="#FFFFFF"/>
 
     <!-- Provider pills -->
     <g font-family="Inter, SF Pro Display, Arial"
@@ -88,59 +112,58 @@
         <!-- Highlighted -->
         <g>
             <rect x="915" y="95" width="130" height="38" rx="19"
-                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
-            <text x="980" y="114" fill="#FFFFFF">OpenAI</text>
+                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
+            <text x="980" y="114" fill="#0F172A">OpenAI</text>
         </g>
 
         <g>
             <rect x="1115" y="155" width="150" height="38" rx="19"
-                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
-            <text x="1190" y="174" fill="#FFFFFF">Anthropic</text>
+                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
+            <text x="1190" y="174" fill="#0F172A">Anthropic</text>
         </g>
 
         <g>
             <rect x="1140" y="310" width="120" height="38" rx="19"
-                  fill="#1A1F3A" stroke="#8B9CFF" stroke-width="2.5"/>
-            <text x="1200" y="329" fill="#FFFFFF">Gemini</text>
+                  fill="#EEF2FF" stroke="#6366F1" stroke-width="2.5"/>
+            <text x="1200" y="329" fill="#0F172A">Gemini</text>
         </g>
 
         <!-- Secondary -->
         <g>
             <rect x="1090" y="470" width="170" height="38" rx="19"
-                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
-            <text x="1175" y="489" fill="#E0E0E0">LM Studio</text>
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="1175" y="489" fill="#334155">LM Studio</text>
         </g>
 
         <g>
             <rect x="915" y="540" width="130" height="38" rx="19"
-                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
-            <text x="980" y="559" fill="#E0E0E0">Ollama</text>
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="980" y="559" fill="#334155">Ollama</text>
         </g>
 
         <g>
             <rect x="720" y="470" width="165" height="38" rx="19"
-                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
-            <text x="802.5" y="489" fill="#E0E0E0">Docker AI</text>
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="802.5" y="489" fill="#334155">Docker AI</text>
         </g>
 
         <g>
             <rect x="705" y="310" width="140" height="38" rx="19"
-                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
-            <text x="775" y="329" fill="#E0E0E0">LocalAI</text>
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="775" y="329" fill="#334155">LocalAI</text>
         </g>
 
         <g>
             <rect x="760" y="155" width="90" height="38" rx="19"
-                  fill="#0B1220" stroke="#FFFFFF44" stroke-width="2"/>
-            <text x="805" y="174" fill="#E0E0E0">X</text>
+                  fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+            <text x="805" y="174" fill="#334155">X</text>
         </g>
     </g>
 
-    <!-- Askimo logo PERFECTLY CENTERED -->
-    <!-- translate(980 - 0.22*512, 340 - 0.22*512) -->
+    <!-- Askimo logo (BLACK STROKE, CENTERED) -->
     <g transform="translate(867.36 227.36) scale(0.22)"
        fill="none"
-       stroke="#FFFFFF"
+       stroke="#0F172A"
        stroke-width="40"
        stroke-linecap="round"
        stroke-linejoin="round">

--- a/shared/src/main/kotlin/io/askimo/core/intent/ToolRegistry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/ToolRegistry.kt
@@ -106,4 +106,10 @@ object ToolRegistry {
      * These tools require user confirmation before use.
      */
     fun getFollowUpOnly(): List<ToolConfig> = tools.values.filter { (it.strategy and ToolStrategy.FOLLOW_UP_BASED) != 0 }
+
+    /**
+     * Look up a single tool by its [ToolSpecification] name.
+     * Returns `null` if no tool with that name has been registered.
+     */
+    fun findByName(name: String): ToolConfig? = tools[name]
 }

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
@@ -31,8 +31,13 @@ import java.util.concurrent.Executors
  * 4. The final output is read from scope using the last step's id (or plan id as fallback).
  *
  * ## Tools
- * `PlanStep.tools` is intentionally ignored in this version.
- * Tool support will be added in a future iteration once the tool resolution layer for plans is designed.
+ * Each step receives a [PlanToolProvider] populated with its *effective* tool list:
+ * - If [PlanStep.tools] is non-empty it is used as-is (step-level override).
+ * - Otherwise [PlanDef.tools] is used as the plan-wide default.
+ * - A step with no tools at either level runs without any tools attached.
+ *
+ * Only built-in [ToolRegistry] tools are resolved at this layer.
+ * MCP tools are skipped until a plan-aware MCP wiring layer is added.
  */
 class PlanExecutor(private val chatModel: ChatModel) {
 
@@ -58,7 +63,7 @@ class PlanExecutor(private val chatModel: ChatModel) {
         // Because inheritedBySubagents() = true, every nested step agent automatically
         // inherits the same listener — no per-step wiring needed.
         val listener = PlanExecutionListener(planId = plan.id, executionId = executionId)
-        val rootAgent: UntypedAgent = buildAgent(plan.workflow, plan.steps, listener)
+        val rootAgent: UntypedAgent = buildAgent(plan.workflow, plan.steps, plan, listener)
 
         // rootAgent.invoke() returns the root composite agent's result, which is null
         // for Sequence/Parallel wrappers — they don't expose a top-level output key.
@@ -120,23 +125,27 @@ class PlanExecutor(private val chatModel: ChatModel) {
     private fun buildAgent(
         node: WorkflowNode,
         steps: Map<String, PlanStep>,
+        plan: PlanDef,
         listener: PlanExecutionListener? = null,
     ): UntypedAgent = when (node) {
-        is WorkflowNode.Step -> buildStepAgent(node, steps, listener)
-        is WorkflowNode.Sequence -> buildSequenceAgent(node, steps, listener)
-        is WorkflowNode.Parallel -> buildParallelAgent(node, steps, listener)
-        is WorkflowNode.Conditional -> buildConditionalAgent(node, steps, listener)
+        is WorkflowNode.Step -> buildStepAgent(node, steps, plan, listener)
+        is WorkflowNode.Sequence -> buildSequenceAgent(node, steps, plan, listener)
+        is WorkflowNode.Parallel -> buildParallelAgent(node, steps, plan, listener)
+        is WorkflowNode.Conditional -> buildConditionalAgent(node, steps, plan, listener)
     }
 
     /**
-     *
      * The step's `message` is the user prompt template; `{{variable}}` placeholders
      * are resolved by LangChain4j from the shared `AgenticScope`.
      * The step result is stored in scope under the step's own `id` as `outputKey`.
+     *
+     * Effective tools = [PlanStep.tools] if non-empty, else [PlanDef.tools].
+     * An empty effective list means no tool provider is attached.
      */
     private fun buildStepAgent(
         node: WorkflowNode.Step,
         steps: Map<String, PlanStep>,
+        plan: PlanDef,
         listener: PlanExecutionListener? = null,
     ): UntypedAgent {
         val step = steps[node.stepId]
@@ -152,7 +161,12 @@ class PlanExecutor(private val chatModel: ChatModel) {
 
         listener?.let { builder.listener(it) }
 
-        // TODO: step.tools — wire tools per step once the plan tool resolution layer is ready
+        // Resolve effective tools: step-level overrides plan-level default.
+        val effectiveTools = step.tools.ifEmpty { plan.tools }
+        if (effectiveTools.isNotEmpty()) {
+            log.debug("[{}] step '{}' tools: {}", plan.id, step.id, effectiveTools)
+            builder.toolProvider(PlanToolProvider(effectiveTools))
+        }
 
         return builder.build()
     }
@@ -164,9 +178,10 @@ class PlanExecutor(private val chatModel: ChatModel) {
     private fun buildSequenceAgent(
         node: WorkflowNode.Sequence,
         steps: Map<String, PlanStep>,
+        plan: PlanDef,
         listener: PlanExecutionListener? = null,
     ): UntypedAgent {
-        val subAgents = node.nodes.map { buildAgent(it, steps, listener) }.toTypedArray()
+        val subAgents = node.nodes.map { buildAgent(it, steps, plan, listener) }.toTypedArray()
 
         return AgenticServices.sequenceBuilder()
             .subAgents(*subAgents)
@@ -180,9 +195,10 @@ class PlanExecutor(private val chatModel: ChatModel) {
     private fun buildParallelAgent(
         node: WorkflowNode.Parallel,
         steps: Map<String, PlanStep>,
+        plan: PlanDef,
         listener: PlanExecutionListener? = null,
     ): UntypedAgent {
-        val subAgents = node.nodes.map { buildAgent(it, steps, listener) }.toTypedArray()
+        val subAgents = node.nodes.map { buildAgent(it, steps, plan, listener) }.toTypedArray()
 
         return AgenticServices.parallelBuilder()
             .subAgents(*subAgents)
@@ -198,9 +214,10 @@ class PlanExecutor(private val chatModel: ChatModel) {
     private fun buildConditionalAgent(
         node: WorkflowNode.Conditional,
         steps: Map<String, PlanStep>,
+        plan: PlanDef,
         listener: PlanExecutionListener? = null,
     ): UntypedAgent {
-        val childAgent = buildAgent(node.node, steps, listener)
+        val childAgent = buildAgent(node.node, steps, plan, listener)
         val condition = node.condition
 
         return AgenticServices.conditionalBuilder()

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanToolProvider.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanToolProvider.kt
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.core.plan
+
+import dev.langchain4j.service.tool.DefaultToolExecutor
+import dev.langchain4j.service.tool.ToolProvider
+import dev.langchain4j.service.tool.ToolProviderRequest
+import dev.langchain4j.service.tool.ToolProviderResult
+import io.askimo.core.intent.ToolRegistry
+import io.askimo.core.intent.ToolSource
+import io.askimo.core.logging.logger
+
+/**
+ * A [ToolProvider] for plan steps that exposes only the tools explicitly allowed
+ * for that step.
+ *
+ * Resolution order:
+ * 1. [allowedToolNames] — the merged list of effective tools for this step
+ *    (step-level overrides plan-level; plan-level is the fallback).
+ * 2. [ToolRegistry] — looks up each name against registered built-in tools.
+ *
+ * Unknown tool names (not in the registry) are skipped with a warning so that
+ * a single typo doesn't silently break the whole plan execution.
+ *
+ * @param allowedToolNames Tool names to expose. Empty means no tools.
+ */
+class PlanToolProvider(
+    private val allowedToolNames: List<String>,
+) : ToolProvider {
+
+    private val log = logger<PlanToolProvider>()
+
+    override fun provideTools(request: ToolProviderRequest?): ToolProviderResult? {
+        if (request == null || allowedToolNames.isEmpty()) return null
+
+        val builder = ToolProviderResult.builder()
+        var added = 0
+
+        for (name in allowedToolNames) {
+            val tool = ToolRegistry.findByName(name)
+            if (tool == null) {
+                log.warn("Plan references unknown tool '{}' — skipping", name)
+                continue
+            }
+
+            if (tool.source != ToolSource.ASKIMO_BUILTIN) {
+                // MCP tools require a live McpClient; skip them here for now.
+                log.debug("Skipping MCP tool '{}' — MCP tools are not yet supported in plan steps", name)
+                continue
+            }
+
+            val className = tool.specification.metadata()["className"] as? String
+            val methodName = tool.specification.metadata()["methodName"] as? String
+
+            if (className == null || methodName == null) {
+                log.warn(
+                    "Built-in tool '{}' is missing className/methodName metadata — skipping",
+                    name,
+                )
+                continue
+            }
+
+            try {
+                val clazz = Class.forName(className)
+                val objectInstance = clazz.kotlin.objectInstance
+                    ?: error("Class '$className' is not a Kotlin object")
+                val method = clazz.methods.find { it.name == methodName }
+                    ?: throw NoSuchMethodException("Method '$methodName' not found in '$className'")
+
+                builder.add(
+                    tool.specification,
+                    DefaultToolExecutor.builder()
+                        .`object`(objectInstance)
+                        .methodToInvoke(method)
+                        .originalMethod(method)
+                        .wrapToolArgumentsExceptions(true)
+                        .propagateToolExecutionExceptions(true)
+                        .build(),
+                )
+                added++
+            } catch (e: ClassNotFoundException) {
+                log.error("Class '{}' not found for tool '{}'", className, name, e)
+            } catch (e: NoSuchMethodException) {
+                log.error("Method '{}' not found in '{}' for tool '{}'", methodName, className, name, e)
+            } catch (e: Exception) {
+                log.error("Failed to register tool '{}'", name, e)
+            }
+        }
+
+        return if (added > 0) builder.build() else null
+    }
+}


### PR DESCRIPTION
- Introduce `PlanToolProvider` and update `PlanExecutor` to supply tools to agents running plan steps.
- Implement tool resolution logic: step-level `tools` override plan-level defaults.
- Add `ToolRegistry.findByName` to allow looking up tool configurations by their specification name.
- Bump project version to 1.3.4.
- Refresh light and dark mode GitHub logo assets.