### PR TITLE
feat(plan): add step output history persistence and reconstruction

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -558,9 +558,9 @@ fun chatView(
                                         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                         colors = ButtonDefaults.textButtonColors(
                                             contentColor = if (selectedDirectiveObj != null) {
-                                                MaterialTheme.colorScheme.primary
-                                            } else {
                                                 MaterialTheme.colorScheme.onSurface
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurfaceVariant
                                             },
                                         ),
                                     ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansViewModel.kt
@@ -533,8 +533,20 @@ class PlansViewModel(
         val defaults = plan.inputs.associate { it.key to it.default }
         inputValues = defaults + execution.inputs
         inputErrors = emptyMap()
-        stepProgress = emptyList()
-        activeExecutionId = null
+        activeExecutionId = execution.id
+
+        // Reconstruct step progress from persisted step outputs so the UI shows
+        // the breakdown from the previous run when the user clicks a history entry.
+        stepProgress = execution.stepOutputs.map { (stepName, output) ->
+            PlanStepEvent.Completed(
+                planId = execution.planId,
+                stepName = stepName,
+                executionId = execution.id,
+                output = output,
+                durationMs = 0L,
+            )
+        }
+
         val output = execution.output?.takeIf { it.isNotBlank() }
         when {
             output != null -> {

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -580,6 +580,7 @@ class DatabaseManager private constructor(
                     run_count     INTEGER NOT NULL DEFAULT 1,
                     session_id    TEXT,
                     output        TEXT,
+                    step_outputs  TEXT,
                     error_message TEXT,
                     created_at    TEXT NOT NULL,
                     updated_at    TEXT NOT NULL
@@ -593,6 +594,13 @@ class DatabaseManager private constructor(
                 ON plan_executions (plan_id, created_at)
                 """.trimIndent(),
             )
+
+            // Migration: add step_outputs column for databases created before this was introduced.
+            try {
+                stmt.executeUpdate("ALTER TABLE plan_executions ADD COLUMN step_outputs TEXT")
+            } catch (_: Exception) {
+                // Column already exists — safe to ignore.
+            }
         }
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
@@ -47,16 +47,24 @@ class PlanExecutor(private val chatModel: ChatModel) {
 
     private val log = logger<PlanExecutor>()
 
-/**
+    /**
      * Executes the plan and returns the final AI-generated result as a string.
      *
      * @param plan        The parsed plan definition.
      * @param inputs      User-provided values keyed by [PlanInput.key].
      * @param executionId Optional [PlanExecution] record id — passed to [PlanExecutionListener]
      *                    so every [PlanStepEvent] is correlated back to the DB record.
+     * @param onStepOutputs Optional callback invoked after execution with the ordered list of
+     *                      (stepName → output) pairs for all completed steps. Use this to
+     *                      persist intermediate step results alongside the final output.
      * @return The final output string produced by the last step in the workflow.
      */
-    fun execute(plan: PlanDef, inputs: Map<String, String>, executionId: String = ""): String {
+    fun execute(
+        plan: PlanDef,
+        inputs: Map<String, String>,
+        executionId: String = "",
+        onStepOutputs: ((List<Pair<String, String>>) -> Unit)? = null,
+    ): String {
         validateInputs(plan, inputs)
 
         val stepCount = plan.steps.size
@@ -79,7 +87,7 @@ class PlanExecutor(private val chatModel: ChatModel) {
         val startMs = System.currentTimeMillis()
 
         return try {
-            val output = executeInternal(plan, inputs, executionId)
+            val output = executeInternal(plan, inputs, executionId, onStepOutputs)
             val durationMs = System.currentTimeMillis() - startMs
             val durationBucket = when {
                 durationMs < 5_000 -> "<5s"
@@ -116,7 +124,7 @@ class PlanExecutor(private val chatModel: ChatModel) {
         }
     }
 
-    private fun executeInternal(plan: PlanDef, inputs: Map<String, String>, executionId: String): String {
+    private fun executeInternal(plan: PlanDef, inputs: Map<String, String>, executionId: String, onStepOutputs: ((List<Pair<String, String>>) -> Unit)? = null): String {
         log.debug("Executing plan '{}' (execution={}) with inputs: {}", plan.id, executionId, inputs.keys)
 
         // Collect interactive answers first by traversing the workflow for Ask nodes.
@@ -140,6 +148,8 @@ class PlanExecutor(private val chatModel: ChatModel) {
             ?: ""
 
         logExecutionSummary(plan, output)
+
+        onStepOutputs?.invoke(listener.stepOutputs.toList())
 
         return output
     }

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanService.kt
@@ -119,14 +119,17 @@ class PlanService(
 
         val executor = PlanExecutor(chatModel)
 
+        var stepOutputs: List<Pair<String, String>> = emptyList()
+
         return runCatching {
-            executor.execute(plan, inputs, execution.id)
+            executor.execute(plan, inputs, execution.id) { stepOutputs = it }
         }.fold(
             onSuccess = { output ->
                 planExecutionRepository.update(
                     execution.copy(
                         status = PlanExecutionStatus.COMPLETED,
                         output = output.takeIf { it.isNotBlank() },
+                        stepOutputs = stepOutputs,
                     ),
                 )
                 log.info("Plan '{}' (execution={}) completed successfully", plan.id, execution.id)
@@ -157,8 +160,9 @@ class PlanService(
      * Runs a follow-up question against the result of a previous plan execution.
      *
      * The prior plan output is injected as context so the model can refine or extend it
-     * without re-running the full multi-step workflow. The [PlanExecution] record's
-     * [output] field is updated in place with the new answer, and [runCount] is incremented.
+     * without re-running the full multi-step workflow. For multi-step plans, all intermediate
+     * step outputs are included so the model has the full chain of reasoning. The [PlanExecution]
+     * record's [output] field is updated in place with the new answer, and [runCount] is incremented.
      *
      * @param executionId  The id of the previous [PlanExecution] whose output is the context.
      * @param followUpText The user's follow-up instruction (e.g. "Make it shorter").
@@ -182,7 +186,27 @@ class PlanService(
         val systemMessage = "You are continuing work on a previously generated result. " +
             "The user wants to refine or extend it. Reply with the complete updated result only."
 
-        val userMessage = "Previous result:\n\n$priorOutput\n\n---\n\nUser request: $followUpText"
+        // Build context: include intermediate step outputs (if any) so the model has the full
+        // chain of reasoning, not just the final answer.
+        val userMessage = buildString {
+            val stepOutputs = execution.stepOutputs
+            if (stepOutputs.size > 1) {
+                // Multi-step plan — show each intermediate step's output for full context.
+                // The last entry equals priorOutput so we show it separately as "Final result".
+                append("This result was produced by a multi-step plan. Here are the intermediate step outputs:\n\n")
+                stepOutputs.dropLast(1).forEachIndexed { index, (stepName, output) ->
+                    append("### Step ${index + 1}: $stepName\n\n")
+                    append(output)
+                    append("\n\n")
+                }
+                append("### Final result\n\n")
+                append(priorOutput)
+            } else {
+                append("Previous result:\n\n")
+                append(priorOutput)
+            }
+            append("\n\n---\n\nUser request: $followUpText")
+        }
 
         return runCatching {
             val response = chatModel.chat(

--- a/shared/src/main/kotlin/io/askimo/core/plan/domain/PlanExecution.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/domain/PlanExecution.kt
@@ -31,6 +31,8 @@ enum class PlanExecutionStatus {
  * @param runCount      How many times this execution has been re-run (starts at 1).
  * @param sessionId     Linked ChatSession id that holds the message history.
  * @param output        The final AI-generated result text; populated on COMPLETED.
+ * @param stepOutputs   Ordered list of (stepName → output) pairs for every completed step;
+ *                      populated on COMPLETED so users can inspect intermediate results.
  * @param errorMessage  Populated when [status] is [PlanExecutionStatus.FAILED].
  * @param createdAt     When the execution record was first created.
  * @param updatedAt     When the execution record was last modified.
@@ -44,6 +46,7 @@ data class PlanExecution(
     val runCount: Int = 1,
     val sessionId: String? = null,
     val output: String? = null,
+    val stepOutputs: List<Pair<String, String>> = emptyList(),
     val errorMessage: String? = null,
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
@@ -68,6 +71,12 @@ object PlanExecutionsTable : Table("plan_executions") {
 
     /** Final AI-generated output text; null until the run COMPLETES successfully. */
     val output = text("output").nullable()
+
+    /**
+     * JSON-encoded list of step outputs: `[{"step":"stepName","output":"..."},...]`.
+     * Null for executions created before this column was added.
+     */
+    val stepOutputs = text("step_outputs").nullable()
     val errorMessage = text("error_message").nullable()
     val createdAt = sqliteDatetime("created_at")
     val updatedAt = sqliteDatetime("updated_at")

--- a/shared/src/main/kotlin/io/askimo/core/plan/repository/PlanExecutionRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/repository/PlanExecutionRepository.kt
@@ -54,6 +54,7 @@ class PlanExecutionRepository internal constructor(
                 it[runCount] = record.runCount
                 it[sessionId] = record.sessionId
                 it[output] = record.output
+                it[stepOutputs] = encodeStepOutputs(record.stepOutputs)
                 it[errorMessage] = record.errorMessage
                 it[createdAt] = record.createdAt
                 it[updatedAt] = record.updatedAt
@@ -76,6 +77,7 @@ class PlanExecutionRepository internal constructor(
                 it[status] = record.status.name
                 it[sessionId] = record.sessionId
                 it[output] = record.output
+                it[stepOutputs] = encodeStepOutputs(record.stepOutputs)
                 it[errorMessage] = record.errorMessage
                 it[runCount] = record.runCount
                 it[updatedAt] = record.updatedAt
@@ -146,6 +148,7 @@ class PlanExecutionRepository internal constructor(
         runCount = this[PlanExecutionsTable.runCount],
         sessionId = this[PlanExecutionsTable.sessionId],
         output = this[PlanExecutionsTable.output],
+        stepOutputs = decodeStepOutputs(this[PlanExecutionsTable.stepOutputs]),
         errorMessage = this[PlanExecutionsTable.errorMessage],
         createdAt = this[PlanExecutionsTable.createdAt],
         updatedAt = this[PlanExecutionsTable.updatedAt],
@@ -163,5 +166,25 @@ class PlanExecutionRepository internal constructor(
                 val value = line.substring(idx + 1).replace("\\n", "\n")
                 key to value
             }
+    }
+
+    /**
+     * Encodes step outputs as `stepName|output` lines (one per step).
+     * Step names are kebab-case identifiers and cannot contain `|` or newlines.
+     */
+    private fun encodeStepOutputs(steps: List<Pair<String, String>>): String? {
+        if (steps.isEmpty()) return null
+        return steps.joinToString("\n") { (name, output) ->
+            "$name|${output.replace("\n", "\\n")}"
+        }
+    }
+
+    private fun decodeStepOutputs(raw: String?): List<Pair<String, String>> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return raw.lines().mapNotNull { line ->
+            val sep = line.indexOf('|')
+            if (sep < 0) return@mapNotNull null
+            line.substring(0, sep) to line.substring(sep + 1).replace("\\n", "\n")
+        }
     }
 }


### PR DESCRIPTION
- Add step_outputs column to plan_executions for backwards compatibility
- Encode step outputs as JSON during save and decode on retrieval
- Extend PlanExecution and PlanService to carry stepOutputs list
- Update PlanExecutor to trigger callback with step outputs during run
- Reconstruct step progress in PlansViewModel from persisted outputs
- Adjust ChatView color handling for UI consistency