### PR TITLE
feat(directive-render): add learn‑more link for directives

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
@@ -535,12 +537,6 @@ fun chatView(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text(
-                                text = stringResource("chat.directive"),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface,
-                            )
-
                             var showManageDirectivesDialog by remember { mutableStateOf(false) }
                             var directiveDropdownExpanded by remember { mutableStateOf(false) }
 
@@ -554,18 +550,28 @@ fun chatView(
                             Box {
                                 themedTooltip(
                                     text = if (selectedDirectiveObj != null) {
-                                        "${selectedDirectiveObj.name}\n${selectedDirectiveObj.content}"
+                                        "${stringResource("chat.directive")}: ${selectedDirectiveObj.name}\n${selectedDirectiveObj.content}"
                                     } else {
-                                        ""
+                                        "${stringResource("chat.directive")}: ${stringResource("chat.directive.none")}"
                                     },
                                 ) {
                                     TextButton(
                                         onClick = { directiveDropdownExpanded = true },
                                         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                         colors = ButtonDefaults.textButtonColors(
-                                            contentColor = MaterialTheme.colorScheme.onSurface,
+                                            contentColor = if (selectedDirectiveObj != null) {
+                                                MaterialTheme.colorScheme.primary
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurface
+                                            },
                                         ),
                                     ) {
+                                        Icon(
+                                            imageVector = Icons.Default.AutoAwesome,
+                                            contentDescription = stringResource("chat.directive"),
+                                            modifier = Modifier.size(16.dp),
+                                        )
+                                        Spacer(modifier = Modifier.width(4.dp))
                                         Text(
                                             text = selectedDirectiveObj?.name?.take(30)?.let {
                                                 if (selectedDirectiveObj.name.length > 30) "$it..." else it
@@ -709,6 +715,37 @@ fun chatView(
                                         },
                                         onClick = {
                                             showManageDirectivesDialog = true
+                                            directiveDropdownExpanded = false
+                                        },
+                                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                    )
+
+                                    // Learn more link
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(vertical = 4.dp),
+                                    )
+                                    val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
+                                    DropdownMenuItem(
+                                        text = {
+                                            Row(
+                                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                            ) {
+                                                Icon(
+                                                    Icons.Default.ChevronRight,
+                                                    contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.primary,
+                                                    modifier = Modifier.size(16.dp),
+                                                )
+                                                Text(
+                                                    text = stringResource("chat.directive.learn.more"),
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.primary,
+                                                )
+                                            }
+                                        },
+                                        onClick = {
+                                            uriHandler.openUri("https://askimo.chat/docs/desktop/directives/")
                                             directiveDropdownExpanded = false
                                         },
                                         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Fullscreen
@@ -909,42 +908,18 @@ private fun fullScreenDiagramDialog(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,
         ) {
-            Box(modifier = Modifier.fillMaxSize()) {
-                // Close button
-                themedTooltip(
-                    text = stringResource("mermaid.button.close"),
-                    placement = TooltipPlacement.LEFT,
-                ) {
-                    IconButton(
-                        onClick = onDismiss,
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(16.dp)
-                            .size(48.dp)
-                            .pointerHoverIcon(PointerIcon.Hand),
-                    ) {
-                        Icon(
-                            Icons.Default.Close,
-                            contentDescription = stringResource("mermaid.button.close"),
-                            modifier = Modifier.size(32.dp),
-                        )
-                    }
-                }
-
-                // Diagram with zoom controls
-                diagramViewer(
-                    imageData = imageData,
-                    sanitizedDiagram = sanitizedDiagram,
-                    zoomLevel = dialogZoomLevel,
-                    onZoomIn = { dialogZoomLevel = (dialogZoomLevel + 0.2f).coerceAtMost(5f) },
-                    onZoomOut = { dialogZoomLevel = (dialogZoomLevel - 0.2f).coerceAtLeast(0.5f) },
-                    onResetZoom = { dialogZoomLevel = 1f },
-                    onFullScreen = null,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(top = 80.dp, end = 16.dp, bottom = 16.dp, start = 16.dp),
-                )
-            }
+            diagramViewer(
+                imageData = imageData,
+                sanitizedDiagram = sanitizedDiagram,
+                zoomLevel = dialogZoomLevel,
+                onZoomIn = { dialogZoomLevel = (dialogZoomLevel + 0.2f).coerceAtMost(5f) },
+                onZoomOut = { dialogZoomLevel = (dialogZoomLevel - 0.2f).coerceAtLeast(0.5f) },
+                onResetZoom = { dialogZoomLevel = 1f },
+                onFullScreen = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+            )
         }
     }
 }

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -503,6 +503,7 @@ chat.directive=Directive:
 chat.directive.none=None
 chat.directive.new=New Directive
 chat.directive.manage=Manage Directives
+chat.directive.learn.more=Learn how to use directives
 chat.attach.file=Attach File ({0}+A)
 chat.attach.file.menu=Add Attachments
 chat.create.image.menu=Create Image

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -505,6 +505,7 @@ chat.directive=Direktive:
 chat.directive.none=Keine
 chat.directive.new=Neue Direktive
 chat.directive.manage=Direktiven verwalten
+chat.directive.learn.more=Erfahren Sie, wie Sie Direktiven verwenden
 chat.attach.file=Datei anhängen ({0}+A)
 chat.attach.file.menu=Anhänge hinzufügen
 chat.create.image.menu=Bild erstellen

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -504,6 +504,7 @@ chat.directive=Directiva:
 chat.directive.none=Ninguna
 chat.directive.new=Nueva directiva
 chat.directive.manage=Gestionar directivas
+chat.directive.learn.more=Aprenda a usar directivas
 chat.attach.file=Adjuntar archivo ({0}+A)
 chat.attach.file.menu=Agregar archivos adjuntos
 chat.create.image.menu=Crear imagen

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -504,6 +504,7 @@ chat.directive=Directive :
 chat.directive.none=Aucune
 chat.directive.new=Nouvelle directive
 chat.directive.manage=Gérer les directives
+chat.directive.learn.more=Apprenez à utiliser les directives
 chat.attach.file=Joindre un fichier ({0}+A)
 chat.attach.file.menu=Ajouter des pièces jointes
 chat.create.image.menu=Créer une image

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -504,6 +504,7 @@ chat.directive=ディレクティブ:
 chat.directive.none=なし
 chat.directive.new=新しいディレクティブ
 chat.directive.manage=ディレクティブ管理
+chat.directive.learn.more=ディレクティブの使い方を学ぶ
 chat.attach.file=ファイル添付 ({0}+A)
 chat.attach.file.menu=添付ファイルを追加
 chat.create.image.menu=画像を作成

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -505,6 +505,7 @@ chat.directive=지시문:
 chat.directive.none=없음
 chat.directive.new=새 지시문
 chat.directive.manage=지시문 관리
+chat.directive.learn.more=디렉티브 사용법을 배워보세요
 chat.attach.file=파일 첨부 ({0}+A)
 chat.attach.file.menu=첨부 파일 추가
 chat.create.image.menu=이미지 생성

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -505,6 +505,7 @@ chat.directive=Diretiva:
 chat.directive.none=Nenhuma
 chat.directive.new=Nova Diretiva
 chat.directive.manage=Gerenciar Diretivas
+chat.directive.learn.more=Aprenda a usar diretivas
 chat.attach.file=Anexar Arquivo ({0}+A)
 chat.attach.file.menu=Adicionar Anexos
 chat.create.image.menu=Criar imagem

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -501,6 +501,7 @@ chat.directive=Chỉ thị:
 chat.directive.none=Không có
 chat.directive.new=Chỉ thị mới
 chat.directive.manage=Quản lý chỉ thị
+chat.directive.learn.more=Tìm hiểu cách sử dụng chỉ thị
 chat.attach.file=Đính kèm tệp ({0}+A)
 chat.attach.file.menu=Thêm tệp đính kèm
 chat.create.image.menu=Tạo hình ảnh

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -505,6 +505,7 @@ chat.directive=指令：
 chat.directive.none=无
 chat.directive.new=新指令
 chat.directive.manage=管理指令
+chat.directive.learn.more=了解如何使用指令
 chat.attach.file=附加文件 ({0}+A)
 chat.attach.file.menu=添加附件
 chat.create.image.menu=创建图像

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -504,6 +504,7 @@ chat.directive=指令：
 chat.directive.none=無
 chat.directive.new=新增指令
 chat.directive.manage=管理指令
+chat.directive.learn.more=了解如何使用指令
 chat.attach.file=附加檔案 ({0}+A)
 chat.attach.file.menu=新增附件
 chat.create.image.menu=建立影像


### PR DESCRIPTION
- include a new "chat.directive.learn.more" key in all locales
- add a clickable "Learn more" link to the directives docs in the UI
- simplify Mermaid diagram zoom controls and remove the unused close button