### PR TITLE
feat(skills): add delete all skills, run record deletion

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -926,7 +926,11 @@
   "name": "com.github.dockerjava.api.model.PeerNode",
   "allDeclaredFields": true,
   "queryAllDeclaredMethods": true,
-  "queryAllDeclaredConstructors": true
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ ]
+  } ]
 }, {
   "name": "com.github.dockerjava.api.model.Ports",
   "allDeclaredFields": true,
@@ -1579,7 +1583,7 @@
   "queryAllDeclaredConstructors": true,
   "methods": [ {
     "name": "<init>",
-    "parameterTypes": [ "java.lang.Integer", "java.lang.Integer", "java.lang.Integer" ]
+    "parameterTypes": [ "java.lang.Integer", "java.lang.Integer", "java.lang.Integer", "java.lang.Integer", "java.lang.Integer" ]
   } ]
 }, {
   "name": "dev.langchain4j.model.googleai.GeminiGenerationConfig",
@@ -1799,6 +1803,9 @@
   }, {
     "name": "index",
     "parameterTypes": [ "java.lang.Integer" ]
+  }, {
+    "name": "logprobs",
+    "parameterTypes": [ "dev.langchain4j.model.openai.internal.chat.LogProbs" ]
   } ]
 }, {
   "name": "dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest",
@@ -1891,6 +1898,16 @@
     "name": "name",
     "parameterTypes": [ "java.lang.String" ]
   } ]
+}, {
+  "name": "dev.langchain4j.model.openai.internal.chat.LogProb$Builder",
+  "allDeclaredFields": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllDeclaredConstructors": true
+}, {
+  "name": "dev.langchain4j.model.openai.internal.chat.LogProbs$Builder",
+  "allDeclaredFields": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllDeclaredConstructors": true
 }, {
   "name": "dev.langchain4j.model.openai.internal.chat.Message",
   "queryAllDeclaredMethods": true
@@ -4956,7 +4973,7 @@
     "parameterTypes": [ "dev.langchain4j.data.message.UserMessage", "dev.langchain4j.model.chat.request.ChatRequestParameters" ]
   } ]
 }, {
-  "name": "io.askimo.core.providers.ChatClient$MockitoMock$IuSXTOm9",
+  "name": "io.askimo.core.providers.ChatClient$MockitoMock$x58T8imA",
   "queryAllDeclaredConstructors": true,
   "methods": [ {
     "name": "<init>",
@@ -5840,6 +5857,274 @@
   "allDeclaredClasses": true,
   "queryAllDeclaredMethods": true,
   "queryAllPublicMethods": true
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ ]
+  } ]
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest$CountSkills",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ "io.askimo.core.skills.SkillRepositoryTest" ]
+  }, {
+    "name": "category folder without skills returns 0",
+    "parameterTypes": [ ]
+  }, {
+    "name": "deeply nested category structure counts correctly",
+    "parameterTypes": [ ]
+  }, {
+    "name": "empty directory returns 0",
+    "parameterTypes": [ ]
+  }, {
+    "name": "git directory is excluded",
+    "parameterTypes": [ ]
+  }, {
+    "name": "hidden directories are skipped",
+    "parameterTypes": [ ]
+  }, {
+    "name": "multiple root-level skill folders count individually",
+    "parameterTypes": [ ]
+  }, {
+    "name": "multiple skills across categories",
+    "parameterTypes": [ ]
+  }, {
+    "name": "reserved files alone do not count as skills",
+    "parameterTypes": [ ]
+  }, {
+    "name": "single root-level skill folder counts as 1",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill nested inside category folder is counted",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill-md matching is case-insensitive",
+    "parameterTypes": [ ]
+  }, {
+    "name": "sub-folder inside a skill folder is NOT a separate skill",
+    "parameterTypes": [ ]
+  }, {
+    "name": "sub-folder with skill-md inside a skill folder is NOT counted separately",
+    "parameterTypes": [ ]
+  } ]
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest$GetAll",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ "io.askimo.core.skills.SkillRepositoryTest" ]
+  }, {
+    "name": "reserved filenames and entry point are excluded",
+    "parameterTypes": [ ]
+  } ]
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest$GetSkillsOnly",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ "io.askimo.core.skills.SkillRepositoryTest" ]
+  }, {
+    "name": "empty skills dir returns empty list",
+    "parameterTypes": [ ]
+  }, {
+    "name": "multiple skill folders across categories",
+    "parameterTypes": [ ]
+  }, {
+    "name": "plain category folder is transparent - skills inside are found",
+    "parameterTypes": [ ]
+  }, {
+    "name": "plain folder without skill dot md is NOT a skill",
+    "parameterTypes": [ ]
+  }, {
+    "name": "reserved files inside skill folder are NOT merged as context",
+    "parameterTypes": [ ]
+  }, {
+    "name": "root-level skill folder has empty category",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder category is the parent folder not the skill folder itself",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder entry point is case-insensitive",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder name comes from folder when frontmatter name is blank",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder sibling md files are NOT listed as separate skills",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder structure section lists all files",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder supplemental content is merged into skill content",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder with non-md supplemental files includes them in content",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder with skill dot md is returned as single skill",
+    "parameterTypes": [ ]
+  }, {
+    "name": "standalone md file is NOT a skill",
+    "parameterTypes": [ ]
+  }, {
+    "name": "sub-folder of skill folder is NOT a separate skill",
+    "parameterTypes": [ ]
+  }, {
+    "name": "supplemental md files have frontmatter stripped in content",
+    "parameterTypes": [ ]
+  } ]
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest$GetTree",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ "io.askimo.core.skills.SkillRepositoryTest" ]
+  }, {
+    "name": "root-level skill folder has no category wrapper",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill deeply nested - only immediate parent shown as category",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder children include sibling md files as Leaf nodes",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder children include sub-directories",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill one level deep - direct parent shown as category",
+    "parameterTypes": [ ]
+  }, {
+    "name": "two skills under same immediate parent grouped under one category",
+    "parameterTypes": [ ]
+  } ]
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest$HiddenDirectoryFiltering",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ "io.askimo.core.skills.SkillRepositoryTest" ]
+  }, {
+    "name": "getAll - files inside dot-git are excluded",
+    "parameterTypes": [ ]
+  }, {
+    "name": "getAll - files inside dot-github are excluded",
+    "parameterTypes": [ ]
+  }, {
+    "name": "getSkillsOnly - skills in dot-hidden dirs are excluded",
+    "parameterTypes": [ ]
+  }, {
+    "name": "getTree - dot-git directory does not appear as Category node",
+    "parameterTypes": [ ]
+  } ]
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest$ImportFromDirectory",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ "io.askimo.core.skills.SkillRepositoryTest" ]
+  }, {
+    "name": "case-insensitive entry point detection on import",
+    "parameterTypes": [ ]
+  }, {
+    "name": "directories with no skills are excluded",
+    "parameterTypes": [ ]
+  }, {
+    "name": "dot git directory is excluded",
+    "parameterTypes": [ ]
+  }, {
+    "name": "multiple skill folders all imported",
+    "parameterTypes": [ ]
+  }, {
+    "name": "reserved files at root are excluded (not skill folders)",
+    "parameterTypes": [ ]
+  }, {
+    "name": "returns correct skill count - only skill folders counted",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder sibling non-md files are imported",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder subdirectory files are imported",
+    "parameterTypes": [ ]
+  }, {
+    "name": "skill folder with skill dot md is imported",
+    "parameterTypes": [ ]
+  }, {
+    "name": "standalone md file is NOT imported (not a skill)",
+    "parameterTypes": [ ]
+  }, {
+    "name": "sub-skill-folder inside skill folder is NOT imported as separate skill",
+    "parameterTypes": [ ]
+  } ]
+}, {
+  "name": "io.askimo.core.skills.SkillRepositoryTest$SaveAndDelete",
+  "allDeclaredFields": true,
+  "allDeclaredClasses": true,
+  "queryAllDeclaredMethods": true,
+  "queryAllPublicMethods": true,
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ "io.askimo.core.skills.SkillRepositoryTest" ]
+  }, {
+    "name": "delete does NOT prune category parent when sibling skill still exists",
+    "parameterTypes": [ ]
+  }, {
+    "name": "delete partially prunes deep category chain up to surviving sibling",
+    "parameterTypes": [ ]
+  }, {
+    "name": "delete prunes empty category parent after last skill removed",
+    "parameterTypes": [ ]
+  }, {
+    "name": "delete prunes skill folder together with supplemental files",
+    "parameterTypes": [ ]
+  }, {
+    "name": "delete prunes the skill folder itself",
+    "parameterTypes": [ ]
+  }, {
+    "name": "delete removes file",
+    "parameterTypes": [ ]
+  }, {
+    "name": "delete returns false for non-existent file and does not prune",
+    "parameterTypes": [ ]
+  }, {
+    "name": "save persists file and findByPath retrieves the skill",
+    "parameterTypes": [ ]
+  } ]
 }, {
   "name": "io.askimo.core.util.AskimoHome",
   "fields": [ {
@@ -7433,7 +7718,7 @@
     "parameterTypes": [ ]
   } ]
 }, {
-  "name": "org.jline.reader.ParsedLine$MockitoMock$GRAXfBY0",
+  "name": "org.jline.reader.ParsedLine$MockitoMock$ldNa7zx3",
   "queryAllDeclaredConstructors": true,
   "methods": [ {
     "name": "<init>",

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/SkillsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/SkillsSettingsSection.kt
@@ -46,6 +46,7 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.AlertDialog
@@ -100,6 +101,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.awt.Cursor
 import java.awt.Desktop
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -240,6 +242,12 @@ fun skillsSettingsSection() {
                     onAddFolderInFolder = { parentPath ->
                         addItemParentPath = parentPath
                         showAddFolderDialog = true
+                    },
+                    onDeleteAll = {
+                        skillRepository.deleteAll()
+                        selectedSkill = null
+                        selectedLeaf = null
+                        refresh()
                     },
                 )
             } else {
@@ -400,6 +408,18 @@ private fun skillsMainContent(
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                         )
+                    }
+                    themedTooltip(text = stringResource("skills.view.docs.tooltip")) {
+                        IconButton(
+                            onClick = { runCatching { Desktop.getDesktop().browse(URI("https://askimo.chat/docs/desktop/skills/")) } },
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Icon(
+                                Icons.Default.Info,
+                                contentDescription = stringResource("skills.view.docs.tooltip"),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
 
@@ -994,9 +1014,11 @@ private fun skillsTreePanel(
     onImportFromGitHub: () -> Unit = {},
     onAddFileInFolder: (folderRelativePath: String) -> Unit = {},
     onAddFolderInFolder: (folderRelativePath: String) -> Unit = {},
+    onDeleteAll: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
     var showAddMenu by remember { mutableStateOf(false) }
+    var showDeleteAllConfirm by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         // Panel header
@@ -1046,6 +1068,13 @@ private fun skillsTreePanel(
                         )
                     }
                 }
+                // Delete all button
+                IconButton(
+                    onClick = { showDeleteAllConfirm = true },
+                    modifier = Modifier.size(28.dp).pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Icon(Icons.Default.Delete, contentDescription = "Delete all skills", modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.error)
+                }
                 // Collapse button
                 IconButton(
                     onClick = onCollapse,
@@ -1056,6 +1085,16 @@ private fun skillsTreePanel(
             }
         }
         HorizontalDivider()
+
+        if (showDeleteAllConfirm) {
+            deleteAllSkillsDialog(
+                onDismiss = { showDeleteAllConfirm = false },
+                onConfirm = {
+                    showDeleteAllConfirm = false
+                    onDeleteAll()
+                },
+            )
+        }
 
         // Tree content
         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
@@ -1675,6 +1714,29 @@ private fun deleteFolderConfirmDialog(
             TextButton(onClick = onDismiss, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource("action.cancel"))
             }
+        },
+    )
+}
+
+@Composable
+private fun deleteAllSkillsDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource("settings.skills.delete.all.title")) },
+        text = {
+            Text(
+                text = stringResource("settings.skills.delete.all.confirm"),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            dangerButton(onClick = onConfirm) { Text(stringResource("action.delete")) }
+        },
+        dismissButton = {
+            linkButton(onClick = onDismiss) { Text(stringResource("action.cancel")) }
         },
     )
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/skills/SkillsGalleryView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/skills/SkillsGalleryView.kt
@@ -34,9 +34,11 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -63,12 +65,15 @@ import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.themedTooltip
+import java.awt.Desktop
+import java.net.URI
 
 @Composable
 internal fun skillsListContent(
     skills: List<SkillDefinition>,
     onSelectSkill: (SkillDefinition) -> Unit,
     onRefresh: () -> Unit,
+    onNavigateToSkillsSettings: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
     var searchQuery by remember { mutableStateOf("") }
@@ -128,12 +133,43 @@ internal fun skillsListContent(
                             modifier = Modifier.padding(top = 4.dp),
                         )
                     }
-                    IconButton(onClick = onRefresh, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
-                        Icon(
-                            Icons.Default.Refresh,
-                            contentDescription = stringResource("action.refresh"),
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        themedTooltip(text = stringResource("skills.view.docs.tooltip")) {
+                            IconButton(
+                                onClick = { runCatching { Desktop.getDesktop().browse(URI("https://askimo.chat/docs/desktop/skills/")) } },
+                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                            ) {
+                                Icon(
+                                    Icons.Default.Info,
+                                    contentDescription = stringResource("skills.view.docs.tooltip"),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        themedTooltip(text = stringResource("skills.view.settings.tooltip")) {
+                            IconButton(
+                                onClick = onNavigateToSkillsSettings,
+                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                            ) {
+                                Icon(
+                                    Icons.Default.Settings,
+                                    contentDescription = stringResource("skills.view.settings.tooltip"),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        themedTooltip(text = stringResource("action.refresh")) {
+                            IconButton(onClick = onRefresh, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
+                                Icon(
+                                    Icons.Default.Refresh,
+                                    contentDescription = stringResource("action.refresh"),
+                                    tint = MaterialTheme.colorScheme.onBackground,
+                                )
+                            }
+                        }
                     }
                 }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/skills/SkillsHistoryPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/skills/SkillsHistoryPanel.kt
@@ -58,6 +58,7 @@ import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.Spacing
+import io.askimo.ui.common.ui.TooltipPlacement
 import io.askimo.ui.common.ui.themedTooltip
 import java.awt.Cursor
 import java.time.format.DateTimeFormatter
@@ -69,6 +70,7 @@ internal val RUN_TIME_FMT: DateTimeFormatter =
 private fun skillRunHistoryPanelRow(
     record: SkillRunRecord,
     onClick: () -> Unit,
+    onDelete: () -> Unit,
     showSkillName: Boolean = true,
 ) {
     val isError = record.error != null
@@ -76,56 +78,86 @@ private fun skillRunHistoryPanelRow(
     val skillDisplayName = remember(record.skillPath) {
         record.skillPath.substringAfterLast('/').substringAfterLast('\\').substringBeforeLast('.')
     }
+    val tooltipText = remember(record) {
+        buildString {
+            append(skillDisplayName)
+            append(" · ")
+            append(timeLabel)
+            if (record.userInput.isNotBlank()) {
+                append("\n")
+                append(record.userInput)
+            }
+            if (isError) {
+                append("\n⚠ ")
+                append(record.error)
+            }
+        }
+    }
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .pointerHoverIcon(PointerIcon.Hand)
-            .hoverable(interactionSource)
-            .clickable(onClick = onClick)
-            .background(
-                if (isHovered) {
-                    MaterialTheme.colorScheme.primary.copy(alpha = 0.05f)
-                } else {
-                    androidx.compose.ui.graphics.Color.Transparent
-                },
-            )
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
-    ) {
-        Icon(
-            if (isError) Icons.Default.Close else Icons.Default.CheckCircle,
-            contentDescription = null,
-            modifier = Modifier.size(12.dp),
-            tint = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
-        )
-        Column(modifier = Modifier.weight(1f)) {
-            if (showSkillName) {
-                Text(
-                    skillDisplayName,
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    color = if (isHovered) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
+    themedTooltip(text = tooltipText, placement = TooltipPlacement.LEFT) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .pointerHoverIcon(PointerIcon.Hand)
+                .hoverable(interactionSource)
+                .clickable(onClick = onClick)
+                .background(
+                    if (isHovered) {
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.05f)
+                    } else {
+                        androidx.compose.ui.graphics.Color.Transparent
+                    },
                 )
+                .padding(start = 12.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+        ) {
+            Icon(
+                if (isError) Icons.Default.Close else Icons.Default.CheckCircle,
+                contentDescription = null,
+                modifier = Modifier.size(12.dp),
+                tint = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                if (showSkillName) {
+                    Text(
+                        skillDisplayName,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Text(
+                    timeLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (record.userInput.isNotBlank()) {
+                    Text(
+                        record.userInput.take(50) + if (record.userInput.length > 50) "…" else "",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
-            Text(
-                timeLabel,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
-            )
-            if (record.userInput.isNotBlank()) {
-                Text(
-                    record.userInput.take(50) + if (record.userInput.length > 50) "…" else "",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+            if (isHovered) {
+                IconButton(
+                    onClick = onDelete,
+                    modifier = Modifier.size(28.dp).pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = "Delete record",
+                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
             }
         }
     }
@@ -138,6 +170,7 @@ internal fun skillsHistoryPanel(
     runHistory: List<SkillRunRecord> = emptyList(),
     filterSkillName: String? = null,
     onSelectRecord: (SkillRunRecord) -> Unit = {},
+    onDeleteRecord: (SkillRunRecord) -> Unit = {},
 ) {
     var panelWidth by remember {
         mutableStateOf(ApplicationPreferences.getSkillsSidePanelWidth().dp)
@@ -238,6 +271,7 @@ internal fun skillsHistoryPanel(
                                         record = record,
                                         showSkillName = filterSkillName == null,
                                         onClick = { onSelectRecord(record) },
+                                        onDelete = { onDeleteRecord(record) },
                                     )
                                     HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.08f))
                                 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/skills/SkillsView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/skills/SkillsView.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -25,10 +26,13 @@ import io.askimo.core.skills.domain.SkillDefinition
 import io.askimo.core.skills.domain.SkillRunRecord
 import io.askimo.ui.common.preferences.ApplicationPreferences
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
-fun skillsView() {
+fun skillsView(
+    onNavigateToSkillsSettings: () -> Unit = {},
+) {
     val skillRepository = remember { SkillRepository() }
     val historyRepo = remember { DatabaseManager.getInstance().getSkillRunHistoryRepository() }
     var refreshKey by remember { mutableStateOf(0) }
@@ -47,6 +51,8 @@ fun skillsView() {
 
     var pendingHistoryRecord by remember { mutableStateOf<SkillRunRecord?>(null) }
 
+    val coroutineScope = rememberCoroutineScope()
+
     Row(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
             if (selectedSkill == null) {
@@ -54,6 +60,7 @@ fun skillsView() {
                     skills = skills,
                     onSelectSkill = { selectedSkill = it },
                     onRefresh = { refreshKey++ },
+                    onNavigateToSkillsSettings = onNavigateToSkillsSettings,
                 )
             } else {
                 skillExecutionArea(
@@ -90,6 +97,12 @@ fun skillsView() {
                 if (skill != null) {
                     selectedSkill = skill
                     pendingHistoryRecord = record
+                }
+            },
+            onDeleteRecord = { record ->
+                coroutineScope.launch(Dispatchers.IO) {
+                    historyRepo.deleteById(record.id)
+                    allRunHistory = historyRepo.findAll()
                 }
             },
         )

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=Delete file
 settings.skills.delete.file.confirm=Delete "{0}"? This cannot be undone.
 settings.skills.delete.folder.title=Delete folder
 settings.skills.delete.folder.confirm=Delete "{0}" and all skills inside it? This cannot be undone.
+settings.skills.delete.all.title=Delete All Skills
+settings.skills.delete.all.confirm=Delete all skills? This will permanently remove all skill folders and cannot be undone.
 settings.skills.import.success.title=Import Successful
 settings.skills.add.file=Add File
 settings.skills.add.file.name=File name
@@ -425,23 +427,13 @@ action.close=Close
 action.back=Back
 action.retry=Try Again
 action.done=Done
+action.refresh=Refresh
 
 # Star Prompt
 star.prompt.title=If Askimo has been helpful…
 star.prompt.message=Askimo is an open-source project built and maintained with community support.\n\nIf it has improved your workflow, consider supporting the project with a star on GitHub ⭐.\n\nYour support helps others discover it and encourages continued development.
 star.prompt.star.button=Join others supporting Askimo
 star.prompt.maybe.later=Not now
-
-# Analytics Consent
-analytics.consent.title=Help make Askimo better for everyone
-analytics.consent.message=Askimo is free and open-source. Sharing anonymous usage data is one small way to give back — it helps us understand what to build next.
-analytics.consent.collected.yes.features=✅  Which features are used (e.g., RAG, MCP tools, Plans)
-analytics.consent.collected.yes.version=✅  App version and OS type
-analytics.consent.collected.no.conversations=❌  No conversation content or prompts
-analytics.consent.collected.no.personal=❌  No personal data, files, or API keys — ever
-analytics.consent.detail=This helps us focus development where it counts. You can turn this off in Settings → Advanced at any time.
-analytics.consent.decline=No thanks
-analytics.consent.accept=Yes, help improve Askimo
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=Anonymous Analytics
@@ -1197,6 +1189,8 @@ skills.view.system.prompt.file=file
 skills.view.system.prompt.files=files
 skills.view.system.prompt.also.included=Also included in agent context:
 skills.view.activity.log=Activity Log
+skills.view.docs.tooltip=View Skills Guide
+skills.view.settings.tooltip=Configure Skills
 
 # File / folder chooser
 file.chooser.folder.select=Select

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=Datei löschen
 settings.skills.delete.file.confirm="{0}" löschen? Dies kann nicht rückgängig gemacht werden.
 settings.skills.delete.folder.title=Ordner löschen
 settings.skills.delete.folder.confirm="{0}" und alle darin enthaltenen Fähigkeiten löschen? Dies kann nicht rückgängig gemacht werden.
+settings.skills.delete.all.title=Alle Fähigkeiten löschen
+settings.skills.delete.all.confirm=Alle Fähigkeiten löschen? Dadurch werden alle Fähigkeitsordner dauerhaft entfernt und dies kann nicht rückgängig gemacht werden.
 settings.skills.import.success.title=Import erfolgreich
 settings.skills.add.file=Datei hinzufügen
 settings.skills.add.file.name=Dateiname
@@ -424,23 +426,13 @@ action.close=Schließen
 action.back=Zurück
 action.retry=Erneut versuchen
 action.done=Fertig
+action.refresh=Aktualisieren
 
 # Star Prompt
 star.prompt.title=Wenn Askimo hilfreich für Sie war …
 star.prompt.message=Askimo ist ein Open-Source-Projekt, das mit Unterstützung der Community entwickelt und gepflegt wird.\n\nWenn es Ihren Arbeitsablauf verbessert hat, unterstützen Sie das Projekt gerne mit einem Stern auf GitHub ⭐.\n\nIhre Unterstützung hilft anderen, Askimo zu entdecken, und fördert die Weiterentwicklung.
 star.prompt.star.button=Gemeinsam Askimo unterstützen
 star.prompt.maybe.later=Jetzt nicht
-
-# Analytics Consent
-analytics.consent.title=Helfen Sie mit, Askimo für alle zu verbessern
-analytics.consent.message=Askimo ist kostenlos und Open Source. Anonyme Nutzungsdaten zu teilen ist eine kleine Möglichkeit, etwas zurückzugeben — es hilft uns zu verstehen, was wir als Nächstes bauen sollen.
-analytics.consent.collected.yes.features=✅  Welche Funktionen genutzt werden (z.B. RAG, MCP-Tools, Plans)
-analytics.consent.collected.yes.version=✅  App-Version und Betriebssystemtyp
-analytics.consent.collected.no.conversations=❌  Keine Gesprächsinhalte oder Prompts
-analytics.consent.collected.no.personal=❌  Keine persönlichen Daten, Dateien oder API-Schlüssel — niemals
-analytics.consent.detail=Dies hilft uns, uns auf das Wichtigste zu konzentrieren. Sie können dies jederzeit in Einstellungen → Erweitert deaktivieren.
-analytics.consent.decline=Nein danke
-analytics.consent.accept=Ja, helfen Sie mit, Askimo zu verbessern
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=Anonyme Analysen
@@ -1204,6 +1196,8 @@ skills.view.system.prompt.file=Datei
 skills.view.system.prompt.files=Dateien
 skills.view.system.prompt.also.included=Ebenfalls im Agent-Kontext enthalten:
 skills.view.activity.log=Aktivitätsprotokoll
+skills.view.docs.tooltip=Fertigkeitsanleitung anzeigen
+skills.view.settings.tooltip=Fertigkeiten konfigurieren
 
 # File / folder chooser
 file.chooser.folder.select=Auswählen

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=Eliminar archivo
 settings.skills.delete.file.confirm=¿Eliminar "{0}"? Esta acción no se puede deshacer.
 settings.skills.delete.folder.title=Eliminar carpeta
 settings.skills.delete.folder.confirm=¿Eliminar "{0}" y todas las habilidades que contiene? Esta acción no se puede deshacer.
+settings.skills.delete.all.title=Eliminar todas las habilidades
+settings.skills.delete.all.confirm=¿Eliminar todas las habilidades? Esto eliminará permanentemente todas las carpetas de habilidades y no se puede deshacer.
 settings.skills.import.success.title=Importación correcta
 settings.skills.add.file=Añadir archivo
 settings.skills.add.file.name=Nombre de archivo
@@ -424,23 +426,13 @@ action.close=Cerrar
 action.back=Atrás
 action.retry=Reintentar
 action.done=Listo
+action.refresh=Actualizar
 
 # Star Prompt
 star.prompt.title=Si Askimo te ha sido útil…
 star.prompt.message=Askimo es un proyecto de código abierto desarrollado y mantenido con el apoyo de la comunidad.\n\nSi ha mejorado tu flujo de trabajo, considera apoyar el proyecto con una estrella en GitHub ⭐.\n\nTu apoyo ayuda a que más personas descubran Askimo y fomenta su desarrollo continuo.
 star.prompt.star.button=Únete a quienes apoyan Askimo
 star.prompt.maybe.later=Ahora no
-
-# Analytics Consent
-analytics.consent.title=Ayuda a mejorar Askimo para todos
-analytics.consent.message=Puedes ayudar a mejorar Askimo compartiendo datos de uso anónimos, como qué funciones utilizas y a qué proveedores de IA te conectas. Sin texto, sin prompts, sin archivos, sin claves API. Nunca.
-analytics.consent.collected.yes.features=✅ ¿Qué funciones se utilizan (por ejemplo, RAG, herramientas MCP, Planes)?
-analytics.consent.collected.yes.version=✅ Versión de la aplicación y tipo de sistema operativo
-analytics.consent.collected.no.conversations=❌ Sin contenido de conversación ni indicaciones
-analytics.consent.collected.no.personal=❌ Sin datos personales, archivos o claves API — nunca
-analytics.consent.detail=Esto nos ayuda a entender qué es lo más importante y a enfocar el desarrollo donde realmente cuenta. Puedes desactivar esto en Configuración en cualquier momento.
-analytics.consent.decline=No, gracias
-analytics.consent.accept=Sí, ayudar a mejorar Askimo
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=Analítica anónima
@@ -1200,6 +1192,8 @@ skills.view.system.prompt.file=archivo
 skills.view.system.prompt.files=archivos
 skills.view.system.prompt.also.included=También incluido en el contexto del agente:
 skills.view.activity.log=Registro de actividad
+skills.view.docs.tooltip=Ver Guía de Habilidades
+skills.view.settings.tooltip=Configurar Habilidades
 
 # File / folder chooser
 file.chooser.folder.select=Seleccionar

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=Supprimer le fichier
 settings.skills.delete.file.confirm=Supprimer "{0}" ? Cette action est irréversible.
 settings.skills.delete.folder.title=Supprimer le dossier
 settings.skills.delete.folder.confirm=Supprimer "{0}" et toutes les compétences qu’il contient ? Cette action est irréversible.
+settings.skills.delete.all.title=Supprimer toutes les compétences
+settings.skills.delete.all.confirm=Supprimer toutes les compétences ? Cela supprimera définitivement tous les dossiers de compétences et ne pourra pas être annulé.
 settings.skills.import.success.title=Importation réussie
 settings.skills.add.file=Ajouter un fichier
 settings.skills.add.file.name=Nom du fichier
@@ -424,23 +426,13 @@ action.close=Fermer
 action.back=Retour
 action.retry=Réessayer
 action.done=Terminé
+action.refresh=Rafraîchir
 
 # Star Prompt
 star.prompt.title=Si Askimo vous a été utile…
 star.prompt.message=Askimo est un projet open source développé et maintenu grâce au soutien de la communauté.\n\nS’il a amélioré votre flux de travail, pensez à soutenir le projet en lui attribuant une étoile sur GitHub ⭐.\n\nVotre soutien aide d’autres personnes à découvrir Askimo et encourage son développement continu.
 star.prompt.star.button=Rejoignez ceux qui soutiennent Askimo
 star.prompt.maybe.later=Pas maintenant
-
-# Analytics Consent
-analytics.consent.title=Aidez-nous à améliorer Askimo pour tout le monde
-analytics.consent.message=Askimo est gratuit et open source. Partager des données d''utilisation anonymes est une petite façon de contribuer — cela nous aide à comprendre quoi construire ensuite.
-analytics.consent.collected.yes.features=✅  Fonctionnalités utilisées (ex. : RAG, outils MCP, Plans)
-analytics.consent.collected.yes.version=✅  Version de l''app et type de système d''exploitation
-analytics.consent.collected.no.conversations=❌  Aucun contenu de conversation ni prompt
-analytics.consent.collected.no.personal=❌  Aucune donnée personnelle, fichier ou clé API — jamais
-analytics.consent.detail=Cela nous aide à nous concentrer sur ce qui compte le plus. Vous pouvez désactiver cela dans Paramètres → Avancé à tout moment.
-analytics.consent.decline=Non merci
-analytics.consent.accept=Oui, aider à améliorer Askimo
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=Analytique anonyme
@@ -1201,6 +1193,8 @@ skills.view.system.prompt.file=fichier
 skills.view.system.prompt.files=fichiers
 skills.view.system.prompt.also.included=Également inclus dans le contexte de l’agent :
 skills.view.activity.log=Journal d’activité
+skills.view.docs.tooltip=Voir le guide des compétences
+skills.view.settings.tooltip=Configurer les compétences
 
 # File / folder chooser
 file.chooser.folder.select=Sélectionner

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=ファイルを削除
 settings.skills.delete.file.confirm="{0}" を削除しますか？この操作は元に戻せません。
 settings.skills.delete.folder.title=フォルダーを削除
 settings.skills.delete.folder.confirm="{0}" とその中のすべてのスキルを削除しますか？この操作は元に戻せません。
+settings.skills.delete.all.title=すべてのスキルを削除
+settings.skills.delete.all.confirm=すべてのスキルを削除しますか？これにより、すべてのスキルフォルダが完全に削除され、元に戻すことはできません。
 settings.skills.import.success.title=インポート成功
 settings.skills.add.file=ファイルを追加
 settings.skills.add.file.name=ファイル名
@@ -424,23 +426,13 @@ action.close=閉じる
 action.back=戻る
 action.retry=再試行
 action.done=完了
+action.refresh=更新
 
 # Star Prompt
 star.prompt.title=Askimoがお役に立てたなら…
 star.prompt.message=Askimoはコミュニティの支援によって開発・維持されているオープンソースプロジェクトです。\n\nワークフローの改善に役立った場合は、GitHubで⭐を付けてプロジェクトを応援していただけると幸いです。\n\n皆さまのサポートは、より多くの方にAskimoを知ってもらい、継続的な開発を後押しします。
 star.prompt.star.button=Askimoを応援する
 star.prompt.maybe.later=今はしない
-
-# Analytics Consent
-analytics.consent.title=Askimoをみんなのためにより良くするお手伝いをお願いします
-analytics.consent.message=Askimoは無料のオープンソースソフトウェアです。匿名の使用データを共有することは、次に何を作るべきか理解するための小さな貢献です。
-analytics.consent.collected.yes.features=✅  使用された機能（例：RAG、MCPツール、Plans）
-analytics.consent.collected.yes.version=✅  アプリのバージョンとOSの種類
-analytics.consent.collected.no.conversations=❌  会話の内容やプロンプトは収集しません
-analytics.consent.collected.no.personal=❌  個人データ、ファイル、APIキーは絶対収集しません
-analytics.consent.detail=これにより、最も重要なことに集中して開発を進めることができます。「設定 → 詳細設定」でいつでもオフにできます。
-analytics.consent.decline=いいえ、結構です
-analytics.consent.accept=はい、Askimoの改善に協力します
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=匿名分析
@@ -1201,6 +1193,8 @@ skills.view.system.prompt.file=ファイル
 skills.view.system.prompt.files=ファイル
 skills.view.system.prompt.also.included=エージェントコンテキストにも含まれています:
 skills.view.activity.log=アクティビティログ
+skills.view.docs.tooltip=スキルガイドを表示
+skills.view.settings.tooltip=スキルを設定
 
 # File / folder chooser
 file.chooser.folder.select=選択

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -259,6 +259,8 @@ settings.skills.delete.file.title=파일 삭제
 settings.skills.delete.file.confirm="{0}"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
 settings.skills.delete.folder.title=폴더 삭제
 settings.skills.delete.folder.confirm="{0}" 및 그 안의 모든 스킬을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+settings.skills.delete.all.title=모든 스킬 삭제
+settings.skills.delete.all.confirm=모든 스킬을 삭제하시겠습니까? 이 작업은 모든 스킬 폴더를 영구적으로 삭제하며, 취소할 수 없습니다.
 settings.skills.import.success.title=가져오기 성공
 settings.skills.add.file=파일 추가
 settings.skills.add.file.name=파일 이름
@@ -425,23 +427,13 @@ action.close=닫기
 action.back=뒤로가기
 action.retry=다시 시도
 action.done=완료
+action.refresh=새로고침
 
 # Star Prompt
 star.prompt.title=Askimo가 도움이 되셨다면…
 star.prompt.message=Askimo는 커뮤니티의 지원으로 개발되고 유지되는 오픈소스 프로젝트입니다.\n\n업무 흐름 개선에 도움이 되었다면 GitHub에서 ⭐를 눌러 프로젝트를 지원해 주세요.\n\n여러분의 지원은 더 많은 사람들이 Askimo를 발견하고 지속적인 개발을 이어가는 데 큰 힘이 됩니다.
 star.prompt.star.button=Askimo 지원하기
 star.prompt.maybe.later=지금은 아니요
-
-# Analytics Consent
-analytics.consent.title=모두를 위해 Askimo를 개선하도록 도와주세요
-analytics.consent.message=익명 사용 데이터를 공유하여 Askimo를 개선하는 데 도움을 줄 수 있습니다. 여기에는 사용 중인 기능과 연결하는 AI 공급자와 같은 정보가 포함됩니다. 텍스트, 프롬프트, 파일, API 키는 포함되지 않습니다. 절대로요.
-analytics.consent.collected.yes.features=✅ 사용되는 기능 (예: RAG, MCP 도구, 플랜)
-analytics.consent.collected.yes.version=✅ 앱 버전 및 OS 유형
-analytics.consent.collected.no.conversations=❌ 대화 내용이나 프롬프트 없음
-analytics.consent.collected.no.personal=❌ 개인 데이터, 파일 또는 API 키 없음 — 절대
-analytics.consent.detail=이는 무엇이 가장 중요한지 이해하고 중요한 부분에 개발을 집중하는 데 도움이 됩니다. 설정에서 언제든지 이 기능을 끌 수 있습니다.
-analytics.consent.decline=아니요, 괜찮습니다
-analytics.consent.accept=예, Askimo 개선을 돕겠습니다
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=익명 분석
@@ -1201,6 +1193,8 @@ skills.view.system.prompt.file=파일
 skills.view.system.prompt.files=파일
 skills.view.system.prompt.also.included=에이전트 컨텍스트에도 포함됨:
 skills.view.activity.log=활동 로그
+skills.view.docs.tooltip=스킬 가이드 보기
+skills.view.settings.tooltip=스킬 구성
 
 # File / folder chooser
 file.chooser.folder.select=선택

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=Excluir arquivo
 settings.skills.delete.file.confirm=Excluir "{0}"? Esta ação não pode ser desfeita.
 settings.skills.delete.folder.title=Excluir pasta
 settings.skills.delete.folder.confirm=Excluir "{0}" e todas as habilidades dentro dela? Esta ação não pode ser desfeita.
+settings.skills.delete.all.title=Excluir todas as habilidades
+settings.skills.delete.all.confirm=Excluir todas as habilidades? Isso removerá permanentemente todas as pastas de habilidades e não poderá ser desfeito.
 settings.skills.import.success.title=Importação bem-sucedida
 settings.skills.add.file=Adicionar arquivo
 settings.skills.add.file.name=Nome do arquivo
@@ -424,23 +426,13 @@ action.close=Fechar
 action.back=Voltar
 action.retry=Tentar novamente
 action.done=Concluído
+action.refresh=Atualizar
 
 # Star Prompt
 star.prompt.title=Se o Askimo foi útil para você…
 star.prompt.message=Askimo é um projeto open-source desenvolvido e mantido com o apoio da comunidade.\n\nSe ele melhorou seu fluxo de trabalho, considere apoiar o projeto com uma estrela no GitHub ⭐.\n\nSeu apoio ajuda mais pessoas a descobrirem o Askimo e incentiva o desenvolvimento contínuo.
 star.prompt.star.button=Junte-se a quem apoia o Askimo
 star.prompt.maybe.later=Agora não
-
-# Analytics Consent
-analytics.consent.title=Ajude a tornar o Askimo melhor para todos
-analytics.consent.message=Askimo é gratuito e de código aberto. Compartilhar dados de uso anônimos é uma pequena forma de contribuir — ajuda-nos a entender o que construir a seguir.
-analytics.consent.collected.yes.features=✅  Quais funcionalidades são usadas (ex.: RAG, ferramentas MCP, Plans)
-analytics.consent.collected.yes.version=✅  Versão do app e tipo de SO
-analytics.consent.collected.no.conversations=❌  Sem conteúdo de conversas ou prompts
-analytics.consent.collected.no.personal=❌  Sem dados pessoais, arquivos ou chaves de API — nunca
-analytics.consent.detail=Isso nos ajuda a focar no que mais importa. Você pode desativar em Configurações → Avançado a qualquer momento.
-analytics.consent.decline=Não, obrigado
-analytics.consent.accept=Sim, ajudar a melhorar o Askimo
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=Análises anônimas
@@ -1201,6 +1193,8 @@ skills.view.system.prompt.file=arquivo
 skills.view.system.prompt.files=arquivos
 skills.view.system.prompt.also.included=Também incluído no contexto do agente:
 skills.view.activity.log=Registro de atividade
+skills.view.docs.tooltip=Ver Guia de Habilidades
+skills.view.settings.tooltip=Configurar Habilidades
 
 # File / folder chooser
 file.chooser.folder.select=Selecionar

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=Xóa tệp
 settings.skills.delete.file.confirm=Xóa "{0}"? Không thể hoàn tác thao tác này.
 settings.skills.delete.folder.title=Xóa thư mục
 settings.skills.delete.folder.confirm=Xóa "{0}" và tất cả kỹ năng bên trong nó? Không thể hoàn tác thao tác này.
+settings.skills.delete.all.title=Xóa tất cả kỹ năng
+settings.skills.delete.all.confirm=Xóa tất cả kỹ năng? Thao tác này sẽ xóa vĩnh viễn tất cả các thư mục kỹ năng và không thể hoàn tác.
 settings.skills.import.success.title=Nhập thành công
 settings.skills.add.file=Thêm tệp
 settings.skills.add.file.name=Tên tệp
@@ -421,23 +423,13 @@ action.close=Đóng
 action.back=Quay lại
 action.retry=Thử lại
 action.done=Hoàn thành
+action.refresh=Tải lại
 
 # Star Prompt
 star.prompt.title=Nếu Askimo hữu ích với bạn…
 star.prompt.message=Askimo là một dự án mã nguồn mở được xây dựng và duy trì với sự hỗ trợ từ cộng đồng.\n\nNếu nó đã cải thiện quy trình làm việc của bạn, hãy cân nhắc ủng hộ dự án bằng cách tặng một ngôi sao trên GitHub ⭐.\n\nSự ủng hộ của bạn giúp nhiều người khác biết đến Askimo và thúc đẩy sự phát triển lâu dài của dự án.
 star.prompt.star.button=Tham gia ủng hộ Askimo
 star.prompt.maybe.later=Để sau
-
-# Analytics Consent
-analytics.consent.title=Giúp cải thiện Askimo cho mọi người
-analytics.consent.message=Askimo là miễn phí và mã nguồn mở. Chia sẻ dữ liệu sử dụng ẩn danh là một cách nhỏ để đóng góp — giúp chúng tôi hiểu nên xây dựng gì tiếp theo.
-analytics.consent.collected.yes.features=✅  Tính năng nào được dùng (VD: RAG, công cụ MCP, Plans)
-analytics.consent.collected.yes.version=✅  Phiên bản ứng dụng và loại hệ điều hành
-analytics.consent.collected.no.conversations=❌  Không có nội dung hội thoại hay prompt
-analytics.consent.collected.no.personal=❌  Không có dữ liệu cá nhân, tệp hay API key — không bao giờ
-analytics.consent.detail=Điều này giúp chúng tôi tập trung phát triển vào nơi cần thiết. Bạn có thể tắt trong Cài đặt → Nâng cao bất cứ lúc nào.
-analytics.consent.decline=Không, cảm ơn
-analytics.consent.accept=Có, giúp cải thiện Askimo
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=Phân tích ẩn danh
@@ -1200,6 +1192,8 @@ skills.view.system.prompt.file=tệp
 skills.view.system.prompt.files=tệp
 skills.view.system.prompt.also.included=Cũng được bao gồm trong ngữ cảnh agent:
 skills.view.activity.log=Nhật ký hoạt động
+skills.view.docs.tooltip=Xem Hướng dẫn Kỹ năng
+skills.view.settings.tooltip=Cấu hình Kỹ năng
 
 # File / folder chooser
 file.chooser.folder.select=Chọn

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=删除文件
 settings.skills.delete.file.confirm=删除 "{0}"？此操作无法撤消。
 settings.skills.delete.folder.title=删除文件夹
 settings.skills.delete.folder.confirm=删除 "{0}" 及其中的所有技能？此操作无法撤消。
+settings.skills.delete.all.title=删除所有技能
+settings.skills.delete.all.confirm=要删除所有技能吗？此操作将永久删除所有技能文件夹，且无法撤销。
 settings.skills.import.success.title=导入成功
 settings.skills.add.file=添加文件
 settings.skills.add.file.name=文件名
@@ -424,23 +426,13 @@ action.close=关闭
 action.back=返回
 action.retry=重试
 action.done=完成
+action.refresh=刷新
 
 # Star Prompt
 star.prompt.title=如果 Askimo 对您有所帮助…
 star.prompt.message=Askimo 是一个由社区支持开发和维护的开源项目。\n\n如果它提升了您的工作效率，欢迎在 GitHub 上为项目点亮 ⭐ 以示支持。\n\n您的支持有助于让更多人了解 Askimo，并推动项目持续发展。
 star.prompt.star.button=加入支持 Askimo 的行列
 star.prompt.maybe.later=暂不
-
-# Analytics Consent
-analytics.consent.title=帮助大家把 Askimo 变得更好
-analytics.consent.message=Askimo 是免费并且开源的。分享匿名使用数据是一种小小的回馈方式 — 它帮助我们了解接下来该构建什么。
-analytics.consent.collected.yes.features=✅  使用了哪些功能（如 RAG、MCP 工具、Plans）
-analytics.consent.collected.yes.version=✅  应用版本和操作系统类型
-analytics.consent.collected.no.conversations=❌  不含任何对话内容或提示词
-analytics.consent.collected.no.personal=❌  不含个人数据、文件或 API 密鑰 — 永远不会
-analytics.consent.detail=这有助于我们了解什么最重要并集中开发精力。您可以随时在「设置 → 高级」中关闭此功能。
-analytics.consent.decline=不了，谢谢
-analytics.consent.accept=是的，帮助改进 Askimo
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=匿名分析
@@ -1202,6 +1194,8 @@ skills.view.system.prompt.file=文件
 skills.view.system.prompt.files=文件
 skills.view.system.prompt.also.included=也包含在代理上下文中:
 skills.view.activity.log=活动日志
+skills.view.docs.tooltip=查看技能指南
+skills.view.settings.tooltip=配置技能
 
 # File / folder chooser
 file.chooser.folder.select=选择

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -258,6 +258,8 @@ settings.skills.delete.file.title=刪除檔案
 settings.skills.delete.file.confirm=刪除 "{0}"？此操作無法復原。
 settings.skills.delete.folder.title=刪除資料夾
 settings.skills.delete.folder.confirm=刪除 "{0}" 及其中的所有技能？此操作無法復原。
+settings.skills.delete.all.title=刪除所有技能
+settings.skills.delete.all.confirm=要刪除所有技能嗎？此操作將永久移除所有技能資料夾，無法還原。
 settings.skills.import.success.title=匯入成功
 settings.skills.add.file=新增檔案
 settings.skills.add.file.name=檔案名稱
@@ -424,23 +426,13 @@ action.close=關閉
 action.back=返回
 action.retry=重試
 action.done=完成
+action.refresh=重新整理
 
 # Star Prompt
 star.prompt.title=如果 Askimo 對您有所幫助…
 star.prompt.message=Askimo 是一個由社群支持開發與維護的開源專案。\n\n如果它提升了您的工作流程，歡迎在 GitHub 上為專案點亮 ⭐ 以示支持。\n\n您的支持能幫助更多人認識 Askimo，並促進專案持續發展。
 star.prompt.star.button=加入支持 Askimo
 star.prompt.maybe.later=暫時不要
-
-# Analytics Consent
-analytics.consent.title=協助大家讓 Askimo 變得更好
-analytics.consent.message=Askimo 是免費且開源的。分享匿名使用資料是一种小小的回饵方式 — 它幫助我們了解接下來該打造什麼。
-analytics.consent.collected.yes.features=✅  使用了哪些功能（如 RAG、MCP 工具、Plans）
-analytics.consent.collected.yes.version=✅  應用程式版本和作業系統類型
-analytics.consent.collected.no.conversations=❌  不含任何對話內容或提示詞
-analytics.consent.collected.no.personal=❌  不含個人資料、檔案或 API 金鑰 — 永遠不會
-analytics.consent.detail=這有助於我們了解什麼最重要並集中開發精力。您可以隨時在「設定 → 進階」中關閉此功能。
-analytics.consent.decline=不了，謝謝
-analytics.consent.accept=是的，協助改進 Askimo
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=匿名分析
@@ -1203,6 +1195,8 @@ skills.view.system.prompt.file=檔案
 skills.view.system.prompt.files=檔案
 skills.view.system.prompt.also.included=也包含在代理程式上下文中:
 skills.view.activity.log=活動記錄
+skills.view.docs.tooltip=檢視技能指南
+skills.view.settings.tooltip=設定技能
 
 # File / folder chooser
 file.chooser.folder.select=選取

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -994,6 +994,11 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                                         onNavigateToSkills = {
                                                             currentView = View.SKILLS
                                                         },
+                                                        onNavigateToSkillsSettings = {
+                                                            settingsSection = SettingsSection.SKILLS
+                                                            previousView = currentView
+                                                            currentView = View.SETTINGS
+                                                        },
                                                         onNavigateToPlanDetail = {
                                                             currentView = View.PLAN_DETAIL
                                                         },
@@ -1702,6 +1707,7 @@ fun mainContent(
     onNavigateToProjects: () -> Unit = {},
     onNavigateToPlans: () -> Unit = {},
     onNavigateToSkills: () -> Unit = {},
+    onNavigateToSkillsSettings: () -> Unit = {},
     onNavigateToPlanDetail: () -> Unit = {},
     onNavigateToPlanEditor: () -> Unit = {},
     onNavigateToMcpSettings: () -> Unit = {},
@@ -1896,7 +1902,9 @@ fun mainContent(
                 modifier = Modifier.fillMaxSize(),
             )
 
-            View.SKILLS -> skillsView()
+            View.SKILLS -> skillsView(
+                onNavigateToSkillsSettings = onNavigateToSkillsSettings,
+            )
         }
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/skills/SkillRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/skills/SkillRepository.kt
@@ -441,6 +441,30 @@ class SkillRepository {
         return true
     }
 
+    /**
+     * Deletes all top-level entries (files and folders) inside the skills directory,
+     * effectively removing all skills.
+     *
+     * @return Number of top-level entries deleted.
+     */
+    fun deleteAll(): Int {
+        val skillsDir = AskimoHome.skillsDir()
+        if (!Files.isDirectory(skillsDir)) return 0
+        var count = 0
+        Files.list(skillsDir).use { stream ->
+            stream.forEach { entry ->
+                if (Files.isDirectory(entry)) {
+                    Files.walk(entry).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+                } else {
+                    Files.deleteIfExists(entry)
+                }
+                count++
+            }
+        }
+        log.debug("Deleted all skills ({} top-level entries)", count)
+        return count
+    }
+
     // ── Import ───────────────────────────────────────────────────────────────
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/skills/agent/ClaudeAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/skills/agent/ClaudeAgent.kt
@@ -13,19 +13,14 @@ import java.io.File
  *
  * Invocation:
  * ```
- * claude --print -
+ * claude --print --dangerously-skip-permissions --append-system-prompt "<systemPrompt>"
  * ```
- * - `--print`  Non-interactive mode: print the response to stdout and exit.
- * - `-`        Read the prompt from stdin.
+ * - `--print`                        Non-interactive mode: print the response to stdout and exit.
+ * - `--dangerously-skip-permissions` Auto-approve all tool actions (no interactive confirmation).
+ * - `--append-system-prompt`         Appends text to Claude's built-in system prompt at the API level,
+ *                                    without touching any files on disk.
  *
- * The combined prompt written to stdin:
- * ```
- * <system prompt>
- *
- * ---
- *
- * <user input>
- * ```
+ * Only [userInput] is written to stdin.
  */
 class ClaudeAgent : ExternalAgent {
 
@@ -79,23 +74,36 @@ class ClaudeAgent : ExternalAgent {
         onToken: (String) -> Unit,
         onStatus: (String) -> Unit,
     ): Result<String> = runCatching {
-        val combinedPrompt = buildPrompt(systemPrompt, userInput)
         val claudePath = resolveClaudePath() ?: error("claude CLI not found on PATH")
+        val effectiveWorkDir = workDir ?: File(System.getProperty("user.home"))
 
-        log.debug("Starting claude --print for skill execution ({} chars, workDir={})", combinedPrompt.length, workDir)
+        log.debug("Starting claude --print for skill execution ({} chars systemPrompt, workDir={})", systemPrompt.length, effectiveWorkDir)
 
-        val process = ProcessBuilderExt(claudePath, "--print", "--verbose", "--output-format", "stream-json")
+        val cmd = buildList {
+            add(claudePath)
+            add("--print")
+            add("--dangerously-skip-permissions")
+            add("--verbose")
+            add("--output-format")
+            add("stream-json")
+            if (systemPrompt.isNotBlank()) {
+                add("--append-system-prompt")
+                add(systemPrompt.trim())
+            }
+        }
+
+        val process = ProcessBuilderExt(*cmd.toTypedArray())
             .apply {
-                if (workDir != null) {
-                    workDir.mkdirs()
-                    directory(workDir)
-                }
+                effectiveWorkDir.mkdirs()
+                directory(effectiveWorkDir)
                 environment()["HOME"] = System.getProperty("user.home")
             }
             .start()
 
-        // Write prompt to stdin then close so claude sees EOF
-        process.outputStream.bufferedWriter().use { it.write(combinedPrompt) }
+        // Write only user input to stdin
+        process.outputStream.bufferedWriter().use { writer ->
+            if (userInput.isNotBlank()) writer.write(userInput.trim() + "\n")
+        }
 
         // Drain stderr in background to prevent blocking
         val stderrOutput = StringBuilder()
@@ -120,46 +128,110 @@ class ClaudeAgent : ExternalAgent {
             }
             log.debug("claude event: type={} line {}", event.type, line)
             when (event.type) {
-                "content_block_delta" -> {
-                    @Suppress("UNCHECKED_CAST")
-                    val delta = event.fields["delta"] as? Map<String, Any>
-                    val text = delta?.get("text") as? String ?: return@forEachLine
-                    if (text.isNotBlank()) {
-                        output.append(text)
-                        onToken(text)
+                "system" -> {
+                    val subtype = event.fields["subtype"] as? String
+                    if (subtype == "init") {
+                        val model = event.fields["model"] as? String
+                        val permissionMode = event.fields["permissionMode"] as? String
+                        val version = event.fields["claude_code_version"] as? String
+                        val summary = buildString {
+                            append("claude init")
+                            if (model != null) append(" | model: $model")
+                            if (version != null) append(" | v$version")
+                            if (permissionMode != null) append(" | permissions: $permissionMode")
+                        }
+                        onStatus(summary)
                     }
                 }
 
-                "message_delta" -> {
-                    @Suppress("UNCHECKED_CAST")
-                    val usage = event.fields["usage"] as? Map<String, Any>
-                    val inputTokens = usage?.get("input_tokens")
-                    val outputTokens = usage?.get("output_tokens")
-                    val stopReason = event.fields["stop_reason"] as? String
-                    val summary = buildString {
-                        if (stopReason != null) append("stop: $stopReason")
-                        if (inputTokens != null) append(" | input tokens: $inputTokens")
-                        if (outputTokens != null) append(" | output tokens: $outputTokens")
+                "assistant" -> {
+                    val blocks = ClaudeStreamJsonEventParser.extractContentBlocks(event.fields)
+                    for (block in blocks) {
+                        when (block.type) {
+                            "text" -> {
+                                val text = block.fields["text"] as? String ?: continue
+                                if (text.isNotBlank()) onToken(text)
+                            }
+
+                            "tool_use" -> {
+                                val toolName = block.fields["name"] as? String ?: "tool"
+
+                                @Suppress("UNCHECKED_CAST")
+                                val input = block.fields["input"] as? Map<String, Any>
+                                val summary = buildString {
+                                    append("tool: $toolName")
+                                    if (input != null) {
+                                        // Show the most useful key: file_path, command, or first key
+                                        val detail = (input["file_path"] ?: input["command"] ?: input.values.firstOrNull())
+                                            ?.toString()?.let {
+                                                if (it.length > 80) it.take(77) + "…" else it
+                                            }
+                                        if (detail != null) append(" → $detail")
+                                    }
+                                }
+                                onStatus(summary)
+                            }
+
+                            "thinking" -> {
+                                val thinking = block.fields["thinking"] as? String ?: continue
+                                log.debug("claude thinking: {}", thinking.take(200))
+                            }
+                        }
                     }
-                    if (summary.isNotBlank()) onStatus(summary)
                 }
 
-                "tool_use" -> {
-                    val toolName = event.fields["name"] as? String ?: "tool"
-                    val input = event.fields["input"]
-                    onStatus("tool: $toolName${if (input != null) " $input" else ""}")
+                "user" -> {
+                    // tool_use_result can be a Map (file op) or String (error/plain result)
+                    when (val toolResult = ClaudeStreamJsonEventParser.extractToolUseResult(event.fields)) {
+                        is Map<*, *> -> {
+                            @Suppress("UNCHECKED_CAST")
+                            val resultMap = toolResult as Map<String, Any>
+                            val opType = resultMap["type"] as? String
+                            val filePath = resultMap["filePath"] as? String
+                            if (opType != null && filePath != null) {
+                                val shortPath = filePath.substringAfterLast("/")
+                                onStatus("✓ $opType: $shortPath")
+                            }
+                        }
+
+                        is String -> {
+                            // Errors like "Answer questions?" from AskUserQuestion — debug only
+                            log.debug("claude tool_use_result: {}", toolResult.take(200))
+                        }
+                    }
                 }
 
-                else -> {
-                    val rendered = event.fields.entries
-                        .joinToString(", ") { "${it.key}=${it.value}" }
-                    if (rendered.isNotBlank()) log.debug("claude {}: {}", event.type, rendered)
+                "result" -> {
+                    val subtype = event.fields["subtype"] as? String
+                    if (subtype == "success") {
+                        val result = event.fields["result"] as? String ?: return@forEachLine
+                        if (result.isNotBlank()) {
+                            output.append(result)
+                            onToken(result)
+                        }
+                        val costUsd = event.fields["total_cost_usd"]
+                        val durationMs = event.fields["duration_ms"]
+                        val numTurns = event.fields["num_turns"]
+                        val stopReason = event.fields["stop_reason"] as? String
+                        val summary = buildString {
+                            append("result: success")
+                            if (stopReason != null) append(" | stop: $stopReason")
+                            if (numTurns != null) append(" | turns: $numTurns")
+                            if (durationMs != null) {
+                                val secs = (durationMs.toString().toDoubleOrNull() ?: 0.0) / 1000.0
+                                append(" | duration: ${"%.1f".format(secs)}s")
+                            }
+                            if (costUsd != null) append(" | cost: \$$costUsd")
+                        }
+                        onStatus(summary)
+                    }
                 }
             }
         }
 
         val exitCode = process.waitFor()
         stderrThread.join(2_000)
+
         if (exitCode != 0) {
             val errMsg = stderrOutput.toString().trim()
             log.warn("claude exited with code {} — stderr: {}", exitCode, errMsg)
@@ -169,16 +241,5 @@ class ClaudeAgent : ExternalAgent {
         output.toString().trimEnd()
     }.onFailure { e ->
         log.error("ClaudeAgent run failed: {}", e.message, e)
-    }
-
-    // ── Helpers ───────────────────────────────────────────────────────────────
-
-    private fun buildPrompt(systemPrompt: String, userInput: String): String = buildString {
-        append(systemPrompt.trim())
-        if (userInput.isNotBlank()) {
-            append("\n\n---\n\n")
-            append(userInput.trim())
-        }
-        append("\n")
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/skills/agent/ClaudeStreamJsonEventParser.kt
+++ b/shared/src/main/kotlin/io/askimo/core/skills/agent/ClaudeStreamJsonEventParser.kt
@@ -6,11 +6,24 @@ package io.askimo.core.skills.agent
 
 /**
  * Parses a single `stream-json` event line emitted by the Claude CLI (`claude --output-format stream-json`).
- * Reuses the same parser infrastructure as [GeminiStreamJsonEventParser].
+ * Reuses the JSON parsing infrastructure from [GeminiStreamJsonEventParser].
+ *
+ * Claude events embed interesting data inside `message.content[]` — a JSON array of content blocks.
+ * This parser extracts that array into a typed list so [ClaudeAgent] can iterate over content blocks.
  */
 object ClaudeStreamJsonEventParser {
 
     private val EXCLUDED_FIELDS = setOf("type", "index")
+
+    /**
+     * A parsed content block from `message.content[]`.
+     * @property type   `"text"`, `"tool_use"`, or `"thinking"`
+     * @property fields All remaining fields for that block (e.g. `text`, `name`, `input`, `thinking`)
+     */
+    data class ContentBlock(
+        val type: String,
+        val fields: Map<String, Any>,
+    )
 
     fun parse(line: String): GeminiStreamJsonEventParser.StreamJsonEvent? {
         if (line.isBlank() || !line.trimStart().startsWith("{")) return null
@@ -18,5 +31,49 @@ object ClaudeStreamJsonEventParser {
         val type = fields["type"] as? String ?: return null
         val remaining = fields.filterKeys { it !in EXCLUDED_FIELDS }
         return GeminiStreamJsonEventParser.StreamJsonEvent(type = type, fields = remaining)
+    }
+
+    /**
+     * Extracts the `message.content[]` array from an `assistant` or `user` event's fields,
+     * returning a list of [ContentBlock]s. Returns empty list if not present or unparseable.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun extractContentBlocks(fields: Map<String, Any>): List<ContentBlock> {
+        val message = fields["message"] as? Map<String, Any> ?: return emptyList()
+        val contentRaw = message["content"] ?: return emptyList()
+
+        // content is stored as a raw JSON array string by GeminiStreamJsonEventParser.readValue
+        val contentJson = contentRaw as? String ?: return emptyList()
+        if (!contentJson.startsWith("[")) return emptyList()
+
+        return parseArray(contentJson).mapNotNull { item ->
+            val block = item as? Map<String, Any> ?: return@mapNotNull null
+            val blockType = block["type"] as? String ?: return@mapNotNull null
+            ContentBlock(type = blockType, fields = block.filterKeys { it != "type" })
+        }
+    }
+
+    /**
+     * Extracts the `tool_use_result` from a `user` event's fields.
+     * Returns the raw value (String or Map) or null.
+     */
+    fun extractToolUseResult(fields: Map<String, Any>): Any? = fields["tool_use_result"]
+
+    /**
+     * Parses a JSON array string `[...]` into a list of values (String, Boolean, Map, etc.).
+     */
+    internal fun parseArray(json: String): List<Any> {
+        val s = json.trim()
+        if (!s.startsWith("[") || !s.endsWith("]")) return emptyList()
+        val result = mutableListOf<Any>()
+        var i = 1 // skip '['
+        while (i < s.length) {
+            while (i < s.length && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' || s[i] == ',')) i++
+            if (i >= s.length || s[i] == ']') break
+            val (value, afterValue) = GeminiStreamJsonEventParser.readValue(s, i) ?: break
+            result.add(value)
+            i = afterValue
+        }
+        return result
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/skills/agent/GeminiStreamJsonEventParser.kt
+++ b/shared/src/main/kotlin/io/askimo/core/skills/agent/GeminiStreamJsonEventParser.kt
@@ -194,7 +194,7 @@ object GeminiStreamJsonEventParser {
      * Reads a JSON value (string, object, boolean, array, or number) starting at [pos].
      * Arrays and numbers are returned as raw strings.
      */
-    private fun readValue(s: String, pos: Int): Pair<Any, Int>? {
+    internal fun readValue(s: String, pos: Int): Pair<Any, Int>? {
         if (pos >= s.length) return null
         return when (s[pos]) {
             '"' -> {

--- a/shared/src/main/kotlin/io/askimo/core/skills/repository/SkillRunHistoryRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/skills/repository/SkillRunHistoryRepository.kt
@@ -90,6 +90,16 @@ class SkillRunHistoryRepository internal constructor(
     }
 
     /**
+     * Deletes a single run record by [id].
+     */
+    fun deleteById(id: String) {
+        transaction(database) {
+            SkillRunHistoryTable.deleteWhere { SkillRunHistoryTable.id eq id }
+        }
+        log.debug("Deleted skill run record '{}'", id)
+    }
+
+    /**
      * Deletes all run records for the given [skillPath].
      */
     fun deleteBySkillPath(skillPath: String) {

--- a/shared/src/test/kotlin/io/askimo/core/skills/ClaudeStreamJsonEventParserTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/skills/ClaudeStreamJsonEventParserTest.kt
@@ -1,0 +1,223 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Hai Nguyen
+ */
+package io.askimo.core.skills
+
+import io.askimo.core.skills.agent.ClaudeStreamJsonEventParser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ClaudeStreamJsonEventParserTest {
+
+    // ── parse() ───────────────────────────────────────────────────────────────
+
+    @Nested
+    inner class Parse {
+
+        @Test
+        fun `blank line returns null`() {
+            assertNull(ClaudeStreamJsonEventParser.parse(""))
+            assertNull(ClaudeStreamJsonEventParser.parse("   "))
+        }
+
+        @Test
+        fun `non-json line returns null`() {
+            assertNull(ClaudeStreamJsonEventParser.parse("not json"))
+        }
+
+        @Test
+        fun `system init event extracts top-level fields`() {
+            val line = """{"type":"system","subtype":"init","cwd":"/work","session_id":"abc123","model":"claude-haiku-4-5-20251001","permissionMode":"bypassPermissions","claude_code_version":"2.1.138","tools":["Bash","Write"],"uuid":"u1"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("system", event!!.type)
+            assertEquals("init", event.fields["subtype"])
+            assertEquals("claude-haiku-4-5-20251001", event.fields["model"])
+            assertEquals("bypassPermissions", event.fields["permissionMode"])
+            assertEquals("2.1.138", event.fields["claude_code_version"])
+            assertNull(event.fields["type"])
+        }
+
+        @Test
+        fun `assistant event with text content block`() {
+            val line = """{"type":"assistant","message":{"model":"claude-haiku-4-5-20251001","id":"msg_01","type":"message","role":"assistant","content":[{"type":"text","text":"Hello, I will create the project."}],"stop_reason":null,"usage":{"input_tokens":9,"output_tokens":7}},"session_id":"s1","uuid":"u2"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("assistant", event!!.type)
+            assertTrue(event.fields["message"] is Map<*, *>)
+            assertNull(event.fields["type"])
+        }
+
+        @Test
+        fun `result success event extracts result and stats fields`() {
+            val line = """{"type":"result","subtype":"success","is_error":false,"duration_ms":5975,"num_turns":1,"result":"# Done\n\nProject created.","stop_reason":"end_turn","total_cost_usd":0.011,"uuid":"u3"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("result", event!!.type)
+            assertEquals("success", event.fields["subtype"])
+            assertEquals("# Done\n\nProject created.", event.fields["result"])
+            assertEquals("end_turn", event.fields["stop_reason"])
+            assertEquals("5975", event.fields["duration_ms"])
+            assertEquals("1", event.fields["num_turns"])
+            assertNull(event.fields["type"])
+        }
+
+        @Test
+        fun `user event with tool_use_result string`() {
+            val line = """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"Answer questions?","is_error":true,"tool_use_id":"t1"}]},"tool_use_result":"Error: Answer questions?","uuid":"u4"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("user", event!!.type)
+            assertEquals("Error: Answer questions?", event.fields["tool_use_result"])
+        }
+
+        @Test
+        fun `user event with tool_use_result map for file creation`() {
+            val line = """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"File created","tool_use_id":"t2"}]},"tool_use_result":{"type":"create","filePath":"/work/pom.xml","content":"<project/>"},"uuid":"u5"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("user", event!!.type)
+            assertTrue(event.fields["tool_use_result"] is Map<*, *>)
+        }
+
+        @Test
+        fun `handles escaped characters in strings`() {
+            val line = """{"type":"result","subtype":"success","result":"line1\nline2\t\"quoted\"","uuid":"u6"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("line1\nline2\t\"quoted\"", event!!.fields["result"])
+        }
+    }
+
+    // ── extractContentBlocks() ────────────────────────────────────────────────
+
+    @Nested
+    inner class ExtractContentBlocks {
+
+        @Test
+        fun `returns text block`() {
+            val line = """{"type":"assistant","message":{"model":"m","id":"i","type":"message","role":"assistant","content":[{"type":"text","text":"Hello world"}],"stop_reason":null},"uuid":"u7"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            val blocks = ClaudeStreamJsonEventParser.extractContentBlocks(event.fields)
+            assertEquals(1, blocks.size)
+            assertEquals("text", blocks[0].type)
+            assertEquals("Hello world", blocks[0].fields["text"])
+        }
+
+        @Test
+        fun `returns tool_use block with name and input`() {
+            val line = """{"type":"assistant","message":{"model":"m","id":"i","type":"message","role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"mkdir -p spring-boot","description":"Create dir"}}],"stop_reason":null},"uuid":"u8"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            val blocks = ClaudeStreamJsonEventParser.extractContentBlocks(event.fields)
+            assertEquals(1, blocks.size)
+            assertEquals("tool_use", blocks[0].type)
+            assertEquals("Bash", blocks[0].fields["name"])
+            val input = blocks[0].fields["input"]
+            assertTrue(input is Map<*, *>)
+            @Suppress("UNCHECKED_CAST")
+            val inputMap = input as Map<String, Any>
+            assertEquals("mkdir -p spring-boot", inputMap["command"])
+        }
+
+        @Test
+        fun `returns thinking block`() {
+            val line = """{"type":"assistant","message":{"model":"m","id":"i","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"I need to plan this carefully.","signature":"sig1"}],"stop_reason":null},"uuid":"u9"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            val blocks = ClaudeStreamJsonEventParser.extractContentBlocks(event.fields)
+            assertEquals(1, blocks.size)
+            assertEquals("thinking", blocks[0].type)
+            assertEquals("I need to plan this carefully.", blocks[0].fields["thinking"])
+        }
+
+        @Test
+        fun `returns multiple mixed blocks in order`() {
+            val line = """{"type":"assistant","message":{"model":"m","id":"i","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"plan"},{"type":"text","text":"I'll help you."},{"type":"tool_use","id":"t1","name":"Write","input":{"file_path":"pom.xml","content":"<project/>"}}],"stop_reason":null},"uuid":"u10"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            val blocks = ClaudeStreamJsonEventParser.extractContentBlocks(event.fields)
+            assertEquals(3, blocks.size)
+            assertEquals("thinking", blocks[0].type)
+            assertEquals("text", blocks[1].type)
+            assertEquals("tool_use", blocks[2].type)
+            assertEquals("Write", blocks[2].fields["name"])
+        }
+
+        @Test
+        fun `returns empty list when no message field`() {
+            val line = """{"type":"result","subtype":"success","result":"done","uuid":"u11"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            val blocks = ClaudeStreamJsonEventParser.extractContentBlocks(event.fields)
+            assertTrue(blocks.isEmpty())
+        }
+    }
+
+    // ── extractToolUseResult() ────────────────────────────────────────────────
+
+    @Nested
+    inner class ExtractToolUseResult {
+
+        @Test
+        fun `returns string for error result`() {
+            val line = """{"type":"user","message":{"role":"user","content":[]},"tool_use_result":"Error: Answer questions?","uuid":"u12"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            val result = ClaudeStreamJsonEventParser.extractToolUseResult(event.fields)
+            assertEquals("Error: Answer questions?", result)
+        }
+
+        @Test
+        fun `returns map for file create result`() {
+            val line = """{"type":"user","message":{"role":"user","content":[]},"tool_use_result":{"type":"create","filePath":"/work/pom.xml","content":"<project/>"},"uuid":"u13"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            val result = ClaudeStreamJsonEventParser.extractToolUseResult(event.fields)
+            assertTrue(result is Map<*, *>)
+            @Suppress("UNCHECKED_CAST")
+            val map = result as Map<String, Any>
+            assertEquals("create", map["type"])
+            assertEquals("/work/pom.xml", map["filePath"])
+        }
+
+        @Test
+        fun `returns null when field absent`() {
+            val line = """{"type":"result","subtype":"success","result":"done","uuid":"u14"}"""
+            val event = ClaudeStreamJsonEventParser.parse(line)!!
+            assertNull(ClaudeStreamJsonEventParser.extractToolUseResult(event.fields))
+        }
+    }
+
+    // ── parseArray() ─────────────────────────────────────────────────────────
+
+    @Nested
+    inner class ParseArray {
+
+        @Test
+        fun `parses array of strings`() {
+            val result = ClaudeStreamJsonEventParser.parseArray("""["Bash","Write","Read"]""")
+            assertEquals(3, result.size)
+            assertEquals("Bash", result[0])
+            assertEquals("Write", result[1])
+            assertEquals("Read", result[2])
+        }
+
+        @Test
+        fun `parses array of objects`() {
+            val result = ClaudeStreamJsonEventParser.parseArray("""[{"type":"text","text":"hello"},{"type":"tool_use","name":"Bash"}]""")
+            assertEquals(2, result.size)
+            assertTrue(result[0] is Map<*, *>)
+            @Suppress("UNCHECKED_CAST")
+            val first = result[0] as Map<String, Any>
+            assertEquals("text", first["type"])
+            assertEquals("hello", first["text"])
+        }
+
+        @Test
+        fun `returns empty for invalid input`() {
+            assertTrue(ClaudeStreamJsonEventParser.parseArray("not an array").isEmpty())
+            assertTrue(ClaudeStreamJsonEventParser.parseArray("{}").isEmpty())
+            assertTrue(ClaudeStreamJsonEventParser.parseArray("").isEmpty())
+        }
+    }
+}

--- a/shared/src/test/kotlin/io/askimo/core/skills/GeminiStreamJsonEventParserTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/skills/GeminiStreamJsonEventParserTest.kt
@@ -9,129 +9,137 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class GeminiStreamJsonEventParserTest {
 
     // ── parse() ───────────────────────────────────────────────────────────────
 
-    @Test
-    fun `parse tool_use event extracts type, tool_name and parameters`() {
-        val line = """{"type":"tool_use","timestamp":"2026-05-08T18:49:16.261Z","tool_name":"write_file","tool_id":"jy4761xi","parameters":{"content":"package com.example;\n","file_path":"src/Main.java"}}"""
-        val event = GeminiStreamJsonEventParser.parse(line)
-        assertNotNull(event)
-        assertEquals("tool_use", event!!.type)
-        assertEquals("write_file", event.fields["tool_name"])
-        // timestamp, role, tool_id excluded; type excluded
-        assertNull(event.fields["timestamp"])
-        assertNull(event.fields["tool_id"])
-        assertNull(event.fields["type"])
-        val params = event.fields["parameters"]
-        assertTrue(params is Map<*, *>)
-        @Suppress("UNCHECKED_CAST")
-        val p = params as Map<String, Any>
-        assertEquals("package com.example;\n", p["content"])
-        assertEquals("src/Main.java", p["file_path"])
-    }
+    @Nested
+    inner class Parse {
 
-    @Test
-    fun `parse tool_result event extracts status`() {
-        val line = """{"type":"tool_result","timestamp":"2026-05-08T18:49:16.730Z","tool_id":"4asg0jeh","status":"success"}"""
-        val event = GeminiStreamJsonEventParser.parse(line)
-        assertNotNull(event)
-        assertEquals("tool_result", event!!.type)
-        assertEquals("success", event.fields["status"])
-        assertNull(event.fields["timestamp"])
-        assertNull(event.fields["tool_id"])
-    }
+        @Test
+        fun `tool_use event extracts type, tool_name and parameters`() {
+            val line = """{"type":"tool_use","timestamp":"2026-05-08T18:49:16.261Z","tool_name":"write_file","tool_id":"jy4761xi","parameters":{"content":"package com.example;\n","file_path":"src/Main.java"}}"""
+            val event = GeminiStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("tool_use", event!!.type)
+            assertEquals("write_file", event.fields["tool_name"])
+            assertNull(event.fields["timestamp"])
+            assertNull(event.fields["tool_id"])
+            assertNull(event.fields["type"])
+            val params = event.fields["parameters"]
+            assertTrue(params is Map<*, *>)
+            @Suppress("UNCHECKED_CAST")
+            val p = params as Map<String, Any>
+            assertEquals("package com.example;\n", p["content"])
+            assertEquals("src/Main.java", p["file_path"])
+        }
 
-    @Test
-    fun `parse message event extracts content and delta`() {
-        val line = """{"type":"message","timestamp":"2026-05-08T18:49:26.880Z","role":"assistant","content":"Hello world","delta":true}"""
-        val event = GeminiStreamJsonEventParser.parse(line)
-        assertNotNull(event)
-        assertEquals("message", event!!.type)
-        assertEquals("Hello world", event.fields["content"])
-        assertEquals(true, event.fields["delta"])
-        assertNull(event.fields["role"])
-        assertNull(event.fields["timestamp"])
-    }
+        @Test
+        fun `tool_result event extracts status`() {
+            val line = """{"type":"tool_result","timestamp":"2026-05-08T18:49:16.730Z","tool_id":"4asg0jeh","status":"success"}"""
+            val event = GeminiStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("tool_result", event!!.type)
+            assertEquals("success", event.fields["status"])
+            assertNull(event.fields["timestamp"])
+            assertNull(event.fields["tool_id"])
+        }
 
-    @Test
-    fun `parse content event extracts value`() {
-        val line = """{"type":"content","value":"some streamed text"}"""
-        val event = GeminiStreamJsonEventParser.parse(line)
-        assertNotNull(event)
-        assertEquals("content", event!!.type)
-        assertEquals("some streamed text", event.fields["value"])
-    }
+        @Test
+        fun `message event extracts content and delta`() {
+            val line = """{"type":"message","timestamp":"2026-05-08T18:49:26.880Z","role":"assistant","content":"Hello world","delta":true}"""
+            val event = GeminiStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("message", event!!.type)
+            assertEquals("Hello world", event.fields["content"])
+            assertEquals(true, event.fields["delta"])
+            assertNull(event.fields["role"])
+            assertNull(event.fields["timestamp"])
+        }
 
-    @Test
-    fun `parse result event extracts content field`() {
-        val line = """{"type":"result","content":"Final answer here"}"""
-        val event = GeminiStreamJsonEventParser.parse(line)
-        assertNotNull(event)
-        assertEquals("result", event!!.type)
-        assertEquals("Final answer here", event.fields["content"])
-    }
+        @Test
+        fun `content event extracts value`() {
+            val line = """{"type":"content","value":"some streamed text"}"""
+            val event = GeminiStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("content", event!!.type)
+            assertEquals("some streamed text", event.fields["value"])
+        }
 
-    @Test
-    fun `parse blank line returns null`() {
-        assertNull(GeminiStreamJsonEventParser.parse(""))
-        assertNull(GeminiStreamJsonEventParser.parse("   "))
-    }
+        @Test
+        fun `result event extracts content field`() {
+            val line = """{"type":"result","content":"Final answer here"}"""
+            val event = GeminiStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("result", event!!.type)
+            assertEquals("Final answer here", event.fields["content"])
+        }
 
-    @Test
-    fun `parse non-json line returns null`() {
-        assertNull(GeminiStreamJsonEventParser.parse("not json"))
-    }
+        @Test
+        fun `blank line returns null`() {
+            assertNull(GeminiStreamJsonEventParser.parse(""))
+            assertNull(GeminiStreamJsonEventParser.parse("   "))
+        }
 
-    @Test
-    fun `parse handles escaped newlines and quotes in string values`() {
-        val line = """{"type":"content","value":"line1\nline2\t\"quoted\""}"""
-        val event = GeminiStreamJsonEventParser.parse(line)
-        assertNotNull(event)
-        assertEquals("line1\nline2\t\"quoted\"", event!!.fields["value"])
+        @Test
+        fun `non-json line returns null`() {
+            assertNull(GeminiStreamJsonEventParser.parse("not json"))
+        }
+
+        @Test
+        fun `handles escaped newlines and quotes in string values`() {
+            val line = """{"type":"content","value":"line1\nline2\t\"quoted\""}"""
+            val event = GeminiStreamJsonEventParser.parse(line)
+            assertNotNull(event)
+            assertEquals("line1\nline2\t\"quoted\"", event!!.fields["value"])
+        }
     }
 
     // ── render() ─────────────────────────────────────────────────────────────
 
-    @Test
-    fun `render tool_use promotes tool_name as sub-header with parameters`() {
-        val line = """{"type":"tool_use","timestamp":"2026-05-08T18:49:16.261Z","tool_name":"write_file","tool_id":"jy4761xi","parameters":{"content":"package com.example;\n","file_path":"src/Main.java"}}"""
-        val event = GeminiStreamJsonEventParser.parse(line)!!
-        val rendered = GeminiStreamJsonEventParser.render(event)
-        assertTrue(rendered.startsWith("tool_use"), "Should start with type")
-        assertTrue(rendered.contains("write_file:"), "Should show tool_name as sub-header")
-        assertTrue(rendered.contains("file_path: src/Main.java"), "Should show file_path parameter")
-        assertTrue(rendered.contains("content:"), "Should show content parameter")
-    }
+    @Nested
+    inner class Render {
 
-    @Test
-    fun `render tool_result shows status`() {
-        val line = """{"type":"tool_result","timestamp":"2026-05-08T18:49:16.730Z","tool_id":"4asg0jeh","status":"success"}"""
-        val event = GeminiStreamJsonEventParser.parse(line)!!
-        val rendered = GeminiStreamJsonEventParser.render(event)
-        assertTrue(rendered.startsWith("tool_result:"))
-        assertTrue(rendered.contains("status: success"))
-    }
+        @Test
+        fun `tool_use promotes tool_name as sub-header with parameters`() {
+            val line = """{"type":"tool_use","timestamp":"2026-05-08T18:49:16.261Z","tool_name":"write_file","tool_id":"jy4761xi","parameters":{"content":"package com.example;\n","file_path":"src/Main.java"}}"""
+            val event = GeminiStreamJsonEventParser.parse(line)!!
+            val rendered = GeminiStreamJsonEventParser.render(event)
+            assertTrue(rendered.startsWith("tool_use"), "Should start with type")
+            assertTrue(rendered.contains("write_file:"), "Should show tool_name as sub-header")
+            assertTrue(rendered.contains("file_path: src/Main.java"), "Should show file_path parameter")
+            assertTrue(rendered.contains("content:"), "Should show content parameter")
+        }
 
-    @Test
-    fun `render message shows content and delta`() {
-        val line = """{"type":"message","timestamp":"2026-05-08T18:49:26.880Z","role":"assistant","content":"Hello world","delta":true}"""
-        val event = GeminiStreamJsonEventParser.parse(line)!!
-        val rendered = GeminiStreamJsonEventParser.render(event)
-        assertTrue(rendered.startsWith("message:"))
-        assertTrue(rendered.contains("content: Hello world"))
-        assertTrue(rendered.contains("delta: true"))
-    }
+        @Test
+        fun `tool_result shows status`() {
+            val line = """{"type":"tool_result","timestamp":"2026-05-08T18:49:16.730Z","tool_id":"4asg0jeh","status":"success"}"""
+            val event = GeminiStreamJsonEventParser.parse(line)!!
+            val rendered = GeminiStreamJsonEventParser.render(event)
+            assertTrue(rendered.startsWith("tool_result:"))
+            assertTrue(rendered.contains("status: success"))
+        }
 
-    @Test
-    fun `render truncates long string values`() {
-        val longValue = "x".repeat(200)
-        val line = """{"type":"content","value":"$longValue"}"""
-        val event = GeminiStreamJsonEventParser.parse(line)!!
-        val rendered = GeminiStreamJsonEventParser.render(event)
-        assertTrue(rendered.contains("…"), "Long value should be truncated with ellipsis")
+        @Test
+        fun `message shows content and delta`() {
+            val line = """{"type":"message","timestamp":"2026-05-08T18:49:26.880Z","role":"assistant","content":"Hello world","delta":true}"""
+            val event = GeminiStreamJsonEventParser.parse(line)!!
+            val rendered = GeminiStreamJsonEventParser.render(event)
+            assertTrue(rendered.startsWith("message:"))
+            assertTrue(rendered.contains("content: Hello world"))
+            assertTrue(rendered.contains("delta: true"))
+        }
+
+        @Test
+        fun `truncates long string values`() {
+            val longValue = "x".repeat(200)
+            val line = """{"type":"content","value":"$longValue"}"""
+            val event = GeminiStreamJsonEventParser.parse(line)!!
+            val rendered = GeminiStreamJsonEventParser.render(event)
+            assertTrue(rendered.contains("…"), "Long value should be truncated with ellipsis")
+        }
     }
 }


### PR DESCRIPTION
- Enable deleting all top-level skills via SkillRepository
- Add per-record deletion to skill run history with UI integration
- Improve Skills views with tooltips and i18n enhancements across locales
- Update Skill gallery and history panels for better UX and safety on bulk actions
- Extend Claude event parser; add test coverage for ClaudeStreamJsonEventParser
- Housekeeping: clean up string resources and docstrings
- Refactor parser access for expanded testability