### PR TITLE
feat(plan-inputs): Add support for file and folder inputs in plans

### DIFF
--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
@@ -62,15 +62,17 @@ class PlanExecutor(private val chatModel: ChatModel) {
         // Collect interactive answers first by traversing the workflow for Ask nodes.
         // This populates a mutable scope map that is seeded into the agentic run.
         val scopeInputs: MutableMap<String, Any> = inputs.toMutableMap()
+
+        // Resolve file/folder inputs: replace the path value with actual file content.
+        resolveFileInputs(plan, scopeInputs)
+
         collectInteractiveInputs(plan.workflow, plan.steps, plan, executionId, scopeInputs)
 
         // Build the root agent with the observability listener attached.
         val listener = PlanExecutionListener(planId = plan.id, executionId = executionId)
         val rootAgent: UntypedAgent? = buildAgent(plan.workflow, plan.steps, plan, listener)
 
-        if (rootAgent != null) {
-            rootAgent.invoke(scopeInputs)
-        }
+        rootAgent?.invoke(scopeInputs)
 
         val lastStepId = lastLeafStepId(plan.workflow)
         val output = listener.stepOutputs.lastOrNull { (stepName, _) -> stepName == lastStepId }?.second
@@ -190,6 +192,24 @@ class PlanExecutor(private val chatModel: ChatModel) {
             return value.isNotBlank() && value != "false"
         }
         return false
+    }
+
+    /**
+     * Resolves `type: file` and `type: folder` inputs by reading the path value from [scope]
+     * and replacing it with the actual file/folder content via [PlanFileContentReader].
+     * Non-file inputs are left untouched.
+     */
+    private fun resolveFileInputs(plan: PlanDef, scope: MutableMap<String, Any>) {
+        plan.inputs
+            .filter { it.type == "file" || it.type == "folder" || it.type == "url" }
+            .forEach { input ->
+                val value = scope[input.key]?.toString()
+                if (value.isNullOrBlank()) return@forEach
+                log.debug("[{}] Resolving {} input '{}' from: {}", plan.id, input.type, input.key, value.take(100))
+                val content = PlanFileContentReader.read(value, input)
+                scope[input.key] = content
+                log.debug("[{}] Injected {} chars for input '{}'", plan.id, content.length, input.key)
+            }
     }
 
     private fun validateInputs(plan: PlanDef, inputs: Map<String, String>) {

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanFileContentReader.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanFileContentReader.kt
@@ -1,0 +1,214 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.core.plan
+
+import io.askimo.core.logging.logger
+import io.askimo.core.plan.domain.PlanInput
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.FileSystems
+import java.time.Duration
+
+/**
+ * Reads content for [PlanInput] entries with `type: file`, `type: folder`, or `type: url`
+ * and returns it as a plain-text string ready for scope injection.
+ *
+ * - `file` / `folder`: reads local file system paths.
+ * - `url`: fetches the page over HTTP, strips HTML tags, injects plain text.
+ *
+ * Content is always capped at [PlanInput.maxKb] kilobytes.
+ */
+object PlanFileContentReader {
+
+    private val log = logger<PlanFileContentReader>()
+
+    private const val SINGLE_FILE_MAX_KB = 128
+    private const val BINARY_THRESHOLD = 0.1
+
+    /**
+     * Resolves content for the given [value] (path or URL) according to [input] type.
+     */
+    fun read(value: String, input: PlanInput): String {
+        if (value.isBlank()) return "[Error: no value provided for input '${input.key}']"
+
+        return when (input.type) {
+            "url" -> fetchUrl(value, input)
+            "file", "folder" -> readFileSystem(value, input)
+            else -> "[Error: unsupported content input type '${input.type}']"
+        }
+    }
+
+    // ── URL ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Fetches [url], strips HTML tags, and returns the plain text truncated to [PlanInput.maxKb].
+     */
+    private fun fetchUrl(url: String, input: PlanInput): String {
+        log.debug("Fetching URL for input '{}': {}", input.key, url)
+
+        val client = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(input.fetchTimeoutSec.toLong()))
+            .build()
+
+        val request = try {
+            HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(input.fetchTimeoutSec.toLong()))
+                .header("User-Agent", "Askimo-Plan/1.0")
+                .GET()
+                .build()
+        } catch (e: Exception) {
+            log.warn("Invalid URL '{}': {}", url, e.message)
+            return "[Error: invalid URL '$url' — ${e.message}]"
+        }
+
+        return try {
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+            if (response.statusCode() !in 200..299) {
+                return "[Error: HTTP ${response.statusCode()} fetching '$url']"
+            }
+            val text = stripHtml(response.body())
+            val header = "=== $url ===\n"
+            buildBlock(header, text, input.maxKb * 1024L)
+        } catch (e: Exception) {
+            log.warn("Failed to fetch URL '{}': {}", url, e.message)
+            "[Error: could not fetch '$url' — ${e.message}]"
+        }
+    }
+
+    /**
+     * Strips HTML tags and normalises whitespace to produce readable plain text.
+     * Handles `<br>`, `<p>`, `<div>`, `<li>` as line breaks before stripping all other tags.
+     */
+    private fun stripHtml(html: String): String = html
+        .replace(Regex("<(br|p|div|li|tr|h[1-6])(\\s[^>]*)?>", RegexOption.IGNORE_CASE), "\n")
+        .replace(Regex("<[^>]+>"), "")
+        .replace(Regex("&nbsp;"), " ")
+        .replace(Regex("&amp;"), "&")
+        .replace(Regex("&lt;"), "<")
+        .replace(Regex("&gt;"), ">")
+        .replace(Regex("&quot;"), "\"")
+        .replace(Regex("&#39;"), "'")
+        .lines()
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .joinToString("\n")
+
+    // ── File system ───────────────────────────────────────────────────────────
+
+    private fun readFileSystem(path: String, input: PlanInput): String {
+        val file = File(path)
+        if (!file.exists()) {
+            log.warn("PlanFileContentReader: path does not exist: {}", path)
+            return "[Error: path '$path' does not exist]"
+        }
+
+        val maxBytes = input.maxKb * 1024L
+        val globs = parseGlobs(input.filter)
+
+        return when {
+            input.type == "file" && file.isFile -> readSingleFile(file, maxBytes)
+
+            input.type == "folder" && file.isDirectory -> readFolder(file, globs, maxBytes)
+
+            input.type == "file" && file.isDirectory -> readFolder(file, globs, maxBytes)
+
+            else -> {
+                log.warn("PlanFileContentReader: unexpected combination type={} isFile={} isDir={}", input.type, file.isFile, file.isDirectory)
+                "[Error: '$path' is not a valid ${input.type}]"
+            }
+        }
+    }
+
+    private fun readSingleFile(file: File, maxBytes: Long): String {
+        if (isBinary(file)) {
+            log.debug("Skipping binary file: {}", file.name)
+            return "[Skipped: '${file.name}' appears to be a binary file]"
+        }
+        if (file.length() > SINGLE_FILE_MAX_KB * 1024L) {
+            log.debug("Skipping oversized single file: {} ({} KB)", file.name, file.length() / 1024)
+            return "[Skipped: '${file.name}' exceeds the ${SINGLE_FILE_MAX_KB} KB per-file limit]"
+        }
+        val content = file.readText(Charsets.UTF_8)
+        return buildBlock("=== ${file.name} ===\n", content, maxBytes)
+    }
+
+    private fun readFolder(root: File, globs: List<String>, maxBytes: Long): String {
+        val files = root.walkTopDown()
+            .filter { it.isFile }
+            .filter { matchesGlobs(it, globs) }
+            .filter { !isBinary(it) }
+            .filter { it.length() <= SINGLE_FILE_MAX_KB * 1024L }
+            .sortedBy { it.relativeTo(root).path }
+            .toList()
+
+        if (files.isEmpty()) return "[No matching text files found in '${root.name}']"
+
+        val sb = StringBuilder()
+        var totalBytes = 0L
+        var truncated = false
+
+        for (file in files) {
+            val header = "=== ${file.relativeTo(root).path} ===\n"
+            val content = file.readText(Charsets.UTF_8)
+            val block = "$header$content\n\n"
+            val blockBytes = block.toByteArray(Charsets.UTF_8).size
+
+            if (totalBytes + blockBytes > maxBytes) {
+                truncated = true
+                break
+            }
+            sb.append(block)
+            totalBytes += blockBytes
+        }
+
+        if (truncated) {
+            sb.append("[... content truncated at ${maxBytes / 1024} KB limit — remaining files omitted ...]")
+        }
+
+        return sb.toString().trimEnd()
+    }
+
+    private fun buildBlock(header: String, content: String, maxBytes: Long): String {
+        val full = "$header$content"
+        val bytes = full.toByteArray(Charsets.UTF_8)
+        return if (bytes.size <= maxBytes) {
+            full
+        } else {
+            val truncated = String(bytes.copyOf(maxBytes.toInt()), Charsets.UTF_8)
+            "$truncated\n[... truncated at ${maxBytes / 1024} KB limit ...]"
+        }
+    }
+
+    private fun parseGlobs(filter: String): List<String> = if (filter.isBlank()) {
+        emptyList()
+    } else {
+        filter.split(",").map { it.trim() }.filter { it.isNotBlank() }
+    }
+
+    private fun matchesGlobs(file: File, globs: List<String>): Boolean {
+        if (globs.isEmpty()) return true
+        val fs = FileSystems.getDefault()
+        return globs.any { glob -> fs.getPathMatcher("glob:$glob").matches(file.toPath().fileName) }
+    }
+
+    private fun isBinary(file: File): Boolean {
+        if (file.length() == 0L) return false
+        return try {
+            val sample = file.inputStream().use { it.readNBytes(8192) }
+            val nonPrintable = sample.count { b ->
+                val c = b.toInt() and 0xFF
+                c < 0x09 || (c in 0x0E..0x1F)
+            }
+            nonPrintable.toDouble() / sample.size > BINARY_THRESHOLD
+        } catch (_: Exception) {
+            true
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
@@ -230,7 +230,7 @@ class PlanService(
             name: string        # REQUIRED. Human-readable display name e.g. "Resume Tailor"
             icon: string        # REQUIRED. A SINGLE emoji character e.g. "🎯". Never a text name.
             description: string # Short description shown in the plan gallery.
-            inputs: []          # Ordered list of PlanInput objects (see below). Can be empty.
+            inputs: []          # Ordered list of PlanInput objects (see below). Can be empty. Supports types: text, multiline, number, toggle, select, file, folder.
             tools: []           # Optional list of tool IDs from the ToolRegistry e.g. [WEB_SEARCH].
             steps: {}           # REQUIRED. Map of stepId -> PlanStep (see below).
             workflow:           # REQUIRED. Root WorkflowNode tree (see below).
@@ -252,6 +252,24 @@ class PlanService(
             - Use "number" for numeric values.
             - Use "toggle" for yes/no boolean switches (default: "true" or "false").
             - Use "select" when the user must pick from a fixed set; populate "options".
+            - Use "file" when the user should pick one or more local files whose TEXT content is injected into the prompt.
+            - Use "folder" when the user should pick a local directory; all matching text files are recursively read and injected.
+            - Use "url" when the user provides a web page URL whose text content should be fetched and injected into the prompt.
+
+            Extra fields for type: file and type: folder only:
+            filter: string      # Comma-separated glob patterns e.g. "*.kt,*.java". Leave blank to include all text files.
+            max_kb: number      # Hard cap on total injected content in kilobytes. Default 512. Lower for large codebases.
+
+            Extra fields for type: url only:
+            fetch_timeout_sec: number  # HTTP timeout in seconds. Default 10.
+            max_kb: number             # Cap on fetched page content in kilobytes. Default 512.
+
+            file / folder / url usage guidance:
+            - Use "file" when the plan needs one specific document (e.g. a resume, a config file, a log file).
+            - Use "folder" when the plan should analyse a whole project or directory (e.g. code review, documentation).
+            - Always add a meaningful "filter" when the folder is a code project (e.g. "*.kt" for Kotlin, "*.py" for Python).
+            - Set max_kb to a sensible value: 128–256 for large codebases, 512 (default) for small documents.
+            - Reference injected content in step messages with {{key}} just like any other input.
 
             ────────────────────────────────────────
             ## PlanStep object (values in `steps:` map)
@@ -330,7 +348,7 @@ class PlanService(
             5. Later steps SHOULD reference prior step outputs via {{stepId}} in their message so reasoning compounds.
             6. The step map key is the step id — never add a redundant "id:" field inside the step body.
             7. icon MUST be one emoji character. Never write a text word like "lightbulb" or "pencil".
-            8. Every input MUST have key, label, type, and required.
+            8. Every input MUST have key, label, type, and required. For type: file or type: folder, add filter and max_kb when the context suggests a specific file type or large directory.
             9. Use "hint" (not "placeholder") for grey hint text.
             10. Do NOT invent tool names. Only include "tools" if the description explicitly requests tools.
         """.trimIndent()

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanYamlParser.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanYamlParser.kt
@@ -191,6 +191,9 @@ object PlanYamlParser {
                     default = i.default,
                     required = i.required,
                     hint = i.resolvedHint,
+                    filter = i.filter,
+                    maxKb = i.maxKb,
+                    fetchTimeoutSec = i.fetchTimeoutSec,
                 )
             },
             tools = raw.tools,
@@ -269,6 +272,11 @@ private data class PlanInputYaml(
     val hint: String = "",
     @param:JsonProperty("placeholder")
     private val _placeholder: String = "",
+    val filter: String = "",
+    @param:JsonProperty("max_kb")
+    val maxKb: Int = 512,
+    @param:JsonProperty("fetch_timeout_sec")
+    val fetchTimeoutSec: Int = 10,
 ) {
     /** Resolved key: prefer explicit `key`, fall back to `id`. */
     val resolvedKey: String get() = key.ifBlank { _id }

--- a/shared/src/main/kotlin/io/askimo/core/plan/domain/PlanInput.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/domain/PlanInput.kt
@@ -11,6 +11,34 @@ package io.askimo.core.plan.domain
  * `destination` is referenced in YAML as `{{destination}}`.
  *
  * The [type] drives the UI control rendered in the Plan Executor input panel.
+ *
+ * ### File / folder inputs
+ * When `type` is `file` or `folder` the user is shown a file/folder picker.
+ * At execution time the selected path(s) are read from disk and their text
+ * content is concatenated and injected into the scope under [key], exactly like
+ * any other input.  The plan prompt can then reference the content as `{{key}}`.
+ *
+ * ```yaml
+ * inputs:
+ *   - key: source_files
+ *     type: folder
+ *     label: Source folder
+ *     filter: "*.kt,*.java"   # comma-separated glob patterns (optional)
+ *     max_kb: 256             # hard cap on total injected bytes (optional, default 512 KB)
+ * ```
+ *
+ * ### URL inputs
+ * When `type` is `url` the user provides a web URL. At execution time the page is
+ * fetched, HTML tags are stripped, and the plain text is injected into scope under [key].
+ *
+ * ```yaml
+ * inputs:
+ *   - key: page_content
+ *     type: url
+ *     label: Web page URL
+ *     max_kb: 128
+ *     fetch_timeout_sec: 15
+ * ```
  */
 data class PlanInput(
     /** Variable name — referenced in prompts as `{{key}}`. */
@@ -21,7 +49,7 @@ data class PlanInput(
 
     /**
      * UI control type.
-     * Supported values: `text`, `select`, `toggle`, `number`, `multiline`.
+     * Supported values: `text`, `select`, `toggle`, `number`, `multiline`, `file`, `folder`, `url`.
      */
     val type: String = "text",
 
@@ -36,4 +64,25 @@ data class PlanInput(
 
     /** Optional helper text shown below the input field. */
     val hint: String = "",
+
+    /**
+     * Comma-separated glob patterns used to filter which files are read for
+     * `type: file` and `type: folder` inputs (e.g. `"*.kt,*.java"`).
+     * When blank, all text files are included.
+     */
+    val filter: String = "",
+
+    /**
+     * Maximum total kilobytes of content injected into the scope.
+     * Applies to `type: file`, `type: folder`, and `type: url`.
+     * Content is truncated with a notice when the limit is exceeded.
+     * Default is 512 KB.
+     */
+    val maxKb: Int = 512,
+
+    /**
+     * HTTP fetch timeout in seconds for `type: url` inputs.
+     * Default is 10 seconds.
+     */
+    val fetchTimeoutSec: Int = 10,
 )


### PR DESCRIPTION
- Resolve file/folder paths to actual content during plan execution.
- Extend PlanService docs to explain new input types and guidance.
- Add PlanFileContentReader helper to read file content.
- Update PlanInput model with filter, maxKb, fetchTimeoutSec