### PR TITLE
refactor(core): Standardize entity identification to use entityId

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -201,7 +201,7 @@ class ChatViewModel(
             EventBus.internalEvents
                 .filterIsInstance<DiagramFixedEvent>()
                 .collect { event ->
-                    val messageId = event.messageId
+                    val messageId = event.entityId
                     val existing = messages.find { it.id == messageId } ?: return@collect
                     val updatedContent = existing.content.replace(event.originalDiagram, event.fixedDiagram)
                     if (updatedContent != existing.content) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
@@ -763,7 +763,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
             mermaidChart(
                 data = chartData,
                 modifier = Modifier.padding(16.dp),
-                messageId = messageId,
+                entityId = messageId,
             )
         }
         return

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
@@ -71,6 +71,7 @@ import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.service.MermaidCliNotAvailableException
 import io.askimo.ui.service.MermaidSvgService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
@@ -86,6 +87,8 @@ import kotlin.time.Duration.Companion.milliseconds
 import org.jetbrains.skia.Image as SkiaImage
 
 private val log = currentFileLogger()
+
+private const val MAX_AI_RETRIES = 3
 
 /**
  * Cache for rendered Mermaid diagrams.
@@ -155,7 +158,7 @@ private object DiagramCache {
 fun mermaidChart(
     data: MermaidChartData,
     modifier: Modifier = Modifier,
-    messageId: String? = null,
+    entityId: String? = null,
 ) {
     val mermaidService = remember { MermaidSvgService() }
     var imageData by remember { mutableStateOf<ByteArray?>(null) }
@@ -225,28 +228,33 @@ fun mermaidChart(
                     log.debug("✅ Successfully rendered and cached diagram ({} bytes)", rendered.size)
 
                     // If this was an AI-fixed diagram, notify so the message can be persisted
-                    if (fixedDiagram != null && messageId != null) {
+                    if (fixedDiagram != null && entityId != null) {
                         EventBus.post(
                             DiagramFixedEvent(
-                                messageId = messageId,
+                                entityId = entityId,
                                 originalDiagram = data.diagram,
                                 fixedDiagram = fixedDiagram!!,
                             ),
                         )
-                        log.debug("Posted DiagramFixedEvent for message {}", messageId)
+                        log.debug("Posted DiagramFixedEvent for entity {}", entityId)
                     }
                 } catch (_: MermaidCliNotAvailableException) {
                     log.warn("Mermaid CLI became unavailable during conversion")
                     error = "mermaid_cli_not_available"
                     isMermaidCliAvailable = false
+                } catch (e: CancellationException) {
+                    // Composition left — don't treat this as a diagram error, just propagate
+                    log.debug("LaunchedEffect cancelled (composition left), skipping AI fix")
+                    throw e
                 } catch (e: Exception) {
                     val parseError = e.message ?: "Unknown render error"
-                    log.error("Failed to convert diagram (attempt ${retryCount + 1}/1): {}", parseError)
+                    val attemptNum = retryCount + 1
+                    log.error("Failed to convert diagram (attempt {}/{}): {}", attemptNum, MAX_AI_RETRIES + 1, parseError)
 
-                    // Only attempt AI fix on the original diagram, not on already-fixed diagrams
-                    if (retryCount < 1 && fixedDiagram == null) {
+                    // Only attempt AI fix up to MAX_AI_RETRIES times
+                    if (retryCount < MAX_AI_RETRIES) {
                         retryCount++
-                        log.debug("Asking AI to fix diagram (retry $retryCount/1)...")
+                        log.debug("Asking AI to fix diagram (attempt {} of {})...", retryCount, MAX_AI_RETRIES)
                         try {
                             val fixPrompt = """
                                 The following Mermaid diagram failed to render with this error:
@@ -303,12 +311,16 @@ fun mermaidChart(
                         } catch (_: TimeoutCancellationException) {
                             log.warn("AI fix timed out after 30s")
                             error = parseError
+                        } catch (aiEx: CancellationException) {
+                            // Composition left during AI fix — propagate, don't swallow
+                            log.debug("AI fix cancelled (composition left), propagating")
+                            throw aiEx
                         } catch (aiEx: Exception) {
                             log.error("AI fix attempt failed", aiEx)
                             error = parseError
                         }
                     } else {
-                        log.warn("Diagram render failed after AI fix attempt, showing error")
+                        log.warn("Diagram render failed after {} AI fix attempts, showing error", MAX_AI_RETRIES)
                         error = parseError
                     }
                 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
@@ -543,6 +543,7 @@ fun planDetailView(
                                         viewModel = viewModel,
                                         planName = plan.name,
                                         showExport = false,
+                                        executionId = pinned.executionId,
                                         modifier = Modifier.weight(1f),
                                     )
                                     resultPanel(
@@ -553,6 +554,7 @@ fun planDetailView(
                                         viewModel = viewModel,
                                         planName = plan.name,
                                         showExport = true,
+                                        executionId = currentResult.executionId,
                                         modifier = Modifier.weight(1f),
                                     )
                                 }
@@ -565,6 +567,7 @@ fun planDetailView(
                                     viewModel = viewModel,
                                     planName = plan.name,
                                     showExport = true,
+                                    executionId = currentResult.executionId,
                                     modifier = Modifier.fillMaxWidth(),
                                 )
                             }
@@ -1091,6 +1094,7 @@ private fun resultPanel(
     viewModel: PlansViewModel,
     planName: String,
     showExport: Boolean,
+    executionId: String? = null,
     modifier: Modifier = Modifier,
 ) {
     // Simulate streaming: reveal the output gradually after it arrives.
@@ -1263,6 +1267,7 @@ private fun resultPanel(
                 markdownText(
                     markdown = if (isStreaming) "$displayedOutput▍" else displayedOutput,
                     modifier = Modifier.fillMaxWidth(),
+                    messageId = executionId,
                 )
             }
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import io.askimo.core.event.EventBus
+import io.askimo.core.event.internal.DiagramFixedEvent
 import io.askimo.core.event.internal.PlansRefreshEvent
 import io.askimo.core.logging.logger
 import io.askimo.core.plan.PlanRunResult
@@ -210,6 +211,22 @@ class PlansViewModel(
                 .collect { event ->
                     log.debug("Plans refresh requested: ${event.reason ?: "no reason specified"}")
                     loadPlans()
+                }
+        }
+        scope.launch {
+            EventBus.internalEvents
+                .filterIsInstance<DiagramFixedEvent>()
+                .collect { event ->
+                    val current = runResult ?: return@collect
+                    if (current.executionId != event.entityId) return@collect
+                    val updatedOutput = current.output.replace(event.originalDiagram, event.fixedDiagram)
+                    if (updatedOutput != current.output) {
+                        log.debug("Updating plan result diagram for execution {}", event.entityId)
+                        runResult = current.copy(output = updatedOutput)
+                        withContext(Dispatchers.IO) {
+                            planService.updateExecutionOutput(current.executionId, updatedOutput)
+                        }
+                    }
                 }
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/event/internal/DiagramFixedEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/event/internal/DiagramFixedEvent.kt
@@ -14,7 +14,7 @@ import java.time.Instant
  * ChatViewModel subscribes and persists the corrected content to the database.
  */
 data class DiagramFixedEvent(
-    val messageId: String,
+    val entityId: String,
     val originalDiagram: String,
     val fixedDiagram: String,
     override val timestamp: Instant = Instant.now(),
@@ -22,5 +22,5 @@ data class DiagramFixedEvent(
 ) : Event {
     override val type = EventType.INTERNAL
 
-    override fun getDetails() = "Diagram auto-fixed in message $messageId"
+    override fun getDetails() = "Diagram auto-fixed in message $entityId"
 }

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
@@ -145,6 +145,15 @@ class PlanService(
     fun deleteExecution(executionId: String) = planExecutionRepository.delete(executionId)
 
     /**
+     * Persists an updated [output] string for an existing execution.
+     * Used to save AI-fixed diagram content back to the database.
+     */
+    fun updateExecutionOutput(executionId: String, output: String) {
+        val execution = planExecutionRepository.findById(executionId) ?: return
+        planExecutionRepository.update(execution.copy(output = output))
+    }
+
+    /**
      * Runs a follow-up question against the result of a previous plan execution.
      *
      * The prior plan output is injected as context so the model can refine or extend it


### PR DESCRIPTION
- Renames `messageId` to `entityId` in several core areas (`ChatViewModel`, internal event definitions, etc.) for canonical data representation.
- Updates the plan execution flow to automatically detect and persist diagram fixes.
- Implements dedicated logic in `PlansViewModel` to receive `DiagramFixedEvent` and update the cached output.
- Improves diagram generation resilience by adding bounded retries and proper cancellation exception handling in `MermaidChartRenderer`.
- Adds `updateExecutionOutput` method to `PlanService` to persist AI-fixed diagram content.