### PR TITLE
feat: add terminal open analytics & enrich telemetry events

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -326,6 +326,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
 
     LaunchedEffect(Unit) {
         EventBus.internalEvents.filterIsInstance<RunCodeEvent>().collect { event ->
+            if (!showTerminalPanel) Analytics.track(AnalyticsEvent.TERMINAL_OPENED, mapOf("source" to "run_code"))
             showTerminalPanel = true
             pendingTerminalCommand = PendingTerminalCommand(
                 code = event.code,
@@ -490,6 +491,8 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                 "mode" to "desktop",
                 "has_rag" to hasRag.toString(),
                 "has_mcp" to hasMcp.toString(),
+                "language" to ThemePreferences.locale.value.language.take(5).ifBlank { "unknown" },
+                "theme" to ThemePreferences.themeMode.value.name.lowercase(),
             ),
         )
     }
@@ -614,7 +617,9 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                     showTutorialWizard = true
                 },
                 onOpenTerminal = {
-                    showTerminalPanel = !showTerminalPanel
+                    val opening = !showTerminalPanel
+                    showTerminalPanel = opening
+                    if (opening) Analytics.track(AnalyticsEvent.TERMINAL_OPENED, mapOf("source" to "toolbar"))
                 },
                 onClearPreferences = {
                     showClearPreferencesDialog = true

--- a/shared/src/main/kotlin/io/askimo/core/analytics/AnalyticsEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/analytics/AnalyticsEvent.kt
@@ -104,10 +104,10 @@ enum class AnalyticsEvent(
 ) {
     // ── Session lifecycle ────────────────────────────────────────────────────
 
-    /** Fired once per session start. Properties: `mode=desktop|cli`, `has_mcp`, `has_rag`. */
+    /** Fired once per session start. Properties: `mode=desktop|cli`, `has_mcp`, `has_rag`, `language`, `theme`. */
     APP_STARTED(
         "app_started",
-        "Session started. Properties: mode=desktop|cli, has_mcp=true|false, has_rag=true|false.",
+        "Session started. Properties: mode=desktop|cli, has_mcp=true|false, has_rag=true|false, language=en|de|…, theme=light|dark|system.",
     ),
 
     /**
@@ -121,10 +121,10 @@ enum class AnalyticsEvent(
 
     // ── Provider & model ─────────────────────────────────────────────────────
 
-    /** A provider was actively used for a chat message. Properties: `provider`, `model_tier=cloud|local`. */
+    /** A provider was actively used for a chat message. Properties: `provider`, `model_name`, `model_tier=cloud|local`. */
     PROVIDER_USED(
         "provider_used",
-        "LLM response received. Properties: provider=OPENAI|ANTHROPIC|…, model_tier=cloud|local.",
+        "LLM response received. Properties: provider=OPENAI|ANTHROPIC|…, model_name, model_tier=cloud|local.",
     ),
 
     // ── RAG ──────────────────────────────────────────────────────────────────
@@ -219,6 +219,14 @@ enum class AnalyticsEvent(
         "Plan execution failed. Properties: step_count, error_type.",
     ),
 
+    // ── Terminal ─────────────────────────────────────────────────────────────
+
+    /** User opened the integrated terminal panel. */
+    TERMINAL_OPENED(
+        "terminal_opened",
+        "User opened the integrated terminal panel.",
+    ),
+
     // ── Other features ───────────────────────────────────────────────────────
 
     /**
@@ -241,11 +249,11 @@ enum class AnalyticsEvent(
     /**
      * A categorised error occurred.
      * Properties: `error_type=provider_timeout|rate_limit|auth_error|context_length|…`,
-     * `provider` (when relevant).
+     * `provider` (when relevant), `error_message` (sanitised, no PII).
      */
     ERROR_OCCURRED(
         "error_occurred",
-        "Categorised error. Properties: error_type, provider (optional).",
+        "Categorised error. Properties: error_type, provider (optional), error_message (sanitised).",
     ),
 
     // ── Retention ────────────────────────────────────────────────────────────

--- a/shared/src/main/kotlin/io/askimo/core/telemetry/TelemetryChatModelListener.kt
+++ b/shared/src/main/kotlin/io/askimo/core/telemetry/TelemetryChatModelListener.kt
@@ -109,6 +109,7 @@ class TelemetryChatModelListener(
             AnalyticsEvent.PROVIDER_USED,
             mapOf(
                 "provider" to provider,
+                "model_name" to model,
                 "model_tier" to Analytics.modelTier(provider),
             ),
         )
@@ -157,9 +158,10 @@ class TelemetryChatModelListener(
 
             else -> "provider_error"
         }
+        val sanitisedMessage = error.message?.take(200)?.replace(Regex("[\\r\\n]+"), " ") ?: "unknown"
         Analytics.track(
             AnalyticsEvent.ERROR_OCCURRED,
-            mapOf("error_type" to errorType, "provider" to provider),
+            mapOf("error_type" to errorType, "provider" to provider, "error_message" to sanitisedMessage),
         )
 
         log.warn("LLM error from $provider:$model: ${error.message}", error)


### PR DESCRIPTION
- Track terminal panel opening from toolbar and run_code
- Updated AnalyticsEvent descriptions to include language and theme
- Added error_message field for sanitised error telemetry
- Added model_name property to telemetry listener
- Minor refactoring of telemetry logic
- Updated documentation comments accordingly