### PR TITLE
refactor(chat): Use enabled server IDs instead of disabled identifiers

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatActions.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatActions.kt
@@ -13,7 +13,7 @@ interface ChatActions {
         message: String,
         attachments: List<FileAttachmentDTO> = emptyList(),
         editingMessage: ChatMessageDTO? = null,
-        disabledServerIds: Set<String> = emptySet(),
+        enabledServerIds: Set<String> = emptySet(),
     ): String?
     fun cancelResponse()
     fun loadPrevious()
@@ -23,5 +23,5 @@ interface ChatActions {
     fun previousSearchResult()
     fun setDirective(directiveId: String?)
     fun updateAIMessage(messageId: String, newContent: String)
-    fun retryMessage(messageId: String, disabledServerIds: Set<String> = emptySet())
+    fun retryMessage(messageId: String, enabledServerIds: Set<String> = emptySet())
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -140,7 +140,7 @@ fun chatInputField(
     onCancelEdit: () -> Unit = {},
     sessionId: String? = null,
     placeholder: String = stringResource("chat.input.placeholder"),
-    onDisabledServerIdsChange: ((Set<String>) -> Unit)? = null,
+    onEnabledServerIdsChange: ((Set<String>) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val inputFocusRequester = remember { FocusRequester() }
@@ -149,14 +149,13 @@ fun chatInputField(
     // Reset to Chat mode when switching to a different session
     var creationMode by remember(sessionId) { mutableStateOf<CreationMode>(CreationMode.Chat) }
 
-    // Session-scoped set of server IDs disabled by the user via the tools popup.
-    // Defaults to built-in tools disabled. Passed directly to sendMessage at send time.
-    var disabledServerIds by remember(sessionId) { mutableStateOf(setOf(ToolRegistry.BUILTIN_SERVER_ID)) }
+    // Session-scoped set of server IDs enabled by the user via the tools popup.
+    // Empty by default — all tools are off until the user opts in.
+    var enabledServerIds by remember(sessionId) { mutableStateOf(emptySet<String>()) }
 
-    // Notify caller whenever the user changes the disabled server selection,
-    // so ChatView always has the live value available for sending message.
-    LaunchedEffect(disabledServerIds) {
-        onDisabledServerIdsChange?.invoke(disabledServerIds)
+    // Notify caller whenever the user changes the enabled server selection.
+    LaunchedEffect(enabledServerIds) {
+        onEnabledServerIdsChange?.invoke(enabledServerIds)
     }
 
     // State for resizable text field (min 60dp, will calculate max based on available space)
@@ -622,9 +621,9 @@ fun chatInputField(
                     toolsIndicatorButton(
                         sessionId = sessionId,
                         isLoading = isLoading,
-                        disabledServerIds = disabledServerIds,
-                        onDisabledServerIdsChange = { updated ->
-                            disabledServerIds = updated
+                        enabledServerIds = enabledServerIds,
+                        onEnabledServerIdsChange = { updated ->
+                            enabledServerIds = updated
                         },
                     )
 
@@ -649,8 +648,8 @@ fun chatInputField(
 private fun toolsIndicatorButton(
     sessionId: String?,
     isLoading: Boolean,
-    disabledServerIds: Set<String>,
-    onDisabledServerIdsChange: (Set<String>) -> Unit,
+    enabledServerIds: Set<String>,
+    onEnabledServerIdsChange: (Set<String>) -> Unit,
 ) {
     var showToolsPopup by remember { mutableStateOf(false) }
     var mcpServers by remember { mutableStateOf<List<McpServerInfo>>(emptyList()) }
@@ -716,8 +715,8 @@ private fun toolsIndicatorButton(
     }
 
     val totalServers = mcpServers.size
-    val enabledServers = mcpServers.count { it.id !in disabledServerIds }
-    val hasDisabled = disabledServerIds.isNotEmpty() && totalServers > 0
+    val enabledServers = mcpServers.count { it.id in enabledServerIds }
+    val hasDisabled = enabledServers < totalServers && totalServers > 0
 
     Box {
         themedTooltip(
@@ -840,13 +839,13 @@ private fun toolsIndicatorButton(
                                     mcpServers.forEach { server ->
                                         mcpServerItem(
                                             server = server,
-                                            isEnabled = server.id !in disabledServerIds,
+                                            isEnabled = server.id in enabledServerIds,
                                             onToggle = {
-                                                onDisabledServerIdsChange(
-                                                    if (server.id in disabledServerIds) {
-                                                        disabledServerIds - server.id
+                                                onEnabledServerIdsChange(
+                                                    if (server.id in enabledServerIds) {
+                                                        enabledServerIds - server.id
                                                     } else {
-                                                        disabledServerIds + server.id
+                                                        enabledServerIds + server.id
                                                     },
                                                 )
                                             },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -155,7 +155,7 @@ fun chatView(
     var editingMessage by remember(sessionId, initialEditingMessage) { mutableStateOf(initialEditingMessage) }
     var editingAIMessage by remember(sessionId) { mutableStateOf<ChatMessageDTO?>(null) }
     // Always-current disabled server IDs from ChatInputField
-    var currentDisabledServerIds by remember(sessionId) { mutableStateOf(emptySet<String>()) }
+    var currentEnabledServerIds by remember(sessionId) { mutableStateOf(emptySet<String>()) }
 
     // When there is no project (e.g. user clicked "New Chat"), drop any pending
     // attachments that were added from the project side panel.
@@ -988,7 +988,7 @@ fun chatView(
                                     onDownloadAttachment = downloadAttachment,
                                     userAvatarPainter = userAvatarPainter,
                                     aiAvatarPainter = aiAvatarPainter,
-                                    onRetryMessage = { messageId -> actions.retryMessage(messageId, currentDisabledServerIds) },
+                                    onRetryMessage = { messageId -> actions.retryMessage(messageId, currentEnabledServerIds) },
                                     viewportTopY = viewportBounds?.top,
                                 )
                             }
@@ -1021,7 +1021,7 @@ fun chatView(
                                     onDownloadAttachment = downloadAttachment,
                                     userAvatarPainter = userAvatarPainter,
                                     aiAvatarPainter = aiAvatarPainter,
-                                    onRetryMessage = { messageId -> actions.retryMessage(messageId, currentDisabledServerIds) },
+                                    onRetryMessage = { messageId -> actions.retryMessage(messageId, currentEnabledServerIds) },
                                     viewportTopY = viewportBounds?.top,
                                 )
                             }
@@ -1061,7 +1061,7 @@ fun chatView(
                                 inputText.text,
                                 attachments,
                                 editingMessage,
-                                currentDisabledServerIds,
+                                currentEnabledServerIds,
                             )
                             inputText = TextFieldValue("")
                             attachments = emptyList()
@@ -1079,7 +1079,7 @@ fun chatView(
                         attachments = emptyList()
                     },
                     sessionId = sessionId,
-                    onDisabledServerIdsChange = { currentDisabledServerIds = it },
+                    onEnabledServerIdsChange = { currentEnabledServerIds = it },
                     modifier = Modifier
                         .widthIn(max = ThemePreferences.CONTENT_MAX_WIDTH)
                         .fillMaxWidth()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -402,7 +402,7 @@ class ChatViewModel(
         message: String,
         attachments: List<FileAttachmentDTO>,
         editingMessage: ChatMessageDTO?,
-        disabledServerIds: Set<String>,
+        enabledServerIds: Set<String>,
     ): String? {
         if (message.isBlank() || isLoading) return currentSessionId.value
 
@@ -413,10 +413,10 @@ class ChatViewModel(
 
             scope.launch {
                 editMessage(originalMessageId, message, attachments)
-                sendMessage(projectId = project?.id, creationMode, message, attachments, disabledServerIds)
+                sendMessage(projectId = project?.id, creationMode, message, attachments, enabledServerIds)
             }
         } else {
-            sendMessage(projectId = project?.id, creationMode, message, attachments, disabledServerIds)
+            sendMessage(projectId = project?.id, creationMode, message, attachments, enabledServerIds)
         }
 
         return currentSessionId
@@ -428,7 +428,7 @@ class ChatViewModel(
      *
      * @param messageId The AI message ID to retry
      */
-    override fun retryMessage(messageId: String, disabledServerIds: Set<String>) {
+    override fun retryMessage(messageId: String, enabledServerIds: Set<String>) {
         scope.launch {
             try {
                 // 1. Find the AI message to retry
@@ -499,7 +499,7 @@ class ChatViewModel(
                             sessionId = sessionId,
                             userMessage = userMessage,
                             willSaveUserMessage = false,
-                            disabledServerIds = disabledServerIds,
+                            enabledServerIds = enabledServerIds,
                             directiveId = selectedDirective,
                         )
 
@@ -557,7 +557,7 @@ class ChatViewModel(
      * @param message The user's message
      * @param attachments Optional list of file attachments
      */
-    fun sendMessage(projectId: String?, mode: CreationMode, message: String, attachments: List<FileAttachmentDTO> = emptyList(), disabledServerIds: Set<String> = emptySet()) {
+    fun sendMessage(projectId: String?, mode: CreationMode, message: String, attachments: List<FileAttachmentDTO> = emptyList(), enabledServerIds: Set<String> = emptySet()) {
         if (message.isBlank() || isLoading) return
 
         // Session ID must be set by this point (from resumeSession)
@@ -601,7 +601,7 @@ class ChatViewModel(
                     sessionId = sessionId,
                     userMessage = userMessage,
                     willSaveUserMessage = true,
-                    disabledServerIds = disabledServerIds,
+                    enabledServerIds = enabledServerIds,
                     directiveId = selectedDirective,
                 )
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
@@ -95,7 +95,7 @@ import kotlin.let
 @Composable
 fun projectView(
     project: Project,
-    onStartChat: (projectId: String, mode: CreationMode, message: String, attachments: List<FileAttachmentDTO>, disabledServerIds: Set<String>) -> Unit,
+    onStartChat: (projectId: String, mode: CreationMode, message: String, attachments: List<FileAttachmentDTO>, enabledServerIds: Set<String>) -> Unit,
     onResumeSession: (String) -> Unit,
     onDeleteSession: (sessionId: String, projectId: String) -> Unit,
     onRenameSession: (String, String) -> Unit,
@@ -113,7 +113,7 @@ fun projectView(
     // Local UI state
     var inputText by remember { mutableStateOf(TextFieldValue("")) }
     var attachments by remember { mutableStateOf<List<FileAttachmentDTO>>(emptyList()) }
-    var currentDisabledServerIds by remember { mutableStateOf(emptySet<String>()) }
+    var currentEnabledServerIds by remember { mutableStateOf(emptySet<String>()) }
     var showProjectMenu by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showAddReferenceMaterialDialog by remember { mutableStateOf(false) }
@@ -298,12 +298,12 @@ fun projectView(
                         onAttachmentsChange = { attachments = it },
                         onSendMessage = { mode ->
                             if (inputText.text.isNotBlank()) {
-                                onStartChat(currentProject.id, mode, inputText.text, attachments, currentDisabledServerIds)
+                                onStartChat(currentProject.id, mode, inputText.text, attachments, currentEnabledServerIds)
                                 inputText = TextFieldValue("")
                                 attachments = emptyList()
                             }
                         },
-                        onDisabledServerIdsChange = { currentDisabledServerIds = it },
+                        onEnabledServerIdsChange = { currentEnabledServerIds = it },
                         sessionId = currentProject.id,
                         placeholder = stringResource("project.new.chat.placeholder", currentProject.name),
                         modifier = Modifier.padding(top = 16.dp),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
@@ -164,7 +164,7 @@ class SessionManager(
         sessionId: String,
         userMessage: ChatMessageDTO,
         willSaveUserMessage: Boolean,
-        disabledServerIds: Set<String> = emptySet(),
+        enabledServerIds: Set<String> = emptySet(),
         directiveId: String? = null,
     ): String? {
         // Create session lazily on first message (only once per session)
@@ -231,7 +231,7 @@ class SessionManager(
                         .sendStreamingMessageWithCallback(
                             projectId = projectId,
                             userMessage = promptWithContext,
-                            disabledServerIds = disabledServerIds,
+                            enabledServerIds = enabledServerIds,
                             onToken = { token ->
                                 streamingScope.launch {
                                     thread.appendChunk(token)
@@ -427,7 +427,7 @@ class SessionManager(
         mode: CreationMode,
         message: String,
         attachments: List<FileAttachmentDTO> = emptyList(),
-        disabledServerIds: Set<String> = emptySet(),
+        enabledServerIds: Set<String> = emptySet(),
         onComplete: () -> Unit,
     ) {
         scope.launch {
@@ -453,7 +453,7 @@ class SessionManager(
 
                 // Now send the message - ViewModel is ready
                 val viewModel = getOrCreateChatViewModel(newSession.id)
-                viewModel.sendMessage(projectId, mode, message, attachments, disabledServerIds)
+                viewModel.sendMessage(projectId, mode, message, attachments, enabledServerIds)
             } catch (e: Exception) {
                 log.error("Failed to create project session and send message", e)
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -1826,13 +1826,13 @@ fun mainContent(
                     if (project != null) {
                         projectView(
                             project = project,
-                            onStartChat = { projId, mode, message, attachments, disabledServerIds ->
+                            onStartChat = { projId, mode, message, attachments, enabledServerIds ->
                                 sessionManager.createProjectSessionAndSendMessage(
                                     projectId = projId,
                                     mode = mode,
                                     message = message,
                                     attachments = attachments,
-                                    disabledServerIds = disabledServerIds,
+                                    enabledServerIds = enabledServerIds,
                                     onComplete = { onNavigateToChat() },
                                 )
                             },

--- a/shared/src/main/kotlin/io/askimo/core/context/ChatContext.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/ChatContext.kt
@@ -7,26 +7,26 @@ package io.askimo.core.context
 /**
  * ThreadLocal storage for passing request-scoped context to [io.askimo.core.tools.ToolProviderImpl].
  *
- * Both [projectId] and [disabledServers] are set on the same thread that calls
+ * Both [projectId] and [enabledServers] are set on the same thread that calls
  * [io.askimo.core.providers.sendStreamingMessageWithCallback], which is the same thread
  * LangChain4j uses to invoke [io.askimo.core.tools.ToolProviderImpl.provideTools].
  * No cross-thread coordination needed.
  */
 object ChatContext {
     private val projectIdThreadLocal = ThreadLocal<String?>()
-    private val disabledServersThreadLocal = ThreadLocal<Set<String>>()
+    private val enabledServersThreadLocal = ThreadLocal<Set<String>>()
 
     fun setProjectId(projectId: String?) = projectIdThreadLocal.set(projectId)
     fun getProjectId(): String? = projectIdThreadLocal.get()
 
-    fun setDisabledServers(disabledServerIds: Set<String>) = disabledServersThreadLocal.set(disabledServerIds)
-    fun getDisabledServers(): Set<String> = disabledServersThreadLocal.get() ?: emptySet()
+    fun setEnabledServers(enabledServerIds: Set<String>) = enabledServersThreadLocal.set(enabledServerIds)
+    fun getEnabledServers(): Set<String> = enabledServersThreadLocal.get() ?: emptySet()
 
     /**
      * Clear all thread-local state. Must be called in a finally block after each request.
      */
     fun clear() {
         projectIdThreadLocal.remove()
-        disabledServersThreadLocal.remove()
+        enabledServersThreadLocal.remove()
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -65,17 +65,17 @@ private fun Throwable.isUnsupportedSamplingError(): Boolean {
 fun ChatClient.sendStreamingMessageWithCallback(
     projectId: String? = null,
     userMessage: UserMessage,
-    disabledServerIds: Set<String> = emptySet(),
+    enabledServerIds: Set<String> = emptySet(),
     onToken: (String) -> Unit = {},
     onFollowUpSuggestion: ((FollowUpSuggestion) -> Unit)? = null,
 ): String {
     val log = logger<ChatClient>()
 
     try {
-        // Set both projectId and disabledServers in ThreadLocal on this thread —
+        // Set both projectId and enabledServers in ThreadLocal on this thread —
         // the same thread LangChain4j uses to call ToolProviderImpl.provideTools().
         ChatContext.setProjectId(projectId)
-        ChatContext.setDisabledServers(disabledServerIds)
+        ChatContext.setEnabledServers(enabledServerIds)
 
         // Get provider and model from AppContext
         val appContext = AppContext.getInstance()

--- a/shared/src/main/kotlin/io/askimo/core/tools/ToolProviderImpl.kt
+++ b/shared/src/main/kotlin/io/askimo/core/tools/ToolProviderImpl.kt
@@ -56,12 +56,12 @@ class ToolProviderImpl(
 
         if (userIntent.tools.isEmpty()) return null
 
-        val disabledServers = ChatContext.getDisabledServers()
+        val enabledServers = ChatContext.getEnabledServers()
 
         val builder = ToolProviderResult.builder()
 
         userIntent.tools
-            .filter { tool -> tool.serverId !in disabledServers }
+            .filter { tool -> tool.serverId in enabledServers }
             .forEach { tool ->
                 if (tool.source == ToolSource.ASKIMO_BUILTIN) {
                     val className = tool.specification.metadata()["className"]


### PR DESCRIPTION
- Refactored state and APIs across the chat components (View, ViewModel, Actions) to manage server selection using an explicit whitelist of enabled server IDs.
- Updated `ChatContext` to use a thread-local storage for `enabledServerIds`.
- Adjusted `ToolProviderImpl` to filter available tools based on the provided `enabledServerIds`, ensuring tools only operate on visible servers.
- Updated several entry points (`mainContent`, `ProjectView`, `SessionManager`) to consume the new `enabledServerIds` parameter.