### PR TITLE
chore: update CI workflows, add share helper, refactor prompt UI,

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -347,7 +347,7 @@ jobs:
         if: steps.meta.outputs.mac_arm_url != ''
         uses: actions/checkout@v6
         with:
-          repository: ${{ vars.TAP_REPO || 'haiphucnguyen/homebrew-askimo' }}
+          repository: ${{ vars.TAP_REPO || 'askimo-ai/homebrew-askimo' }}
           token: ${{ secrets.TAP_PUSH_TOKEN }}
           path: tap
           fetch-depth: 0
@@ -438,7 +438,7 @@ jobs:
         if: steps.meta.outputs.win_url != ''
         uses: actions/checkout@v6
         with:
-          repository: haiphucnguyen/scoop-askimo
+          repository: askimo-ai/scoop-askimo
           token: ${{ secrets.TAP_PUSH_TOKEN }}
           ref: main
           path: bucket
@@ -480,7 +480,7 @@ jobs:
           git add bucket/askimo.json
           if ! git diff --cached --quiet; then
             git commit -m "askimo ${{ steps.meta.outputs.tag }}"
-            git remote set-url origin "https://x-access-token:${TOKEN}@github.com/haiphucnguyen/scoop-askimo.git"
+            git remote set-url origin "https://x-access-token:${TOKEN}@github.com/askimo-ai/scoop-askimo.git"
             git push origin HEAD:main
           else
             echo "No changes to commit."

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansGalleryView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansGalleryView.kt
@@ -35,8 +35,6 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -375,22 +373,22 @@ private fun planCard(
     val isHovered by interactionSource.collectIsHoveredAsState()
     var showMenu by remember { mutableStateOf(false) }
 
-    Card(
-        onClick = onSelect,
+    Surface(
         modifier = modifier
             .hoverable(interactionSource)
+            .clickable(onClick = onSelect)
             .pointerHoverIcon(PointerIcon.Hand),
-        interactionSource = interactionSource,
-        colors = if (isHovered) {
-            AppComponents.primaryCardColors()
-        } else {
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
         shape = MaterialTheme.shapes.medium,
-        elevation = CardDefaults.cardElevation(defaultElevation = if (isHovered) 4.dp else 1.dp),
+        color = if (isHovered) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant
+        },
+        contentColor = if (isHovered) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(Spacing.large)) {
             Row(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NativeMenuBar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NativeMenuBar.kt
@@ -20,7 +20,6 @@ import java.awt.Window
 import java.awt.event.ActionListener
 import java.awt.event.KeyEvent
 import java.net.URI
-import java.net.URLEncoder
 
 /**
  * Native menu bar handler that provides OS-specific menu implementations.
@@ -493,42 +492,11 @@ object NativeMenuBar {
             // Share Askimo submenu
             val shareMenu = Menu(LocalizationManager.getString("menu.help.share"))
 
-            val shareText = LocalizationManager.getString("menu.help.share.text")
-            val shareTextEncoded = URLEncoder.encode(shareText, "UTF-8")
-
-            val shareXItem = MenuItem(LocalizationManager.getString("menu.help.share.x"))
-            shareXItem.addActionListener(
-                ActionListener {
-                    runCatching { if (Desktop.isDesktopSupported()) Desktop.getDesktop().browse(URI("https://x.com/intent/tweet?text=$shareTextEncoded")) }
-                },
-            )
-            shareMenu.add(shareXItem)
-
-            val shareLinkedInItem = MenuItem(LocalizationManager.getString("menu.help.share.linkedin"))
-            shareLinkedInItem.addActionListener(
-                ActionListener {
-                    runCatching {
-                        if (Desktop.isDesktopSupported()) {
-                            val url = URLEncoder.encode("https://askimo.chat", "UTF-8")
-                            Desktop.getDesktop().browse(URI("https://www.linkedin.com/sharing/share-offsite/?url=$url"))
-                        }
-                    }
-                },
-            )
-            shareMenu.add(shareLinkedInItem)
-
-            val shareFacebookItem = MenuItem(LocalizationManager.getString("menu.help.share.facebook"))
-            shareFacebookItem.addActionListener(
-                ActionListener {
-                    runCatching {
-                        if (Desktop.isDesktopSupported()) {
-                            val url = URLEncoder.encode("https://askimo.chat", "UTF-8")
-                            Desktop.getDesktop().browse(URI("https://www.facebook.com/sharer/sharer.php?u=$url"))
-                        }
-                    }
-                },
-            )
-            shareMenu.add(shareFacebookItem)
+            ShareTarget.entries.forEach { target ->
+                val item = MenuItem(ShareUtils.labelFor(target))
+                item.addActionListener(ActionListener { ShareUtils.share(target) })
+                shareMenu.add(item)
+            }
 
             helpMenu.add(shareMenu)
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/ShareUtils.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/ShareUtils.kt
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2025 Hai Nguyen
+ */
+package io.askimo.ui.shell
+
+import io.askimo.core.i18n.LocalizationManager
+import java.awt.Desktop
+import java.net.URI
+import java.net.URLEncoder
+
+/**
+ * Share targets supported by Askimo.
+ */
+enum class ShareTarget { X, LINKEDIN, FACEBOOK }
+
+/**
+ * Common share utilities
+ */
+object ShareUtils {
+    fun shareText(): String = LocalizationManager.getString("menu.help.share.text")
+
+    fun labelFor(target: ShareTarget): String = when (target) {
+        ShareTarget.X -> LocalizationManager.getString("menu.help.share.x")
+        ShareTarget.LINKEDIN -> LocalizationManager.getString("menu.help.share.linkedin")
+        ShareTarget.FACEBOOK -> LocalizationManager.getString("menu.help.share.facebook")
+    }
+
+    /** Opens the browser to share on the given target. Silently ignores failures. */
+    fun share(target: ShareTarget) {
+        runCatching {
+            if (!Desktop.isDesktopSupported()) return
+            val desktop = Desktop.getDesktop()
+            val encoded = URLEncoder.encode(shareText(), "UTF-8")
+            val url = URLEncoder.encode("https://askimo.chat", "UTF-8")
+            val uri = when (target) {
+                ShareTarget.X -> "https://x.com/intent/tweet?text=$encoded"
+                ShareTarget.LINKEDIN -> "https://www.linkedin.com/sharing/share-offsite/?url=$url"
+                ShareTarget.FACEBOOK -> "https://www.facebook.com/sharer/sharer.php?u=$url"
+            }
+            desktop.browse(URI(uri))
+        }
+    }
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/StarPromptDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/StarPromptDialog.kt
@@ -4,104 +4,234 @@
  */
 package io.askimo.ui.shell
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import io.askimo.ui.common.components.primaryButton
-import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppComponents
 
 /**
- * Dialog prompting users to star the project on GitHub.
+ * Dialog prompting users to support the project.
  * Shows once after meaningful usage.
  *
- * @param onDismiss Callback when user dismisses (clicks "Maybe Later")
- * @param onStar Callback when user clicks "Star on GitHub"
+ * @param onDismiss Callback when user dismisses ("Maybe Later")
+ * @param onStar    Callback when user clicks "Star on GitHub"
  */
 @Composable
 fun starPromptDialog(
     onDismiss: () -> Unit,
     onStar: () -> Unit,
+    onShare: () -> Unit = {}, // kept for binary compatibility, not used — sharing is handled inline
 ) {
     Dialog(onDismissRequest = {}) {
         Surface(
-            modifier = Modifier.width(600.dp),
+            modifier = Modifier.width(520.dp),
             shape = MaterialTheme.shapes.large,
             tonalElevation = 8.dp,
         ) {
             Column(
                 modifier = Modifier.padding(24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
             ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalAlignment = Alignment.Top,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Star,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.size(32.dp),
+                // Header
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource("star.prompt.title"),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    Text(
+                        text = stringResource("star.prompt.message"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                // Action cards
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    supportActionCard(
+                        icon = Icons.Default.Star,
+                        iconTint = Color(0xFFFFC107),
+                        label = stringResource("star.prompt.star.button"),
+                        description = stringResource("star.prompt.star.description"),
+                        onClick = onStar,
                         modifier = Modifier.weight(1f),
+                    )
+                    // Share card with dropdown
+                    shareActionCard(
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                // Maybe Later link
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
-                            text = stringResource("star.prompt.title"),
-                            style = MaterialTheme.typography.titleLarge,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = stringResource("star.prompt.message"),
-                            style = MaterialTheme.typography.bodyMedium,
+                            text = stringResource("star.prompt.maybe.later"),
+                            style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    secondaryButton(
-                        onClick = onDismiss,
-                    ) {
-                        Text(stringResource("star.prompt.maybe.later"))
-                    }
-
-                    Spacer(modifier = Modifier.width(8.dp))
-
-                    primaryButton(
-                        onClick = onStar,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Star,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(stringResource("star.prompt.star.button"))
-                    }
-                }
             }
+        }
+    }
+}
+
+@Composable
+private fun shareActionCard(modifier: Modifier = Modifier) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    var showMenu by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .hoverable(interactionSource)
+                .clickable { showMenu = true }
+                .pointerHoverIcon(PointerIcon.Hand),
+            shape = MaterialTheme.shapes.medium,
+            color = if (isHovered) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = if (isHovered) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = Color(0xFF1DA1F2), // Twitter/share blue
+                )
+                Text(
+                    text = stringResource("star.prompt.share.button"),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (isHovered) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = stringResource("star.prompt.share.description"),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isHovered) {
+                        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                    },
+                )
+            }
+        }
+
+        AppComponents.dropdownMenu(
+            expanded = showMenu,
+            onDismissRequest = { showMenu = false },
+        ) {
+            ShareTarget.entries.forEach { target ->
+                DropdownMenuItem(
+                    text = { Text(ShareUtils.labelFor(target)) },
+                    onClick = {
+                        showMenu = false
+                        ShareUtils.share(target)
+                    },
+                    colors = AppComponents.menuItemColors(),
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun supportActionCard(
+    icon: ImageVector,
+    iconTint: Color,
+    label: String,
+    description: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    Surface(
+        modifier = modifier
+            .hoverable(interactionSource)
+            .clickable(onClick = onClick)
+            .pointerHoverIcon(PointerIcon.Hand),
+        shape = MaterialTheme.shapes.medium,
+        color = if (isHovered) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = if (isHovered) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(28.dp),
+                tint = iconTint,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = if (isHovered) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isHovered) {
+                    MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                },
+            )
         }
     }
 }

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -48,7 +48,7 @@ menu.help.share=🗣 Share Askimo
 menu.help.share.x=Share on X / Twitter
 menu.help.share.linkedin=Share on LinkedIn
 menu.help.share.facebook=Share on Facebook
-menu.help.share.text=Check out Askimo — a free, local-first AI desktop client. Works with Ollama, OpenAI, Anthropic and more. https://askimo.chat
+menu.help.share.text=Just discovered Askimo - an AI desktop app packed with RAG, MCP tools, multi-step Plans, and AI Skills. Works with Claude, Gemini, Codex, Ollama, OpenAI and more. One app for every AI workflow. https://askimo.chat
 menu.eventlog=Event Log
 menu.dev.clear.account.preferences=[Dev] Clear Account Preferences
 menu.about=About Askimo
@@ -434,10 +434,13 @@ action.done=Done
 action.refresh=Refresh
 
 # Star Prompt
-star.prompt.title=If Askimo has been helpful…
-star.prompt.message=Askimo is an open-source project built and maintained with community support.\n\nIf it has improved your workflow, consider supporting the project with a star on GitHub ⭐.\n\nYour support helps others discover it and encourages continued development.
-star.prompt.star.button=Join others supporting Askimo
-star.prompt.maybe.later=Not now
+star.prompt.title=Enjoying Askimo? Help spread the word 💙
+star.prompt.message=Askimo is free and open-source, built with community support. Two quick ways to help others discover it:
+star.prompt.star.button=Star on GitHub
+star.prompt.star.description=Show your support and help others find the project.
+star.prompt.share.button=Share
+star.prompt.share.description=Tell your network about Askimo on X, LinkedIn, or Facebook.
+star.prompt.maybe.later=Maybe later
 
 # Analytics Settings (Advanced section toggle)
 settings.analytics.title=Anonymous Analytics


### PR DESCRIPTION
- Update homebrew and scoop repository references in the CLI release workflow.
- Introduce ShareUtils.kt to centralize share actions and simplify share menu setup.
- Replace legacy share menu logic with ShareTarget entries in NativeMenuBar.kt.
- Refactor StarPromptDialog.kt for improved layout, hover interactions, and type‑safe Compose usage.
- Add new i18n messages for sharing and star prompt, enhancing user experience.
- Update existing i18n entries for clearer messaging about Askimo.