### PR TITLE
feat: add MCP settings navigation support

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Card
@@ -49,6 +50,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -141,6 +143,7 @@ fun chatInputField(
     sessionId: String? = null,
     placeholder: String = stringResource("chat.input.placeholder"),
     onEnabledServerIdsChange: ((Set<String>) -> Unit)? = null,
+    onNavigateToMcpSettings: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val inputFocusRequester = remember { FocusRequester() }
@@ -625,6 +628,7 @@ fun chatInputField(
                         onEnabledServerIdsChange = { updated ->
                             enabledServerIds = updated
                         },
+                        onNavigateToMcpSettings = onNavigateToMcpSettings,
                     )
 
                     // Spacer to push any future right-aligned controls
@@ -650,6 +654,7 @@ private fun toolsIndicatorButton(
     isLoading: Boolean,
     enabledServerIds: Set<String>,
     onEnabledServerIdsChange: (Set<String>) -> Unit,
+    onNavigateToMcpSettings: (() -> Unit)? = null,
 ) {
     var showToolsPopup by remember { mutableStateOf(false) }
     var mcpServers by remember { mutableStateOf<List<McpServerInfo>>(emptyList()) }
@@ -852,6 +857,34 @@ private fun toolsIndicatorButton(
                                             onCloseAll = { showToolsPopup = false },
                                         )
                                     }
+                                }
+                            }
+                        }
+
+                        // Footer link to MCP settings
+                        if (onNavigateToMcpSettings != null) {
+                            HorizontalDivider()
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.End,
+                            ) {
+                                TextButton(
+                                    onClick = {
+                                        showToolsPopup = false
+                                        onNavigateToMcpSettings()
+                                    },
+                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                ) {
+                                    Icon(
+                                        Icons.Outlined.Settings,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(14.dp),
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text(
+                                        text = stringResource("chat.tools.popup.manage"),
+                                        style = MaterialTheme.typography.labelMedium,
+                                    )
                                 }
                             }
                         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -126,6 +126,7 @@ fun chatView(
     onExportSession: (String) -> Unit = {},
     onDeleteSession: (String) -> Unit = {},
     onNavigateToProject: ((String) -> Unit)? = null,
+    onNavigateToMcpSettings: (() -> Unit)? = null,
     userAvatarPath: String? = null,
     serverBaseUrl: String? = null,
     modifier: Modifier = Modifier,
@@ -1088,6 +1089,7 @@ fun chatView(
                     },
                     sessionId = sessionId,
                     onEnabledServerIdsChange = { currentEnabledServerIds = it },
+                    onNavigateToMcpSettings = onNavigateToMcpSettings,
                     modifier = Modifier
                         .widthIn(max = ThemePreferences.CONTENT_MAX_WIDTH)
                         .fillMaxWidth()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Cards.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Cards.kt
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.ui.common.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A card with a properly rounded ripple/hover effect.
+ *
+ * Using [Card] with its built-in `onClick` parameter causes a double border / focus-ring
+ * artifact in Compose Desktop — M3 draws its own focus indicator on top of the card border.
+ * This composable avoids that by attaching [Modifier.clip] + [Modifier.clickable] directly
+ * on the card modifier so the ripple is clipped to the card shape without any extra outline.
+ *
+ * Usage:
+ * ```
+ * clickableCard(onClick = { /* ... */ }) {
+ *     Text("Hello")
+ * }
+ * ```
+ *
+ * @param onClick Action invoked on click. Pass `null` to render a non-interactive card.
+ * @param modifier Modifier applied to the card.
+ * @param shape Card corner shape. Defaults to [MaterialTheme.shapes.large].
+ * @param colors Card colors. Defaults to [CardDefaults.cardColors].
+ * @param elevation Card shadow elevation. Defaults to 0.dp (flat).
+ * @param content Card content lambda.
+ */
+@Composable
+fun clickableCard(
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    shape: Shape = MaterialTheme.shapes.large,
+    colors: CardColors = CardDefaults.cardColors(),
+    elevation: Dp = 0.dp,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        modifier = modifier
+            .clip(shape)
+            .then(
+                if (onClick != null) {
+                    Modifier
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = ripple(bounded = true),
+                            onClick = onClick,
+                        )
+                        .pointerHoverIcon(PointerIcon.Hand)
+                } else {
+                    Modifier
+                },
+            ),
+        colors = colors,
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation),
+        shape = shape,
+        content = { content() },
+    )
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
@@ -7,6 +7,7 @@ package io.askimo.ui.discover
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
@@ -25,21 +27,19 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.ChatBubbleOutline
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.FolderOpen
-import androidx.compose.material.icons.filled.LibraryBooks
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -58,6 +58,7 @@ import io.askimo.core.chat.repository.ProjectRepository
 import io.askimo.core.plan.repository.PlanDefRepository
 import io.askimo.core.user.domain.UserProfile
 import io.askimo.core.util.TimeUtil
+import io.askimo.ui.common.components.clickableCard
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.ThemePreferences
 import kotlinx.coroutines.Dispatchers
@@ -79,7 +80,7 @@ fun discoverView(
     onNavigateToSessions: () -> Unit,
     onNavigateToProjects: () -> Unit,
     onNavigateToPlans: () -> Unit,
-    onNavigateToSettings: () -> Unit,
+    onNavigateToMcpSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var totalChats by remember { mutableStateOf<Int?>(null) }
@@ -123,7 +124,7 @@ fun discoverView(
                     onNavigateToSessions = onNavigateToSessions,
                     onNavigateToProjects = onNavigateToProjects,
                     onNavigateToPlans = onNavigateToPlans,
-                    onNavigateToSettings = onNavigateToSettings,
+                    onNavigateToMcpSettings = onNavigateToMcpSettings,
                 )
 
                 exploreFeaturesSection()
@@ -197,7 +198,7 @@ private fun statCardsSection(
     onNavigateToSessions: () -> Unit,
     onNavigateToProjects: () -> Unit,
     onNavigateToPlans: () -> Unit,
-    onNavigateToSettings: () -> Unit,
+    onNavigateToMcpSettings: () -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -221,7 +222,7 @@ private fun statCardsSection(
             label = stringResource("discover.stat.mcp"),
             value = totalMcpServers.toString(),
             icon = { Icon(Icons.Default.Settings, contentDescription = null, modifier = Modifier.size(24.dp), tint = MaterialTheme.colorScheme.primary) },
-            onClick = onNavigateToSettings,
+            onClick = onNavigateToMcpSettings,
             modifier = Modifier.weight(1f),
         )
         statCard(
@@ -242,22 +243,12 @@ private fun statCard(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
 ) {
-    Card(
-        modifier = modifier
-            .then(
-                if (onClick != null) {
-                    Modifier
-                        .clickable(onClick = onClick)
-                        .pointerHoverIcon(PointerIcon.Hand)
-                } else {
-                    Modifier
-                },
-            ),
+    clickableCard(
+        onClick = onClick,
+        modifier = modifier,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-        shape = MaterialTheme.shapes.large,
     ) {
         Column(
             modifier = Modifier
@@ -339,15 +330,12 @@ private fun exploreCard(
     url: String,
     modifier: Modifier = Modifier,
 ) {
-    Card(
-        modifier = modifier
-            .clickable { runCatching { Desktop.getDesktop().browse(URI(url)) } }
-            .pointerHoverIcon(PointerIcon.Hand),
+    clickableCard(
+        onClick = { runCatching { Desktop.getDesktop().browse(URI(url)) } },
+        modifier = modifier,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-        shape = MaterialTheme.shapes.large,
     ) {
         Column(
             modifier = Modifier
@@ -409,7 +397,11 @@ private fun recentSessionsSection(
                 tonalElevation = 1.dp,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Column(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                ) {
                     sessions.forEachIndexed { index, session ->
                         recentSessionRow(
                             session = session,
@@ -435,9 +427,13 @@ private fun recentSessionRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onResumeSession(session.id) }
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(bounded = true),
+                onClick = { onResumeSession(session.id) },
+            )
             .pointerHoverIcon(PointerIcon.Hand)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -460,6 +456,7 @@ private fun recentSessionRow(
                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
             )
         }
+        Spacer(modifier = Modifier.width(16.dp))
         Text(
             text = TimeUtil.formatDisplay(session.updatedAt),
             style = MaterialTheme.typography.bodySmall,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectView.kt
@@ -105,6 +105,7 @@ fun projectView(
     onExportSession: (String) -> Unit,
     onEditProject: (String) -> Unit,
     onDeleteProject: (String) -> Unit,
+    onNavigateToMcpSettings: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     // Create ViewModel
@@ -334,6 +335,7 @@ fun projectView(
                             }
                         },
                         onEnabledServerIdsChange = { currentEnabledServerIds = it },
+                        onNavigateToMcpSettings = onNavigateToMcpSettings,
                         sessionId = currentProject.id,
                         placeholder = stringResource("project.new.chat.placeholder", currentProject.name),
                         modifier = Modifier.padding(top = 16.dp),

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -512,6 +512,7 @@ chat.tools.button=Available Tools
 chat.tools.popup.title=Available Tools
 chat.tools.popup.loading=Loading servers...
 chat.tools.popup.no.servers.global=No global MCP servers configured.
+chat.tools.popup.manage=Manage MCP Servers
 chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Project
 chat.tools.server.scope.builtin=Built-in

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -514,6 +514,7 @@ chat.tools.button=Verfügbare Tools
 chat.tools.popup.title=Verfügbare Tools
 chat.tools.popup.loading=Server werden geladen...
 chat.tools.popup.no.servers.global=Keine globalen MCP-Server konfiguriert.
+chat.tools.popup.manage=MCP-Server verwalten
 chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Projekt
 chat.tools.server.scope.builtin=Integriert

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -513,6 +513,7 @@ chat.tools.button=Herramientas disponibles
 chat.tools.popup.title=Herramientas disponibles
 chat.tools.popup.loading=Cargando servidores...
 chat.tools.popup.no.servers.global=No hay servidores MCP globales configurados.
+chat.tools.popup.manage=Administrar servidores MCP
 chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Proyecto
 chat.tools.server.scope.builtin=Integrado

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -513,6 +513,7 @@ chat.tools.button=Outils disponibles
 chat.tools.popup.title=Outils disponibles
 chat.tools.popup.loading=Chargement des serveurs...
 chat.tools.popup.no.servers.global=Aucun serveur MCP global configuré.
+chat.tools.popup.manage=Gérer les serveurs MCP
 chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Projet
 chat.tools.server.scope.builtin=Intégré

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -513,6 +513,7 @@ chat.tools.button=利用可能なツール
 chat.tools.popup.title=利用可能なツール
 chat.tools.popup.loading=サーバーを読み込み中...
 chat.tools.popup.no.servers.global=グローバル MCP サーバーが設定されていません。
+chat.tools.popup.manage=MCPサーバーを管理
 chat.tools.server.scope.global=グローバル
 chat.tools.server.scope.project=プロジェクト
 chat.tools.server.scope.builtin=組み込み

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -514,6 +514,7 @@ chat.tools.button=사용 가능한 도구
 chat.tools.popup.title=사용 가능한 도구
 chat.tools.popup.loading=서버 로딩 중...
 chat.tools.popup.no.servers.global=전역 MCP 서버가 설정되지 않았습니다.
+chat.tools.popup.manage=MCP 서버 관리
 chat.tools.server.scope.global=전역
 chat.tools.server.scope.project=프로젝트
 chat.tools.server.scope.builtin=내장

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -514,6 +514,7 @@ chat.tools.button=Ferramentas disponíveis
 chat.tools.popup.title=Ferramentas disponíveis
 chat.tools.popup.loading=Carregando servidores...
 chat.tools.popup.no.servers.global=Nenhum servidor MCP global configurado.
+chat.tools.popup.manage=Gerenciar servidores MCP
 chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Projeto
 chat.tools.server.scope.builtin=Integrado

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -510,6 +510,7 @@ chat.tools.button=Công cụ khả dụng
 chat.tools.popup.title=Công cụ khả dụng
 chat.tools.popup.loading=Đang tải máy chủ...
 chat.tools.popup.no.servers.global=Chưa cấu hình máy chủ MCP toàn cục.
+chat.tools.popup.manage=Quản lý máy chủ MCP
 chat.tools.server.scope.global=Toàn cục
 chat.tools.server.scope.project=Dự án
 chat.tools.server.scope.builtin=Tích hợp sẵn

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -514,6 +514,7 @@ chat.tools.button=可用工具
 chat.tools.popup.title=可用工具
 chat.tools.popup.loading=正在加载服务器...
 chat.tools.popup.no.servers.global=未配置全局 MCP 服务器。
+chat.tools.popup.manage=管理 MCP 服务器
 chat.tools.server.scope.global=全局
 chat.tools.server.scope.project=项目
 chat.tools.server.scope.builtin=内置

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -513,6 +513,7 @@ chat.tools.button=可用工具
 chat.tools.popup.title=可用工具
 chat.tools.popup.loading=正在載入伺服器...
 chat.tools.popup.no.servers.global=尚未設定全域 MCP 伺服器。
+chat.tools.popup.manage=管理 MCP 伺服器
 chat.tools.server.scope.global=全域
 chat.tools.server.scope.project=專案
 chat.tools.server.scope.builtin=內建

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -1064,7 +1064,11 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                                         chatSessionRepository = koin.get(),
                                                         projectRepository = koin.get(),
                                                         planDefRepository = koin.get(),
-                                                        onNavigateToSettings = { currentView = View.SETTINGS },
+                                                        onNavigateToMcpSettings = {
+                                                            settingsSection = SettingsSection.MCP_SERVERS
+                                                            previousView = currentView
+                                                            currentView = View.SETTINGS
+                                                        },
                                                     )
                                                 } else {
                                                     Box(
@@ -1803,7 +1807,7 @@ fun mainContent(
     onNavigateToPlans: () -> Unit = {},
     onNavigateToPlanDetail: () -> Unit = {},
     onNavigateToPlanEditor: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {},
+    onNavigateToMcpSettings: () -> Unit = {},
     activeSessionId: String?,
     sessionChatState: ChatViewState?,
     onChatStateChange: (TextFieldValue, List<FileAttachmentDTO>, ChatMessageDTO?) -> Unit,
@@ -1839,7 +1843,7 @@ fun mainContent(
                 onNavigateToSessions = onNavigateToSessions,
                 onNavigateToProjects = onNavigateToProjects,
                 onNavigateToPlans = onNavigateToPlans,
-                onNavigateToSettings = onNavigateToSettings,
+                onNavigateToMcpSettings = onNavigateToMcpSettings,
                 modifier = Modifier.fillMaxSize(),
             )
 
@@ -1868,6 +1872,7 @@ fun mainContent(
                         sessionsViewModel.deleteSessionWithCleanup(sessionId)
                     },
                     onNavigateToProject = onSelectProject,
+                    onNavigateToMcpSettings = onNavigateToMcpSettings,
                     userAvatarPath = userAvatarPath,
                     modifier = Modifier.fillMaxSize(),
                 )
@@ -1917,6 +1922,7 @@ fun mainContent(
                                 projectsViewModel.deleteProject(projectId)
                                 onNavigateToSessions()
                             },
+                            onNavigateToMcpSettings = onNavigateToMcpSettings,
                             modifier = Modifier.fillMaxSize(),
                         )
                     } else {

--- a/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/util/UrlContentExtractor.kt
@@ -126,7 +126,7 @@ object UrlContentExtractor {
 
         val mainContent = doc.body()
 
-        val cleanText = mainContent.text().trim() ?: ""
+        val cleanText = mainContent.text().trim()
 
         val finalContent = if (cleanText.length < 100) {
             doc.body().text().trim()


### PR DESCRIPTION
- Add onNavigateToMcpSettings callback to Chat, Discover, Project, and Main views
- Create Cards component for nested view navigation
- Update i18n resources with new “Manage MCP Servers” label
- Adjust spacing for recent session row