### PR TITLE
feat(plan-support-tools): sync plan changes and support ephemeral MCP servers

### DIFF
--- a/desktop-shared/build.gradle.kts
+++ b/desktop-shared/build.gradle.kts
@@ -27,9 +27,9 @@ publishing {
 }
 
 dependencies {
-    implementation(compose.desktop.currentOs)
-    implementation(compose.material3)
-    implementation(compose.materialIconsExtended)
+    api(compose.desktop.currentOs)
+    api(libs.compose.material3)
+    api(libs.compose.material.icons.extended)
     api(project(":shared"))
     implementation(libs.konform)
     implementation(libs.bundles.commonmark)

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/preferences/ApplicationPreferences.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/preferences/ApplicationPreferences.kt
@@ -294,6 +294,26 @@ object ApplicationPreferences {
     }
 
     // ============================================================
+    // PLAN SYNC
+    // ============================================================
+    private const val LAST_PLAN_SYNC_SEQ_KEY = "sync.plan_last_seq"
+
+    /**
+     * The highest plan `seq` value received from the server during the last pull.
+     * Send this as the `since` parameter on the next pull to fetch only the delta.
+     * Defaults to 0 (first pull fetches all history).
+     */
+    fun getLastPlanSyncSeq(): Long = safeGetLong(LAST_PLAN_SYNC_SEQ_KEY, 0L)
+
+    /**
+     * Persists [seq] as the new plan cursor bookmark after a successful pull.
+     * Must only be called when the pull succeeded.
+     */
+    fun saveLastPlanSyncSeq(seq: Long) {
+        safePutLong(LAST_PLAN_SYNC_SEQ_KEY, seq)
+    }
+
+    // ============================================================
     // PLAN INPUT PERSISTENCE
     // ============================================================
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansViewModel.kt
@@ -46,6 +46,11 @@ import java.io.File
 class PlansViewModel(
     private val scope: CoroutineScope,
     private val planService: PlanService,
+    /**
+     * Optional callback invoked after a plan is saved or deleted so the team sync
+     * layer can push the change to the server. Pass null in offline / community mode.
+     */
+    private val onPlanChanged: (suspend (planId: String, deleted: Boolean) -> Unit)? = null,
 ) {
 
     private val log = logger<PlansViewModel>()
@@ -426,6 +431,7 @@ class PlansViewModel(
             runCatching {
                 withContext(Dispatchers.IO) { planService.deletePlan(planId) }
             }
+            onPlanChanged?.invoke(planId, true)
             planStateCache.remove(planId)
             loadPlans()
         }
@@ -568,9 +574,10 @@ class PlansViewModel(
             }.fold(
                 onSuccess = { result ->
                     result.fold(
-                        onSuccess = {
+                        onSuccess = { saved ->
                             loadPlans()
                             onSuccess()
+                            onPlanChanged?.let { cb -> scope.launch { cb(saved.id, false) } }
                         },
                         onFailure = { saveError = it.message ?: "Save failed" },
                     )

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -48,9 +48,6 @@ version = rootProject.version
 val distPackageVersion = project.version.toString().substringBefore("-")
 
 dependencies {
-    implementation(compose.desktop.currentOs)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
     implementation(project(":shared"))
     implementation(project(":desktop-shared"))
 

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
@@ -80,6 +80,7 @@ class McpClientFactory(
             log.debug("Successfully created MCP client for '${instance.name}'")
             Result.success(client)
         } catch (e: Exception) {
+            log.debug("Failed to create MCP client for '${instance.name}'", e)
             Result.failure(
                 IllegalStateException(
                     "Failed to create MCP client for '${instance.name}': ${e.message}",

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpInstanceService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpInstanceService.kt
@@ -96,6 +96,32 @@ class McpInstanceService(
 
     private val instancesConfig = McpInstancesConfig
 
+    /**
+     * Ephemeral in-memory instances (e.g. org-managed MCP servers from the team server).
+     * These are never persisted and are merged with disk-loaded instances at runtime.
+     * Replaced atomically on every sync — older entries are dropped automatically.
+     */
+    @Volatile
+    private var ephemeralInstances: List<McpInstance> = emptyList()
+
+    /**
+     * Replaces the current set of ephemeral instances.
+     * Call this after fetching org-managed MCP servers from the team server.
+     * Invalidates the tools cache so the new instances are picked up on the next request.
+     */
+    fun setEphemeralInstances(instances: List<McpInstance>) {
+        ephemeralInstances = instances
+        invalidateCache()
+        log.debug("Registered {} ephemeral MCP instances", instances.size)
+    }
+
+    /** Remove all ephemeral instances (e.g. on logout). */
+    fun clearEphemeralInstances() {
+        ephemeralInstances = emptyList()
+        invalidateCache()
+        log.debug("Cleared ephemeral MCP instances")
+    }
+
     private val globalToolsCache: Cache<String, List<ToolConfig>> = Caffeine.newBuilder()
         .maximumSize(200)
         .expireAfterWrite(30.minutes.toJavaDuration())
@@ -118,9 +144,12 @@ class McpInstanceService(
 
     // ── Instance management ──────────────────────────────────────────────────
 
-    fun getInstances(): List<McpInstance> = instancesConfig.load()
+    fun getInstances(): List<McpInstance> = instancesConfig.load() + ephemeralInstances
 
-    fun getInstance(instanceId: String): McpInstance? = instancesConfig.get(instanceId)
+    fun getInstance(instanceId: String): McpInstance? = instancesConfig.get(instanceId) ?: ephemeralInstances.find { it.id == instanceId }
+
+    /** Returns true if the given instance is org-managed (ephemeral, not user-owned). */
+    fun isEphemeral(instanceId: String): Boolean = ephemeralInstances.any { it.id == instanceId }
 
     fun createInstance(
         serverId: String,
@@ -341,7 +370,7 @@ class McpInstanceService(
             toolVectorIndexCache.put(GLOBAL_MCP_SCOPE_ID, index)
             log.debug("Built and cached global ToolVectorIndex ({} tools)", tools.size)
         } catch (e: Exception) {
-            log.warn("Could not build global ToolVectorIndex (embedding model unavailable?): {}", e.message)
+            log.warn("Could not build global ToolVectorIndex (embedding model unavailable?): {}", e.message, e)
             EventBus.emit(
                 AppErrorEvent(
                     title = "Global MCP Tool Index Unavailable",

--- a/shared/src/main/kotlin/io/askimo/core/mcp/config/McpServersConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/config/McpServersConfig.kt
@@ -30,17 +30,44 @@ object McpServersConfig {
     @Volatile
     private var cached: List<McpServerDefinition>? = null
 
+    /** Ephemeral in-memory definitions (e.g. org-managed MCP servers from the team server).
+     *  These are never persisted to disk and take precedence over disk-loaded definitions
+     *  with the same ID. Replaced atomically on every sync. */
+    @Volatile
+    private var ephemeral: Map<String, McpServerDefinition> = emptyMap()
+
     private const val MCP_CONFIG_FILE = "mcp-servers.yml"
+
+    /**
+     * Register a set of ephemeral (in-memory only) server definitions.
+     * Any previously registered ephemeral definition not present in [definitions] is removed.
+     */
+    fun setEphemeral(definitions: List<McpServerDefinition>) {
+        ephemeral = definitions.associateBy { it.id }
+        log.debug("Registered {} ephemeral MCP server definitions", definitions.size)
+    }
+
+    /** Remove all ephemeral server definitions (e.g. on logout). */
+    fun clearEphemeral() {
+        ephemeral = emptyMap()
+        log.debug("Cleared ephemeral MCP server definitions")
+    }
 
     /**
      * Get all registered MCP server definitions
      */
-    fun getAll(): List<McpServerDefinition> = cached ?: loadFromDisk()
+    fun getAll(): List<McpServerDefinition> {
+        val disk = cached ?: loadFromDisk()
+        val ep = ephemeral
+        if (ep.isEmpty()) return disk
+        // Merge: ephemeral wins on ID collision
+        return disk.filter { it.id !in ep } + ep.values
+    }
 
     /**
      * Get a specific MCP server definition by ID
      */
-    fun get(id: String): McpServerDefinition? = getAll().find { it.id == id }
+    fun get(id: String): McpServerDefinition? = ephemeral[id] ?: (cached ?: loadFromDisk()).find { it.id == id }
 
     /**
      * Add a new MCP server definition


### PR DESCRIPTION
- persist the last successful plan sync sequence as a bookmark for pulls
- add an optional plan change callback so saves and deletes can trigger team sync
- expose desktop-shared Compose dependencies for plan support tooling reuse
- merge org-managed ephemeral MCP instances and server definitions at runtime
- keep ephemeral MCP entries in memory only and let them override disk entries
- improve MCP client and tool index logging to aid failure diagnosis