### PR TITLE
feat(desktop): Improve version update dialog flow and dismissal persistence

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -503,54 +503,88 @@ jobs:
           # Fetch current release body first
           CURRENT_BODY=$(gh release view "$TAG" --json body --jq '.body' 2>/dev/null || echo "")
 
-          # Skip if contributors section already exists (idempotent re-runs)
-          if echo "$CURRENT_BODY" | grep -q "^## Contributors"; then
+          # Skip if OUR contributors section already exists (idempotent re-runs).
+          # GitHub's auto-generated section uses "<!-- Release notes generated"
+          # as a marker; ours does not — so we key on our unique thank-you line.
+          if echo "$CURRENT_BODY" | grep -qF "Thank you to everyone who contributed"; then
             echo "ℹ️  Contributors section already present — skipping to preserve manual edits."
             exit 0
           fi
 
           # Skip if release notes are empty — don't add contributors to a blank body.
-          # Notes should be written manually first; contributors are appended after.
           TRIMMED=$(echo "$CURRENT_BODY" | tr -d '[:space:]')
           if [ -z "$TRIMMED" ]; then
             echo "ℹ️  Release notes are empty — skipping contributors until notes are written."
             exit 0
           fi
 
-          # Find the previous tag (the one before this one)
+          # Find the previous tag
           PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${TAG}$" | head -n1 || true)
+          RANGE="${PREV_TAG:+${PREV_TAG}..}${TAG}"
+          echo "Contributors range: $RANGE"
 
-          if [ -n "$PREV_TAG" ]; then
-            RANGE="${PREV_TAG}..${TAG}"
-            echo "Contributors from $RANGE"
-          else
-            RANGE="${TAG}"
-            echo "No previous tag found — listing all contributors up to $TAG"
-          fi
-
-          # Collect unique authors: "Login (Name)" sorted, bots excluded
-          mapfile -t AUTHORS < <(
-            git log "$RANGE" --format='%aN|%aE' \
-              | sort -u \
+          # Collect unique commit SHAs (exclude bots and GitHub noreply addresses)
+          mapfile -t COMMITS < <(
+            git log "$RANGE" --format='%H|%aE' \
               | grep -viE '\[bot\]|noreply\.github\.com' \
-              | awk -F'|' '{print $1}' \
               | sort -u
           )
 
-          if [ ${#AUTHORS[@]} -eq 0 ]; then
-            echo "No human contributors found — skipping append."
+          # Resolve each commit to a GitHub login + avatar via the Commits API.
+          declare -A SEEN_LOGINS
+          declare -a CONTRIBUTOR_LINES
+
+          for ENTRY in "${COMMITS[@]}"; do
+            SHA="${ENTRY%%|*}"
+            JSON=$(gh api "/repos/${GITHUB_REPOSITORY}/commits/${SHA}" \
+              --jq '{login: .author.login, avatar: .author.avatar_url, name: .commit.author.name}' \
+              2>/dev/null || echo "{}")
+
+            LOGIN=$(echo "$JSON" | jq -r '.login // empty')
+            AVATAR=$(echo "$JSON" | jq -r '.avatar // empty')
+            NAME=$(echo "$JSON"   | jq -r '.name   // empty')
+
+            # Skip bots and unresolved entries
+            if [ -z "$LOGIN" ] || echo "$LOGIN" | grep -qiE '\[bot\]|bot$'; then
+              continue
+            fi
+
+            # Deduplicate
+            [ -n "${SEEN_LOGINS[$LOGIN]+x}" ] && continue
+            SEEN_LOGINS[$LOGIN]=1
+
+            if [ -n "$AVATAR" ]; then
+              LINE="- <img src=\"${AVATAR}&s=20\" width=\"20\" height=\"20\" style=\"border-radius:50%\"> [@${LOGIN}](https://github.com/${LOGIN})"
+            else
+              LINE="- [@${LOGIN}](https://github.com/${LOGIN})"
+            fi
+            [ -n "$NAME" ] && LINE="${LINE} — ${NAME}"
+            CONTRIBUTOR_LINES+=("$LINE")
+          done
+
+          if [ ${#CONTRIBUTOR_LINES[@]} -eq 0 ]; then
+            echo "No human contributors resolved — skipping append."
             exit 0
           fi
 
-          echo "Found ${#AUTHORS[@]} contributor(s): ${AUTHORS[*]}"
+          echo "Found ${#CONTRIBUTOR_LINES[@]} contributor(s)."
 
-          # Build markdown section
+          # Strip any existing GitHub-auto-generated "## Contributors" block from
+          # CURRENT_BODY so we replace it with our richer version (avatar + link).
+          # GitHub's block starts with "## Contributors" and ends at EOF or next "## ".
+          STRIPPED_BODY=$(echo "$CURRENT_BODY" | awk '
+            /^## Contributors/ { skip=1; next }
+            skip && /^## /     { skip=0 }
+            !skip              { print }
+          ')
+
+          # Build our contributors section
           SECTION=$'\n\n## Contributors\n\nThank you to everyone who contributed to this release! 🎉\n\n'
-          for AUTHOR in "${AUTHORS[@]}"; do
-            SECTION+="- ${AUTHOR}"$'\n'
+          for LINE in "${CONTRIBUTOR_LINES[@]}"; do
+            SECTION+="${LINE}"$'\n'
           done
 
-          NEW_BODY="${CURRENT_BODY}${SECTION}"
+          NEW_BODY="${STRIPPED_BODY}${SECTION}"
 
           gh release edit "$TAG" --notes "$NEW_BODY"
           echo "✅ Contributors section appended to release $TAG"

--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -4956,7 +4956,7 @@
     "parameterTypes": [ "dev.langchain4j.data.message.UserMessage", "dev.langchain4j.model.chat.request.ChatRequestParameters" ]
   } ]
 }, {
-  "name": "io.askimo.core.providers.ChatClient$MockitoMock$SfxzjTeR",
+  "name": "io.askimo.core.providers.ChatClient$MockitoMock$3QM71SKv",
   "queryAllDeclaredConstructors": true,
   "methods": [ {
     "name": "<init>",
@@ -7438,7 +7438,7 @@
     "parameterTypes": [ ]
   } ]
 }, {
-  "name": "org.jline.reader.ParsedLine$MockitoMock$9dkxsF5P",
+  "name": "org.jline.reader.ParsedLine$MockitoMock$vYdUUW5f",
   "queryAllDeclaredConstructors": true,
   "methods": [ {
     "name": "<init>",

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/UpdateDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/UpdateDialog.kt
@@ -10,10 +10,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import io.askimo.core.service.UpdateChecker
 import io.askimo.core.service.UpdateInfo
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
@@ -40,6 +47,13 @@ fun updateCheckDialog(
                 currentVersion = viewModel.getCurrentVersion(),
                 onDownload = {
                     viewModel.openDownloadPage()
+                    onDismiss()
+                },
+                onHowToUpdate = {
+                    viewModel.openHowToUpdatePage()
+                },
+                onSkipVersion = {
+                    viewModel.skipThisVersion()
                     onDismiss()
                 },
                 onLater = onDismiss,
@@ -62,13 +76,28 @@ fun updateCheckDialog(
     }
 }
 
+/** Urgency tier derived from [UpdateInfo.versionsBehind]. */
+private enum class UpdateUrgency { LOW, MEDIUM, HIGH }
+
+private fun urgencyFor(versionsBehind: Int): UpdateUrgency = when {
+    versionsBehind >= 5 -> UpdateUrgency.HIGH
+    versionsBehind >= 2 -> UpdateUrgency.MEDIUM
+    else -> UpdateUrgency.LOW
+}
+
 @Composable
 private fun newVersionDialog(
     releaseInfo: UpdateInfo,
     currentVersion: String,
     onDownload: () -> Unit,
+    onHowToUpdate: () -> Unit,
+    onSkipVersion: () -> Unit,
     onLater: () -> Unit,
 ) {
+    val urgency = urgencyFor(releaseInfo.versionsBehind)
+    val cap = UpdateChecker.MAX_VERSIONS_BEHIND_CAP
+    val behindLabel = if (releaseInfo.versionsBehind >= cap) "$cap+" else "${releaseInfo.versionsBehind}"
+
     AppComponents.alertDialog(
         onDismissRequest = onLater,
         title = {
@@ -84,13 +113,45 @@ private fun newVersionDialog(
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                // Header message
-                Text(
-                    text = stringResource("update.dialog.new.version.available"),
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                // Urgency banner
+                val bannerColors = when (urgency) {
+                    UpdateUrgency.HIGH -> CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+
+                    UpdateUrgency.MEDIUM -> CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    )
+
+                    UpdateUrgency.LOW -> AppComponents.bannerCardColors()
+                }
+                val bannerIcon = if (urgency == UpdateUrgency.HIGH) Icons.Default.Warning else Icons.Default.Info
+                val bannerText = when (urgency) {
+                    UpdateUrgency.HIGH -> stringResource("update.urgency.high", behindLabel)
+                    UpdateUrgency.MEDIUM -> stringResource("update.urgency.medium", behindLabel)
+                    UpdateUrgency.LOW -> stringResource("update.dialog.new.version.available")
+                }
+
+                Card(modifier = Modifier.fillMaxWidth(), colors = bannerColors) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = bannerIcon,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Text(
+                            text = bannerText,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                }
 
                 // Version info card
                 Card(
@@ -170,17 +231,21 @@ private fun newVersionDialog(
             }
         },
         confirmButton = {
-            primaryButton(
-                onClick = onDownload,
-            ) {
+            primaryButton(onClick = onDownload) {
                 Text(stringResource("update.dialog.download"))
             }
         },
         dismissButton = {
-            secondaryButton(
-                onClick = onLater,
-            ) {
-                Text(stringResource("update.dialog.later"))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                secondaryButton(onClick = onHowToUpdate) {
+                    Text(stringResource("update.dialog.how.to.update"))
+                }
+                secondaryButton(onClick = onSkipVersion) {
+                    Text(stringResource("update.dialog.skip.version"))
+                }
+                secondaryButton(onClick = onLater) {
+                    Text(stringResource("update.dialog.later"))
+                }
             }
         },
     )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/preferences/ApplicationPreferences.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/preferences/ApplicationPreferences.kt
@@ -293,6 +293,22 @@ object ApplicationPreferences {
         safePutBoolean(PLAN_HISTORY_SIDE_PANEL_EXPANDED_KEY, expanded)
     }
 
+    private const val DISMISSED_UPDATE_VERSION_KEY = "update.dismissed_version"
+
+    /**
+     * Returns the latest version string the user has already dismissed,
+     * or null if they have never dismissed an update notification.
+     */
+    fun getDismissedUpdateVersion(): String? = safeGet(DISMISSED_UPDATE_VERSION_KEY, null)
+
+    /**
+     * Persists [version] so the update popup is not auto-shown again for this release.
+     * Call this when the user dismisses the notification popup or banner.
+     */
+    fun setDismissedUpdateVersion(version: String) {
+        safePut(DISMISSED_UPDATE_VERSION_KEY, version)
+    }
+
     // ============================================================
     // PLAN SYNC
     // ============================================================

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NotificationComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NotificationComponents.kt
@@ -56,6 +56,7 @@ import io.askimo.core.event.system.ShellErrorEvent
 import io.askimo.core.event.system.UpdateAvailableEvent
 import io.askimo.core.util.TimeUtil.formatInstantDisplay
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.preferences.ApplicationPreferences
 import io.askimo.ui.common.theme.AppComponents
 
 /**
@@ -91,12 +92,28 @@ fun notificationIcon(onShowUpdateDetails: () -> Unit) {
             if (events.size > 100) {
                 events.removeAt(100)
             }
+            // Auto-open the notification popup when a new version is detected,
+            // unless the user has already dismissed this exact version.
+            if (event is UpdateAvailableEvent &&
+                ApplicationPreferences.getDismissedUpdateVersion() != event.latestVersion
+            ) {
+                showEventPopup = true
+            }
         }
     }
 
     Box {
         IconButton(
-            onClick = { showEventPopup = !showEventPopup },
+            onClick = {
+                if (showEventPopup) {
+                    // Closing — persist dismissed version
+                    val latestUpdate = events.firstNotNullOfOrNull { it.event as? UpdateAvailableEvent }
+                    if (latestUpdate != null) {
+                        ApplicationPreferences.setDismissedUpdateVersion(latestUpdate.latestVersion)
+                    }
+                }
+                showEventPopup = !showEventPopup
+            },
             modifier = Modifier
                 .size(32.dp)
                 .pointerHoverIcon(PointerIcon.Hand),
@@ -134,7 +151,14 @@ fun notificationIcon(onShowUpdateDetails: () -> Unit) {
             Popup(
                 alignment = Alignment.BottomEnd,
                 offset = IntOffset(0, -40),
-                onDismissRequest = { showEventPopup = false },
+                onDismissRequest = {
+                    showEventPopup = false
+                    // Persist the latest update version so the popup won't auto-reopen for it
+                    val latestUpdate = events.mapNotNull { it.event as? UpdateAvailableEvent }.firstOrNull()
+                    if (latestUpdate != null) {
+                        ApplicationPreferences.setDismissedUpdateVersion(latestUpdate.latestVersion)
+                    }
+                },
             ) {
                 Card(
                     modifier = Modifier.padding(8.dp),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/UpdateViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/UpdateViewModel.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import io.askimo.core.logging.logger
 import io.askimo.core.service.UpdateInfo
+import io.askimo.ui.common.preferences.ApplicationPreferences
 import io.askimo.ui.service.UpdateService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -88,6 +89,15 @@ class UpdateViewModel(
     }
 
     /**
+     * Dismiss the update dialog AND mark this version as skipped so the
+     * auto-popup never appears again for this specific release.
+     */
+    fun skipThisVersion() {
+        releaseInfo?.latestVersion?.let { ApplicationPreferences.setDismissedUpdateVersion(it) }
+        showUpdateDialog = false
+    }
+
+    /**
      * Show update dialog for existing release info without re-checking.
      * Used when user clicks Details button in notification.
      */
@@ -97,15 +107,15 @@ class UpdateViewModel(
         }
     }
 
+    fun openHowToUpdatePage() {
+        runCatching { Desktop.getDesktop().browse(URI("https://askimo.chat/docs/desktop/updating/")) }
+            .onFailure { log.error("Failed to open how-to-update page", it) }
+    }
+
     fun openDownloadPage() {
         releaseInfo?.let { info ->
-            try {
-                val desktop = Desktop.getDesktop()
-                desktop.browse(URI(info.downloadUrl))
-            } catch (e: Exception) {
-                log.error("Failed to open download page", e)
-                errorMessage = "Failed to open browser: ${e.message}"
-            }
+            runCatching { Desktop.getDesktop().browse(URI(info.downloadUrl)) }
+                .onFailure { log.error("Failed to open download page", it) }
         }
     }
 

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -523,12 +523,17 @@ sessions.error.rename.failed=Failed to rename session.
 # Update Check
 update.dialog.title=Software Update
 update.dialog.new.version.available=A new version of Askimo is available!
+update.urgency.low=A new version of Askimo is available.
+update.urgency.medium=You are {0} versions behind — you may be missing important bug fixes and new features.
+update.urgency.high=You are {0} versions behind — you are missing significant improvements. Please update soon.
 update.dialog.current.version.label=Current Version
 update.dialog.new.version.label=New Version
 update.dialog.release.date=Release Date
 update.dialog.release.notes=What's New
 update.dialog.download=Download Now
+update.dialog.how.to.update=How to Update
 update.dialog.later=Later
+update.dialog.skip.version=Skip This Version
 update.check.up.to.date=You're using the latest version!
 update.check.failed=Update Check Failed
 

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -526,12 +526,17 @@ sessions.error.rename.failed=Umbenennen fehlgeschlagen.
 # Update Check
 update.dialog.title=Software-Update
 update.dialog.new.version.available=Eine neue Version von Askimo ist verfügbar!
+update.urgency.low=Eine neue Version von Askimo ist verfügbar.
+update.urgency.medium=Sie liegen {0} Versionen zurück — Sie könnten wichtige Fehlerbehebungen und neue Funktionen verpassen.
+update.urgency.high=Sie liegen {0} Versionen zurück — Sie verpassen erhebliche Verbesserungen. Bitte bald aktualisieren.
 update.dialog.current.version.label=Aktuelle Version
 update.dialog.new.version.label=Neue Version
 update.dialog.release.date=Veröffentlichungsdatum
 update.dialog.release.notes=Was ist neu
 update.dialog.download=Jetzt herunterladen
+update.dialog.how.to.update=So aktualisieren Sie
 update.dialog.later=Später
+update.dialog.skip.version=Diese Version überspringen
 update.check.up.to.date=Sie verwenden die neueste Version!
 update.check.failed=Update-Prüfung fehlgeschlagen
 

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -525,12 +525,17 @@ sessions.error.rename.failed=Fallo al renombrar sesión.
 # Update Check
 update.dialog.title=Actualización de software
 update.dialog.new.version.available=¡Hay una nueva versión de Askimo disponible!
+update.urgency.low=Hay una nueva versión de Askimo disponible.
+update.urgency.medium=Llevas {0} versiones de retraso — puede que te estés perdiendo correcciones importantes y nuevas funciones.
+update.urgency.high=Llevas {0} versiones de retraso — te estás perdiendo mejoras significativas. Por favor, actualiza pronto.
 update.dialog.current.version.label=Versión actual
 update.dialog.new.version.label=Nueva versión
 update.dialog.release.date=Fecha de lanzamiento
 update.dialog.release.notes=Novedades
 update.dialog.download=Descargar ahora
+update.dialog.how.to.update=Cómo actualizar
 update.dialog.later=Más tarde
+update.dialog.skip.version=Omitir esta versión
 update.check.up.to.date=¡Ya estás usando la última versión!
 update.check.failed=Fallo al buscar actualizaciones
 

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -525,12 +525,17 @@ sessions.error.rename.failed=Renommage impossible.
 # Update Check
 update.dialog.title=Mise à jour du logiciel
 update.dialog.new.version.available=Une nouvelle version d’Askimo est disponible !
+update.urgency.low=Une nouvelle version d'Askimo est disponible.
+update.urgency.medium=Vous avez {0} versions de retard — vous pourriez manquer des correctifs importants et de nouvelles fonctionnalités.
+update.urgency.high=Vous avez {0} versions de retard — vous manquez des améliorations importantes. Veuillez mettre à jour bientôt.
 update.dialog.current.version.label=Version actuelle
 update.dialog.new.version.label=Nouvelle version
 update.dialog.release.date=Date de sortie
 update.dialog.release.notes=Notes de version
 update.dialog.download=Télécharger maintenant
+update.dialog.how.to.update=Comment mettre à jour
 update.dialog.later=Plus tard
+update.dialog.skip.version=Ignorer cette version
 update.check.up.to.date=Vous utilisez la dernière version !
 update.check.failed=Échec de la vérification
 

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -525,12 +525,17 @@ sessions.error.rename.failed=セッション名の変更に失敗しました。
 # Update Check
 update.dialog.title=ソフトウェアアップデート
 update.dialog.new.version.available=新しい Askimo バージョンがあります！
+update.urgency.low=新しい Askimo バージョンがあります。
+update.urgency.medium={0} バージョン遅れています — 重要なバグ修正や新機能を見逃している可能性があります。
+update.urgency.high={0} バージョン遅れています — 大幅な改善を見逃しています。早急に更新してください。
 update.dialog.current.version.label=現在のバージョン
 update.dialog.new.version.label=新しいバージョン
 update.dialog.release.date=リリース日
 update.dialog.release.notes=更新内容
 update.dialog.download=今すぐダウンロード
+update.dialog.how.to.update=更新方法
 update.dialog.later=後で
+update.dialog.skip.version=このバージョンをスキップ
 update.check.up.to.date=最新バージョンです！
 update.check.failed=アップデート確認に失敗
 

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -526,12 +526,17 @@ sessions.error.rename.failed=이름 변경 실패.
 # Update Check
 update.dialog.title=소프트웨어 업데이트
 update.dialog.new.version.available=새로운 Askimo 버전 이용 가능!
+update.urgency.low=새로운 Askimo 버전이 있습니다.
+update.urgency.medium={0}개 버전 뒤처져 있습니다 — 중요한 버그 수정 및 신기능을 놓쳤을 수 있습니다.
+update.urgency.high={0}개 버전 뒤처져 있습니다 — 상당한 개선 사항을 놓치고 있습니다. 빨리 업데이트하세요.
 update.dialog.current.version.label=현재 버전
 update.dialog.new.version.label=새 버전
 update.dialog.release.date=릴리스 날짜
 update.dialog.release.notes=변경 사항
 update.dialog.download=지금 다운로드
+update.dialog.how.to.update=업데이트 방법
 update.dialog.later=나중에
+update.dialog.skip.version=이 버전 건너뛰기
 update.check.up.to.date=최신 버전을 사용 중입니다!
 update.check.failed=업데이트 확인 실패
 

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -526,12 +526,17 @@ sessions.error.rename.failed=Falha ao renomear sessão.
 # Update Check
 update.dialog.title=Atualização de Software
 update.dialog.new.version.available=Uma nova versão do Askimo está disponível!
+update.urgency.low=Uma nova versão do Askimo está disponível.
+update.urgency.medium=Você está {0} versões atrás — pode estar perdendo correções importantes e novos recursos.
+update.urgency.high=Você está {0} versões atrás — está perdendo melhorias significativas. Atualize em breve.
 update.dialog.current.version.label=Versão Atual
 update.dialog.new.version.label=Nova Versão
 update.dialog.release.date=Data de lançamento
 update.dialog.release.notes=Novidades
 update.dialog.download=Baixar Agora
+update.dialog.how.to.update=Como atualizar
 update.dialog.later=Depois
+update.dialog.skip.version=Pular esta versão
 update.check.up.to.date=Você está usando a versão mais recente!
 update.check.failed=Falha ao verificar atualizações
 

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -521,12 +521,17 @@ sessions.error.rename.failed=Đổi tên thất bại.
 # Update Check
 update.dialog.title=Cập nhật phần mềm
 update.dialog.new.version.available=Có phiên bản Askimo mới!
+update.urgency.low=Có phiên bản Askimo mới.
+update.urgency.medium=Bạn đang dùng phiên bản cũ hơn {0} bản — bạn có thể đã bỏ lỡ các bản sửa lỗi quan trọng và tính năng mới.
+update.urgency.high=Bạn đang dùng phiên bản cũ hơn {0} bản — bạn đang bỏ lỡ nhiều cải tiến đáng kể. Vui lòng cập nhật sớm.
 update.dialog.current.version.label=Phiên bản hiện tại
 update.dialog.new.version.label=Phiên bản mới
 update.dialog.release.date=Ngày phát hành
 update.dialog.release.notes=Thông tin bản phát hành
 update.dialog.download=Tải ngay
+update.dialog.how.to.update=Cách cập nhật
 update.dialog.later=Để sau
+update.dialog.skip.version=Bỏ qua phiên bản này
 update.check.up.to.date=Bạn đang sử dụng phiên bản mới nhất!
 update.check.failed=Kiểm tra cập nhật thất bại
 

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -525,12 +525,17 @@ sessions.error.rename.failed=重命名会话失败。
 # Update Check
 update.dialog.title=软件更新
 update.dialog.new.version.available=有新的 Askimo 版本可用！
+update.urgency.low=有新的 Askimo 版本可用。
+update.urgency.medium=您落后了 {0} 个版本——可能错过了重要的错误修复和新功能。
+update.urgency.high=您落后了 {0} 个版本——错过了重大改进，请尽快更新。
 update.dialog.current.version.label=当前版本
 update.dialog.new.version.label=新版本
 update.dialog.release.date=发布日期
 update.dialog.release.notes=更新内容
 update.dialog.download=立即下载
+update.dialog.how.to.update=如何更新
 update.dialog.later=稍后
+update.dialog.skip.version=跳过此版本
 update.check.up.to.date=已是最新版本！
 update.check.failed=检查更新失败
 

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -525,12 +525,17 @@ sessions.error.rename.failed=重新命名失敗。
 # Update Check
 update.dialog.title=軟體更新
 update.dialog.new.version.available=有可用的 Askimo 新版本！
+update.urgency.low=有可用的 Askimo 新版本。
+update.urgency.medium=您落後了 {0} 個版本——可能錯過了重要的錯誤修復和新功能。
+update.urgency.high=您落後了 {0} 個版本——錯過了重大改進，請盡快更新。
 update.dialog.current.version.label=目前版本
 update.dialog.new.version.label=新版本
 update.dialog.release.date=發布日期
 update.dialog.release.notes=更新內容
 update.dialog.download=立即下載
+update.dialog.how.to.update=如何更新
 update.dialog.later=稍後
+update.dialog.skip.version=跳過此版本
 update.check.up.to.date=您已使用最新版本！
 update.check.failed=更新檢查失敗
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.3.6
+projectVersion=1.3.7
 
 # About information
 author=Askimo

--- a/shared/src/main/kotlin/io/askimo/core/service/UpdateChecker.kt
+++ b/shared/src/main/kotlin/io/askimo/core/service/UpdateChecker.kt
@@ -7,6 +7,7 @@ package io.askimo.core.service
 import io.askimo.core.VersionInfo
 import io.askimo.core.logging.logger
 import io.askimo.core.util.JsonUtils.json
+import kotlinx.serialization.builtins.ListSerializer
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -24,6 +25,9 @@ data class GitHubRelease(
 
 /**
  * Information about a software release.
+ *
+ * @param versionsBehind How many releases the current install lags behind the latest.
+ *        Capped at [UpdateChecker.MAX_VERSIONS_BEHIND_CAP]. 0 means up to date.
  */
 data class UpdateInfo(
     val currentVersion: String,
@@ -33,6 +37,7 @@ data class UpdateInfo(
     val downloadUrl: String,
     val releaseNotes: String,
     val isNewVersion: Boolean,
+    val versionsBehind: Int = 0,
 )
 
 /**
@@ -44,7 +49,13 @@ class UpdateChecker(
     private val userAgent: String = "Askimo/${VersionInfo.version}",
 ) {
     private val log = logger<UpdateChecker>()
-    private val githubApiUrl = "https://api.github.com/repos/$githubRepo/releases/latest"
+
+    /**
+     * Uses the list endpoint (newest-first) so we can count how many releases
+     * the user is behind in a single request.
+     */
+    private val githubReleasesUrl = "https://api.github.com/repos/$githubRepo/releases?per_page=100"
+
     private val httpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
         .build()
@@ -54,10 +65,10 @@ class UpdateChecker(
      * Returns null if the check fails or if there's an error.
      */
     fun checkForUpdates(): UpdateInfo? = try {
-        log.debug("Checking for updates from: $githubApiUrl")
+        log.debug("Checking for updates from: $githubReleasesUrl")
 
         val request = HttpRequest.newBuilder()
-            .uri(URI.create(githubApiUrl))
+            .uri(URI.create(githubReleasesUrl))
             .header("Accept", "application/vnd.github.v3+json")
             .header("User-Agent", userAgent)
             .GET()
@@ -77,22 +88,43 @@ class UpdateChecker(
     }
 
     private fun parseUpdateInfo(jsonResponse: String): UpdateInfo? = try {
-        val release = json.decodeFromString<GitHubRelease>(jsonResponse)
-        val latestVersion = release.tag_name.removePrefix("v")
+        val releases = json.decodeFromString(ListSerializer(GitHubRelease.serializer()), jsonResponse)
+        if (releases.isEmpty()) return null
+
+        // Releases are returned newest-first by the API
+        val latest = releases.first()
+        val latestVersion = latest.tag_name.removePrefix("v")
         val currentVersion = VersionInfo.version
 
         log.debug("Current version: $currentVersion, Latest version: $latestVersion")
 
         val isNewVersion = isNewerVersion(latestVersion, currentVersion)
 
+        // Count how many releases are newer than the current version (stop early at cap)
+        val versionsBehind = if (isNewVersion) {
+            var count = 0
+            for (release in releases) {
+                val v = release.tag_name.removePrefix("v")
+                if (v == currentVersion) break
+                count++
+                if (count >= MAX_VERSIONS_BEHIND_CAP) break
+            }
+            count
+        } else {
+            0
+        }
+
+        log.debug("Versions behind: $versionsBehind")
+
         UpdateInfo(
             currentVersion = currentVersion,
             latestVersion = latestVersion,
-            releaseName = release.name,
-            releaseDate = formatReleaseDate(release.published_at),
-            downloadUrl = release.html_url,
-            releaseNotes = release.body,
+            releaseName = latest.name,
+            releaseDate = formatReleaseDate(latest.published_at),
+            downloadUrl = latest.html_url,
+            releaseNotes = latest.body,
             isNewVersion = isNewVersion,
+            versionsBehind = versionsBehind,
         )
     } catch (e: Exception) {
         log.error("Error parsing release info", e)
@@ -127,5 +159,7 @@ class UpdateChecker(
 
     companion object {
         fun getCurrentVersion(): String = VersionInfo.version
+
+        const val MAX_VERSIONS_BEHIND_CAP = 10
     }
 }


### PR DESCRIPTION
- Persist the last dismissed update version to prevent the dialog from reappearing immediately.
- Add options to the update prompt for "How to Update" and "Skip This Version".
- Refactor the version checking logic to accurately calculate and cap versions behind.
- Update the release workflow to correctly parse and structure contributor information.
- Localize new urgency messages and dismissal options across multiple languages.