### PR TITLE
feat(mcp-dialog): add MCP server catalog dialog

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -874,6 +875,9 @@ private fun toolsIndicatorButton(
                                         onNavigateToMcpSettings()
                                     },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                    colors = ButtonDefaults.textButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    ),
                                 ) {
                                     Icon(
                                         Icons.Outlined.Settings,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -7,6 +7,8 @@ package io.askimo.ui.common.theme
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.ButtonColors
@@ -23,6 +25,7 @@ import androidx.compose.material3.NavigationDrawerItemColors
 import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.NavigationRailItemColors
 import androidx.compose.material3.NavigationRailItemDefaults
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
@@ -107,6 +110,47 @@ object AppComponents {
         unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
         cursorColor = MaterialTheme.colorScheme.onSurface,
     )
+
+    /**
+     * Themed [OutlinedTextField] with default colors from [outlinedTextFieldColors].
+     */
+    @Composable
+    fun appOutlinedTextField(
+        value: String,
+        onValueChange: (String) -> Unit,
+        modifier: Modifier = Modifier,
+        label: (@Composable () -> Unit)? = null,
+        placeholder: (@Composable () -> Unit)? = null,
+        leadingIcon: (@Composable () -> Unit)? = null,
+        trailingIcon: (@Composable () -> Unit)? = null,
+        supportingText: (@Composable () -> Unit)? = null,
+        isError: Boolean = false,
+        enabled: Boolean = true,
+        readOnly: Boolean = false,
+        singleLine: Boolean = false,
+        maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+        keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+        keyboardActions: KeyboardActions = KeyboardActions.Default,
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            label = label,
+            placeholder = placeholder,
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            supportingText = supportingText,
+            isError = isError,
+            enabled = enabled,
+            readOnly = readOnly,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            colors = outlinedTextFieldColors(),
+        )
+    }
 
     @Composable
     fun menuItemColors(): MenuItemColors = MenuDefaults.itemColors(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
@@ -5,6 +5,7 @@
 package io.askimo.ui.mcp
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,12 +14,20 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SecondaryTabRow
@@ -43,6 +52,8 @@ import io.askimo.core.mcp.HttpConfig
 import io.askimo.core.mcp.McpClientFactory
 import io.askimo.core.mcp.McpInstance
 import io.askimo.core.mcp.McpServerDefinition
+import io.askimo.core.mcp.McpServerTemplateRegistry
+import io.askimo.core.mcp.ParameterType
 import io.askimo.core.mcp.ServerDefinitionSecretManager
 import io.askimo.core.mcp.StdioConfig
 import io.askimo.core.mcp.TransportType
@@ -62,63 +73,111 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 /**
- * Simplified one-step dialog for creating/editing MCP instances directly.
- * No template selection - user enters configuration directly.
+ * Dialog for creating or editing an MCP server instance.
+ *
+ * When [templateDefinition] is provided (selected from the catalog), the dialog renders
+ * labeled parameter fields for each [io.askimo.core.mcp.Parameter] declared by the template
+ * instead of showing the raw command/env textarea fields
+ *
+ * When [templateDefinition] is null (manual setup or editing an existing instance), the full
+ * raw STDIO / HTTP configuration fields are shown.
  */
 @Composable
 fun addMcpInstanceDialog(
     existingInstance: McpInstance? = null,
+    templateDefinition: McpServerDefinition? = null,
     onDismiss: () -> Unit,
     onSave: (serverId: String, name: String, parameters: Map<String, String>) -> Unit,
 ) {
     val dialogState = rememberDialogState()
     val scope = rememberCoroutineScope()
 
-    // Get server definition if editing
+    // Editing an existing instance takes precedence over a template
     val existingServerDef = remember(existingInstance) {
         existingInstance?.let { McpServersConfig.get(it.serverId) }
     }
 
+    // The effective "pre-fill" source: existing def when editing, template when creating from catalog
+    val prefill = existingServerDef ?: templateDefinition
+
     // Basic fields
-    var instanceName by remember { mutableStateOf(existingInstance?.name ?: "") }
-    var description by remember { mutableStateOf(existingServerDef?.description ?: "") }
+    var instanceName by remember { mutableStateOf(existingInstance?.name ?: templateDefinition?.name ?: "") }
+    var description by remember { mutableStateOf(prefill?.description ?: "") }
+
+    // Template parameter values — keyed by Parameter.key
+    val templateParamValues = remember(templateDefinition) {
+        mutableStateOf(
+            templateDefinition?.parameters?.associate { p ->
+                p.key to (p.defaultValue ?: "")
+            } ?: emptyMap(),
+        )
+    }
+
+    // Whether we are in "template mode" (catalog-driven) vs "manual mode"
+    val isTemplateMode = templateDefinition != null && existingInstance == null
+
+    // Whether the user has expanded the Advanced settings section in template mode.
+    // When true, buildServerDefinition uses the raw fields instead of resolving the template.
+    var showAdvanced by remember { mutableStateOf(false) }
 
     // Transport type: 0 = STDIO, 1 = HTTP
     var selectedTab by remember {
         mutableStateOf(
-            if (existingServerDef?.transportType == TransportType.HTTP) 1 else 0,
+            if (prefill?.transportType == TransportType.HTTP) 1 else 0,
         )
     }
 
-    // STDIO fields
+    // STDIO fields — pre-filled from existingServerDef (edit) or from the template (advanced mode)
     var command by remember {
         mutableStateOf(
-            existingServerDef?.stdioConfig?.commandTemplate?.firstOrNull() ?: "",
+            existingServerDef?.stdioConfig?.commandTemplate?.firstOrNull()
+                ?: templateDefinition?.stdioConfig?.commandTemplate?.firstOrNull()
+                ?: "",
         )
     }
     var args by remember {
         mutableStateOf(
-            existingServerDef?.stdioConfig?.commandTemplate?.drop(1)?.joinToString(" ") ?: "",
+            existingServerDef?.stdioConfig?.commandTemplate?.drop(1)?.joinToString(" ")
+                ?: templateDefinition?.stdioConfig?.commandTemplate?.drop(1)?.joinToString(" ")
+                ?: "",
         )
     }
     var workingDir by remember {
-        mutableStateOf(existingServerDef?.stdioConfig?.workingDirectory ?: "")
+        mutableStateOf(
+            existingServerDef?.stdioConfig?.workingDirectory
+                ?: templateDefinition?.stdioConfig?.workingDirectory
+                ?: "",
+        )
     }
     var envVars by remember {
         mutableStateOf(
-            existingServerDef?.stdioConfig?.envTemplate?.entries?.joinToString("\n") { "${it.key}=${it.value}" } ?: "",
+            existingServerDef?.stdioConfig?.envTemplate?.entries?.joinToString("\n") { "${it.key}=${it.value}" }
+                ?: templateDefinition?.stdioConfig?.envTemplate?.entries?.joinToString("\n") { "${it.key}=${it.value}" }
+                ?: "",
         )
     }
 
     // HTTP fields
-    var url by remember { mutableStateOf(existingServerDef?.httpConfig?.urlTemplate ?: "") }
+    var url by remember {
+        mutableStateOf(
+            existingServerDef?.httpConfig?.urlTemplate
+                ?: templateDefinition?.httpConfig?.urlTemplate
+                ?: "",
+        )
+    }
     var headers by remember {
         mutableStateOf(
-            existingServerDef?.httpConfig?.headersTemplate?.entries?.joinToString("\n") { "${it.key}=${it.value}" } ?: "",
+            existingServerDef?.httpConfig?.headersTemplate?.entries?.joinToString("\n") { "${it.key}=${it.value}" }
+                ?: templateDefinition?.httpConfig?.headersTemplate?.entries?.joinToString("\n") { "${it.key}=${it.value}" }
+                ?: "",
         )
     }
     var timeoutMs by remember {
-        mutableStateOf(existingServerDef?.httpConfig?.timeoutMs?.toString() ?: "60000")
+        mutableStateOf(
+            existingServerDef?.httpConfig?.timeoutMs?.toString()
+                ?: templateDefinition?.httpConfig?.timeoutMs?.toString()
+                ?: "60000",
+        )
     }
 
     // Connection test state
@@ -128,7 +187,6 @@ fun addMcpInstanceDialog(
 
     val transportType = if (selectedTab == 0) TransportType.STDIO else TransportType.HTTP
 
-    // Helper function to parse environment variables
     fun parseEnvironmentVariables(envVarsString: String): Map<String, String> {
         if (envVarsString.isBlank()) return emptyMap()
         return envVarsString
@@ -193,7 +251,15 @@ fun addMcpInstanceDialog(
     }
 
     // Helper function to build server definition from current form state
-    fun buildServerDefinition(serverId: String): McpServerDefinition = if (transportType == TransportType.STDIO) {
+    fun buildServerDefinition(serverId: String): McpServerDefinition = if (isTemplateMode && !showAdvanced) {
+        // Template mode (simple): resolve {{key}} placeholders with user-supplied parameter values
+        McpServerTemplateRegistry.resolve(
+            template = templateDefinition,
+            instanceId = serverId,
+            instanceName = instanceName,
+            paramValues = templateParamValues.value,
+        ).copy(description = description)
+    } else if (transportType == TransportType.STDIO) {
         // Parse the command field as a complete command line
         val commandList = buildList {
             addAll(parseCommandLine(command))
@@ -364,138 +430,71 @@ fun addMcpInstanceDialog(
 
                         HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.small))
 
-                        // Transport Type Selector
-                        Text(
-                            text = stringResource("mcp.instance.field.transport"),
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        SecondaryTabRow(
-                            selectedTabIndex = selectedTab,
-                            modifier = Modifier.fillMaxWidth(),
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                            contentColor = MaterialTheme.colorScheme.onSurface,
-                        ) {
-                            Tab(
-                                selected = selectedTab == 0,
-                                onClick = { selectedTab = 0 },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                text = {
-                                    Text(
-                                        text = stringResource("mcp.instance.transport.stdio"),
-                                        color = if (selectedTab == 0) {
-                                            MaterialTheme.colorScheme.primary
+                        if (isTemplateMode) {
+                            // ── Toggle row (always visible in template mode) ───────────────
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { showAdvanced = !showAdvanced }
+                                    .pointerHoverIcon(PointerIcon.Hand)
+                                    .padding(vertical = Spacing.extraSmall),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.End,
+                            ) {
+                                Text(
+                                    text = stringResource(
+                                        if (showAdvanced) {
+                                            "mcp.instance.template.advanced.hide"
                                         } else {
-                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                            "mcp.instance.template.advanced.show"
                                         },
-                                    )
-                                },
-                            )
-                            Tab(
-                                selected = selectedTab == 1,
-                                onClick = { selectedTab = 1 },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                text = {
-                                    Text(
-                                        text = stringResource("mcp.instance.transport.http"),
-                                        color = if (selectedTab == 1) {
-                                            MaterialTheme.colorScheme.primary
-                                        } else {
-                                            MaterialTheme.colorScheme.onSurfaceVariant
-                                        },
-                                    )
-                                },
-                            )
-                        }
-
-                        // STDIO Configuration
-                        AnimatedVisibility(visible = selectedTab == 0) {
-                            Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
-                                OutlinedTextField(
-                                    value = command,
-                                    onValueChange = { command = it },
-                                    label = { Text(stringResource("mcp.instance.field.command")) },
-                                    placeholder = { Text(stringResource("mcp.instance.field.command.placeholder")) },
-                                    supportingText = { Text(stringResource("mcp.instance.field.command.hint")) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    singleLine = true,
-                                    colors = AppComponents.outlinedTextFieldColors(),
+                                    ),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
-
-                                OutlinedTextField(
-                                    value = args,
-                                    onValueChange = { args = it },
-                                    label = { Text(stringResource("mcp.instance.field.args")) },
-                                    placeholder = { Text(stringResource("mcp.instance.field.args.placeholder")) },
-                                    supportingText = { Text(stringResource("mcp.instance.field.args.hint")) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    singleLine = true,
-                                    colors = AppComponents.outlinedTextFieldColors(),
-                                )
-
-                                OutlinedTextField(
-                                    value = workingDir,
-                                    onValueChange = { workingDir = it },
-                                    label = { Text(stringResource("mcp.instance.field.workingdir")) },
-                                    placeholder = { Text(System.getProperty("user.home")) },
-                                    supportingText = { Text(stringResource("mcp.instance.field.workingdir.hint")) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    singleLine = true,
-                                    colors = AppComponents.outlinedTextFieldColors(),
-                                )
-
-                                OutlinedTextField(
-                                    value = envVars,
-                                    onValueChange = { envVars = it },
-                                    label = { Text(stringResource("mcp.instance.env.label")) },
-                                    placeholder = { Text(stringResource("mcp.instance.env.placeholder")) },
-                                    supportingText = { Text(stringResource("mcp.instance.env.hint")) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    minLines = 3,
-                                    maxLines = 5,
-                                    colors = AppComponents.outlinedTextFieldColors(),
+                                Icon(
+                                    imageVector = if (showAdvanced) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(16.dp),
                                 )
                             }
-                        }
 
-                        // HTTP Configuration
-                        AnimatedVisibility(visible = selectedTab == 1) {
-                            Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
-                                OutlinedTextField(
-                                    value = url,
-                                    onValueChange = { url = it },
-                                    label = { Text(stringResource("mcp.instance.http.url.label")) },
-                                    placeholder = { Text(stringResource("mcp.instance.http.url.placeholder")) },
-                                    supportingText = { Text(stringResource("mcp.instance.http.url.hint")) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    singleLine = true,
-                                    colors = AppComponents.outlinedTextFieldColors(),
+                            if (!showAdvanced) {
+                                // ── Simple view: labeled parameter fields ─────────────────
+                                templateParameterFields(
+                                    template = templateDefinition,
+                                    paramValues = templateParamValues.value,
+                                    onParamChange = { key, value ->
+                                        templateParamValues.value += (key to value)
+                                    },
                                 )
-
-                                OutlinedTextField(
-                                    value = headers,
-                                    onValueChange = { headers = it },
-                                    label = { Text(stringResource("mcp.instance.http.headers.label")) },
-                                    placeholder = { Text(stringResource("mcp.instance.http.headers.placeholder")) },
-                                    supportingText = { Text(stringResource("mcp.instance.http.headers.hint")) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    minLines = 3,
-                                    maxLines = 5,
-                                    colors = AppComponents.outlinedTextFieldColors(),
-                                )
-
-                                OutlinedTextField(
-                                    value = timeoutMs,
-                                    onValueChange = { timeoutMs = it },
-                                    label = { Text(stringResource("mcp.instance.http.timeout.label")) },
-                                    placeholder = { Text("60000") },
-                                    supportingText = { Text(stringResource("mcp.instance.http.timeout.hint")) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    singleLine = true,
-                                    colors = AppComponents.outlinedTextFieldColors(),
+                            } else {
+                                // ── Advanced view: full manual dialog fields ──────────────
+                                advancedTransportFields(
+                                    selectedTab = selectedTab,
+                                    onTabChange = { selectedTab = it },
+                                    command = command, onCommandChange = { command = it },
+                                    args = args, onArgsChange = { args = it },
+                                    workingDir = workingDir, onWorkingDirChange = { workingDir = it },
+                                    envVars = envVars, onEnvVarsChange = { envVars = it },
+                                    url = url, onUrlChange = { url = it },
+                                    headers = headers, onHeadersChange = { headers = it },
+                                    timeoutMs = timeoutMs, onTimeoutMsChange = { timeoutMs = it },
                                 )
                             }
+                        } else {
+                            advancedTransportFields(
+                                selectedTab = selectedTab,
+                                onTabChange = { selectedTab = it },
+                                command = command, onCommandChange = { command = it },
+                                args = args, onArgsChange = { args = it },
+                                workingDir = workingDir, onWorkingDirChange = { workingDir = it },
+                                envVars = envVars, onEnvVarsChange = { envVars = it },
+                                url = url, onUrlChange = { url = it },
+                                headers = headers, onHeadersChange = { headers = it },
+                                timeoutMs = timeoutMs, onTimeoutMsChange = { timeoutMs = it },
+                            )
                         }
 
                         HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.medium))
@@ -535,7 +534,7 @@ fun addMcpInstanceDialog(
                                     ),
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = if (success) {
-                                        MaterialTheme.colorScheme.tertiary
+                                        MaterialTheme.colorScheme.onSurfaceVariant
                                     } else {
                                         MaterialTheme.colorScheme.error
                                     },
@@ -685,6 +684,223 @@ fun addMcpInstanceDialog(
                         Text(stringResource("action.save"))
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * SECRET parameters show a password visibility toggle.
+ */
+@Composable
+private fun templateParameterFields(
+    template: McpServerDefinition,
+    paramValues: Map<String, String>,
+    onParamChange: (key: String, value: String) -> Unit,
+) {
+    if (template.parameters.isEmpty()) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+        ) {
+            Text(
+                text = stringResource("mcp.instance.template.no.credentials"),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.padding(Spacing.medium),
+            )
+        }
+        return
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
+        Text(
+            text = stringResource("mcp.instance.template.config.title"),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource("mcp.instance.template.config.description"),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        template.parameters.forEach { param ->
+            val value = paramValues[param.key] ?: ""
+            val isSecret = param.type == ParameterType.SECRET
+            var showSecret by remember { mutableStateOf(false) }
+
+            OutlinedTextField(
+                value = value,
+                onValueChange = { onParamChange(param.key, it) },
+                label = {
+                    Text(
+                        param.label + if (!param.required) stringResource("mcp.instance.template.param.optional") else "",
+                    )
+                },
+                placeholder = param.placeholder?.let { { Text(it) } },
+                supportingText = param.description?.let { desc -> { Text(desc) } },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = isSecret || param.type != ParameterType.PATH,
+                visualTransformation = if (isSecret && !showSecret) {
+                    androidx.compose.ui.text.input.PasswordVisualTransformation()
+                } else {
+                    androidx.compose.ui.text.input.VisualTransformation.None
+                },
+                trailingIcon = if (isSecret) {
+                    {
+                        IconButton(onClick = { showSecret = !showSecret }) {
+                            Icon(
+                                imageVector = if (showSecret) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription = if (showSecret) "Hide" else "Show",
+                            )
+                        }
+                    }
+                } else {
+                    null
+                },
+                colors = AppComponents.outlinedTextFieldColors(),
+            )
+        }
+    }
+}
+
+/**
+ * The transport configuration fields (STDIO / HTTP tabs + all raw inputs).
+ * Shared between manual mode and the Advanced section in template mode.
+ */
+@Composable
+private fun advancedTransportFields(
+    selectedTab: Int,
+    onTabChange: (Int) -> Unit,
+    command: String,
+    onCommandChange: (String) -> Unit,
+    args: String,
+    onArgsChange: (String) -> Unit,
+    workingDir: String,
+    onWorkingDirChange: (String) -> Unit,
+    envVars: String,
+    onEnvVarsChange: (String) -> Unit,
+    url: String,
+    onUrlChange: (String) -> Unit,
+    headers: String,
+    onHeadersChange: (String) -> Unit,
+    timeoutMs: String,
+    onTimeoutMsChange: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
+        Text(
+            text = stringResource("mcp.instance.field.transport"),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        SecondaryTabRow(
+            selectedTabIndex = selectedTab,
+            modifier = Modifier.fillMaxWidth(),
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+            Tab(
+                selected = selectedTab == 0,
+                onClick = { onTabChange(0) },
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                text = {
+                    Text(
+                        text = stringResource("mcp.instance.transport.stdio"),
+                        color = if (selectedTab == 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+            )
+            Tab(
+                selected = selectedTab == 1,
+                onClick = { onTabChange(1) },
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                text = {
+                    Text(
+                        text = stringResource("mcp.instance.transport.http"),
+                        color = if (selectedTab == 1) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+            )
+        }
+
+        AnimatedVisibility(visible = selectedTab == 0) {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
+                OutlinedTextField(
+                    value = command,
+                    onValueChange = onCommandChange,
+                    label = { Text(stringResource("mcp.instance.field.command")) },
+                    placeholder = { Text(stringResource("mcp.instance.field.command.placeholder")) },
+                    supportingText = { Text(stringResource("mcp.instance.field.command.hint")) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = AppComponents.outlinedTextFieldColors(),
+                )
+                OutlinedTextField(
+                    value = args,
+                    onValueChange = onArgsChange,
+                    label = { Text(stringResource("mcp.instance.field.args")) },
+                    placeholder = { Text(stringResource("mcp.instance.field.args.placeholder")) },
+                    supportingText = { Text(stringResource("mcp.instance.field.args.hint")) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = AppComponents.outlinedTextFieldColors(),
+                )
+                OutlinedTextField(
+                    value = workingDir,
+                    onValueChange = onWorkingDirChange,
+                    label = { Text(stringResource("mcp.instance.field.workingdir")) },
+                    placeholder = { Text(System.getProperty("user.home")) },
+                    supportingText = { Text(stringResource("mcp.instance.field.workingdir.hint")) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = AppComponents.outlinedTextFieldColors(),
+                )
+                OutlinedTextField(
+                    value = envVars, onValueChange = onEnvVarsChange,
+                    label = { Text(stringResource("mcp.instance.env.label")) },
+                    placeholder = { Text(stringResource("mcp.instance.env.placeholder")) },
+                    supportingText = { Text(stringResource("mcp.instance.env.hint")) },
+                    modifier = Modifier.fillMaxWidth(), minLines = 3, maxLines = 5,
+                    colors = AppComponents.outlinedTextFieldColors(),
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = selectedTab == 1) {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = onUrlChange,
+                    label = { Text(stringResource("mcp.instance.http.url.label")) },
+                    placeholder = { Text(stringResource("mcp.instance.http.url.placeholder")) },
+                    supportingText = { Text(stringResource("mcp.instance.http.url.hint")) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = AppComponents.outlinedTextFieldColors(),
+                )
+                OutlinedTextField(
+                    value = headers, onValueChange = onHeadersChange,
+                    label = { Text(stringResource("mcp.instance.http.headers.label")) },
+                    placeholder = { Text(stringResource("mcp.instance.http.headers.placeholder")) },
+                    supportingText = { Text(stringResource("mcp.instance.http.headers.hint")) },
+                    modifier = Modifier.fillMaxWidth(), minLines = 3, maxLines = 5,
+                    colors = AppComponents.outlinedTextFieldColors(),
+                )
+                OutlinedTextField(
+                    value = timeoutMs,
+                    onValueChange = onTimeoutMsChange,
+                    label = { Text(stringResource("mcp.instance.http.timeout.label")) },
+                    placeholder = { Text("60000") },
+                    supportingText = { Text(stringResource("mcp.instance.http.timeout.hint")) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    colors = AppComponents.outlinedTextFieldColors(),
+                )
             }
         }
     }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpServerCatalogDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpServerCatalogDialog.kt
@@ -1,0 +1,304 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.mcp
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.askimo.core.mcp.McpServerDefinition
+import io.askimo.core.mcp.McpServerTemplateRegistry
+import io.askimo.ui.common.components.primaryButton
+import io.askimo.ui.common.components.secondaryButton
+import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.Spacing
+
+/**
+ * Two-panel dialog for picking an MCP server from the built-in catalog or opting for manual setup.
+ *
+ * @param onSelectTemplate  Called with a pre-filled [McpServerDefinition] when the user picks a catalog entry.
+ * @param onManualSetup     Called when the user wants to configure a server from scratch.
+ * @param onDismiss         Called when the dialog is closed without a selection.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun mcpServerCatalogDialog(
+    onSelectTemplate: (McpServerDefinition) -> Unit,
+    onManualSetup: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    var selectedCategory by remember { mutableStateOf("All") }
+
+    val visibleTemplates = remember(searchQuery, selectedCategory) {
+        McpServerTemplateRegistry.getByCategory(selectedCategory)
+            .let { list ->
+                if (searchQuery.isBlank()) {
+                    list
+                } else {
+                    val q = searchQuery.trim().lowercase()
+                    list.filter {
+                        it.name.lowercase().contains(q) ||
+                            it.description.lowercase().contains(q) ||
+                            it.tags.any { t -> t.contains(q) }
+                    }
+                }
+            }
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier
+                .widthIn(min = 700.dp, max = 900.dp)
+                .heightIn(min = 520.dp, max = 720.dp),
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 8.dp,
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                // ── Header ────────────────────────────────────────────────────
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 0.dp),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                ) {
+                    Text(
+                        text = stringResource("mcp.catalog.dialog.title"),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = stringResource("mcp.catalog.dialog.description"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.medium))
+
+                // ── Search + category filters ──────────────────────────────────
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                ) {
+                    OutlinedTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        placeholder = { Text(stringResource("mcp.catalog.search.placeholder")) },
+                        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        colors = AppComponents.outlinedTextFieldColors(),
+                    )
+
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        McpServerTemplateRegistry.CATEGORIES.forEach { cat ->
+                            FilterChip(
+                                selected = cat == selectedCategory,
+                                onClick = { selectedCategory = cat },
+                                label = { Text(cat, style = MaterialTheme.typography.labelSmall) },
+                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(Spacing.small))
+
+                // ── Template grid ─────────────────────────────────────────────
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        if (visibleTemplates.isEmpty()) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 40.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = stringResource("mcp.catalog.search.empty"),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else {
+                            // Two-column layout
+                            visibleTemplates.chunked(2).forEach { row ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                                ) {
+                                    row.forEach { template ->
+                                        mcpTemplateCatalogCard(
+                                            template = template,
+                                            modifier = Modifier.weight(1f),
+                                            onSelect = { onSelectTemplate(template) },
+                                        )
+                                    }
+                                    // Pad the last row if odd number of cards
+                                    if (row.size == 1) Spacer(Modifier.weight(1f))
+                                }
+                            }
+                        }
+
+                        Spacer(Modifier.height(Spacing.small))
+                    }
+                }
+
+                // ── Footer ────────────────────────────────────────────────────
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    secondaryButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) {
+                        Text(stringResource("mcp.catalog.action.cancel"))
+                    }
+
+                    secondaryButton(
+                        onClick = onManualSetup,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) {
+                        Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(Modifier.width(Spacing.small))
+                        Text(stringResource("mcp.catalog.action.manual"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun mcpTemplateCatalogCard(
+    template: McpServerDefinition,
+    modifier: Modifier = Modifier,
+    onSelect: () -> Unit,
+) {
+    val isPopular = "popular" in template.tags
+
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.medium),
+            verticalArrangement = Arrangement.spacedBy(Spacing.small),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top,
+            ) {
+                Text(
+                    text = template.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                if (isPopular) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = stringResource("mcp.catalog.category.popular"),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+            }
+
+            Text(
+                text = template.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            val credentialLabel = if (template.parameters.isNotEmpty()) {
+                stringResource("mcp.catalog.card.credentials.required", template.parameters.count { it.required }.toString())
+            } else {
+                stringResource("mcp.catalog.card.no.credentials")
+            }
+            Text(
+                text = credentialLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(Modifier.height(2.dp))
+
+            primaryButton(
+                onClick = onSelect,
+                modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
+            ) {
+                Text(stringResource("mcp.catalog.card.configure"), style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/SkillsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/SkillsSettingsSection.kt
@@ -51,6 +51,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenuItem
@@ -93,6 +94,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppComponents.appOutlinedTextField
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.markdownText
 import io.askimo.ui.common.ui.themedTooltip
@@ -458,6 +460,9 @@ private fun skillsMainContent(
                                 TextButton(
                                     onClick = { openSkillsFolder(AskimoHome.skillsDir()) },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                    colors = ButtonDefaults.textButtonColors(
+                                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    ),
                                 ) {
                                     Text(stringResource("settings.skills.open.folder"))
                                 }
@@ -1539,7 +1544,7 @@ private fun importFromGitHubDialog(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                OutlinedTextField(
+                appOutlinedTextField(
                     value = repoUrl,
                     onValueChange = {
                         repoUrl = it

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -243,7 +243,7 @@ settings.skills.import.github=Import from GitHub
 settings.skills.import.github.description=Clone a GitHub repository containing skill (.md) files into your skills directory. Requires git on PATH.
 settings.skills.import.github.url.label=GitHub Repository URL
 settings.skills.import.github.button=Import
-settings.skills.import.github.importing=Importing\u2026
+settings.skills.import.github.importing=Importing…
 settings.skills.editor.name=Name
 settings.skills.editor.description=Description
 settings.skills.editor.system.prompt=System Prompt
@@ -1066,6 +1066,26 @@ mcp.tools.dialog.search.empty=No tools match your search
 mcp.tools.dialog.export=Export Tools
 mcp.tools.dialog.export.success=Tools exported to {0}
 mcp.tools.dialog.export.failed=Failed to export tools: {0}
+
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=Add MCP Server
+mcp.catalog.dialog.description=Choose a popular integration from the catalog, or configure one manually.
+mcp.catalog.search.placeholder=Search servers…
+mcp.catalog.search.empty=No servers match your search.
+mcp.catalog.category.popular=Popular
+mcp.catalog.card.credentials.required={0} credential(s) required
+mcp.catalog.card.no.credentials=No credentials required
+mcp.catalog.card.configure=Configure
+mcp.catalog.action.cancel=Cancel
+mcp.catalog.action.manual=Manual Setup
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ No credentials required — this server works out of the box.
+mcp.instance.template.config.title=Configuration
+mcp.instance.template.config.description=Fill in the credentials required for this integration. Values are stored securely on your device.
+mcp.instance.template.param.optional= (optional)
+mcp.instance.template.advanced.show=Advanced settings
+mcp.instance.template.advanced.hide=Hide advanced settings
 
 # RAG Sources Tree
 rag.tree.expand=Expand

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1074,6 +1074,26 @@ mcp.tools.dialog.export=Tools exportieren
 mcp.tools.dialog.export.success=Tools nach {0} exportiert
 mcp.tools.dialog.export.failed=Fehler beim Exportieren der Tools: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=MCP-Server hinzufügen
+mcp.catalog.dialog.description=Wählen Sie eine beliebte Integration aus dem Katalog aus oder konfigurieren Sie eine manuell.
+mcp.catalog.search.placeholder=Server suchen…
+mcp.catalog.search.empty=Keine Server entsprechen Ihrer Suche.
+mcp.catalog.category.popular=Beliebt
+mcp.catalog.card.credentials.required={0} Anmeldeinformation(en) erforderlich
+mcp.catalog.card.no.credentials=Keine Anmeldeinformationen erforderlich
+mcp.catalog.card.configure=Konfigurieren
+mcp.catalog.action.cancel=Abbrechen
+mcp.catalog.action.manual=Manuelle Einrichtung
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ Keine Anmeldeinformationen erforderlich — dieser Server funktioniert sofort.
+mcp.instance.template.config.title=Konfiguration
+mcp.instance.template.config.description=Geben Sie die für diese Integration erforderlichen Anmeldeinformationen ein. Die Werte werden sicher auf Ihrem Gerät gespeichert.
+mcp.instance.template.param.optional= (optional)
+mcp.instance.template.advanced.show=Erweiterte Einstellungen
+mcp.instance.template.advanced.hide=Erweiterte Einstellungen ausblenden
+
 # RAG Sources Tree
 rag.tree.expand=Erweitern
 rag.tree.collapse=Reduzieren

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1070,6 +1070,26 @@ mcp.tools.dialog.export=Exportar herramientas
 mcp.tools.dialog.export.success=Herramientas exportadas a {0}
 mcp.tools.dialog.export.failed=Error al exportar herramientas: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=Añadir servidor MCP
+mcp.catalog.dialog.description=Elija una integración popular del catálogo o configure una manualmente.
+mcp.catalog.search.placeholder=Buscar servidores…
+mcp.catalog.search.empty=Ningún servidor coincide con su búsqueda.
+mcp.catalog.category.popular=Popular
+mcp.catalog.card.credentials.required={0} credencial(es) requerida(s)
+mcp.catalog.card.no.credentials=No se requieren credenciales
+mcp.catalog.card.configure=Configurar
+mcp.catalog.action.cancel=Cancelar
+mcp.catalog.action.manual=Configuración manual
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ No se requieren credenciales — este servidor funciona de inmediato.
+mcp.instance.template.config.title=Configuración
+mcp.instance.template.config.description=Complete las credenciales requeridas para esta integración. Los valores se almacenan de forma segura en su dispositivo.
+mcp.instance.template.param.optional= (opcional)
+mcp.instance.template.advanced.show=Ajustes avanzados
+mcp.instance.template.advanced.hide=Ocultar ajustes avanzados
+
 # RAG Sources Tree
 rag.tree.expand=Expandir
 rag.tree.collapse=Contraer

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1073,6 +1073,26 @@ mcp.tools.dialog.export=Exporter les outils
 mcp.tools.dialog.export.success=Outils exportés vers {0}
 mcp.tools.dialog.export.failed=Échec de l'exportation des outils : {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=Ajouter un serveur MCP
+mcp.catalog.dialog.description=Choisissez une intégration populaire dans le catalogue ou configurez-en une manuellement.
+mcp.catalog.search.placeholder=Rechercher des serveurs…
+mcp.catalog.search.empty=Aucun serveur ne correspond à votre recherche.
+mcp.catalog.category.popular=Populaire
+mcp.catalog.card.credentials.required={0} identifiant(s) requis
+mcp.catalog.card.no.credentials=Aucun identifiant requis
+mcp.catalog.card.configure=Configurer
+mcp.catalog.action.cancel=Annuler
+mcp.catalog.action.manual=Configuration manuelle
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ Aucun identifiant requis — ce serveur fonctionne immédiatement.
+mcp.instance.template.config.title=Configuration
+mcp.instance.template.config.description=Renseignez les identifiants requis pour cette intégration. Les valeurs sont stockées en toute sécurité sur votre appareil.
+mcp.instance.template.param.optional= (facultatif)
+mcp.instance.template.advanced.show=Paramètres avancés
+mcp.instance.template.advanced.hide=Masquer les paramètres avancés
+
 # RAG Sources Tree
 rag.tree.expand=Développer
 rag.tree.collapse=Réduire

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1073,6 +1073,26 @@ mcp.tools.dialog.export=ツールのエクスポート
 mcp.tools.dialog.export.success={0} にツールをエクスポートしました
 mcp.tools.dialog.export.failed=ツールのエクスポートに失敗しました: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=MCPサーバーを追加
+mcp.catalog.dialog.description=カタログから人気のある統合を選択するか、手動で設定してください。
+mcp.catalog.search.placeholder=サーバーを検索…
+mcp.catalog.search.empty=検索条件に一致するサーバーはありません。
+mcp.catalog.category.popular=人気
+mcp.catalog.card.credentials.required={0}件の認証情報が必要です
+mcp.catalog.card.no.credentials=認証情報は不要です
+mcp.catalog.card.configure=設定
+mcp.catalog.action.cancel=キャンセル
+mcp.catalog.action.manual=手動設定
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ 認証情報は不要です — このサーバーはすぐに使用できます。
+mcp.instance.template.config.title=設定
+mcp.instance.template.config.description=この統合に必要な認証情報を入力してください。値はデバイスに安全に保存されます。
+mcp.instance.template.param.optional= (オプション)
+mcp.instance.template.advanced.show=詳細設定
+mcp.instance.template.advanced.hide=詳細設定を隠す
+
 # RAG Sources Tree
 rag.tree.expand=展開
 rag.tree.collapse=折りたたむ

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1071,6 +1071,26 @@ mcp.tools.dialog.export=도구 내보내기
 mcp.tools.dialog.export.success={0}로 도구를 내보냈습니다
 mcp.tools.dialog.export.failed=도구 내보내기 실패: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=MCP 서버 추가
+mcp.catalog.dialog.description=카탈로그에서 인기 있는 연동을 선택하거나 수동으로 구성하세요.
+mcp.catalog.search.placeholder=서버 검색…
+mcp.catalog.search.empty=검색 조건과 일치하는 서버가 없습니다.
+mcp.catalog.category.popular=인기
+mcp.catalog.card.credentials.required={0}개의 자격 증명이 필요합니다
+mcp.catalog.card.no.credentials=자격 증명이 필요하지 않습니다
+mcp.catalog.card.configure=구성
+mcp.catalog.action.cancel=취소
+mcp.catalog.action.manual=수동 설정
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ 자격 증명이 필요하지 않습니다 — 이 서버는 바로 작동합니다.
+mcp.instance.template.config.title=구성
+mcp.instance.template.config.description=이 연동에 필요한 자격 증명을 입력하세요. 값은 기기에 안전하게 저장됩니다.
+mcp.instance.template.param.optional= (선택 사항)
+mcp.instance.template.advanced.show=고급 설정
+mcp.instance.template.advanced.hide=고급 설정 숨기기
+
 # RAG Sources Tree
 rag.tree.expand=확장
 rag.tree.collapse=축소

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1073,6 +1073,26 @@ mcp.tools.dialog.export=Exportar Ferramentas
 mcp.tools.dialog.export.success=Ferramentas exportadas para {0}
 mcp.tools.dialog.export.failed=Falha ao exportar ferramentas: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=Adicionar Servidor MCP
+mcp.catalog.dialog.description=Escolha uma integração popular do catálogo ou configure uma manualmente.
+mcp.catalog.search.placeholder=Pesquisar servidores…
+mcp.catalog.search.empty=Nenhum servidor corresponde à sua pesquisa.
+mcp.catalog.category.popular=Popular
+mcp.catalog.card.credentials.required={0} credencial(is) necessária(s)
+mcp.catalog.card.no.credentials=Não requer credenciais
+mcp.catalog.card.configure=Configurar
+mcp.catalog.action.cancel=Cancelar
+mcp.catalog.action.manual=Configuração Manual
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ Não requer credenciais — este servidor funciona imediatamente.
+mcp.instance.template.config.title=Configuração
+mcp.instance.template.config.description=Preencha as credenciais necessárias para esta integração. Os valores são armazenados com segurança no seu dispositivo.
+mcp.instance.template.param.optional= (opcional)
+mcp.instance.template.advanced.show=Configurações avançadas
+mcp.instance.template.advanced.hide=Ocultar configurações avançadas
+
 # RAG Sources Tree
 rag.tree.expand=Expandir
 rag.tree.collapse=Recolher

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1072,6 +1072,26 @@ mcp.tools.dialog.export=Xuất công cụ
 mcp.tools.dialog.export.success=Các công cụ đã được xuất tới {0}
 mcp.tools.dialog.export.failed=Lỗi khi xuất công cụ: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=Thêm Máy chủ MCP
+mcp.catalog.dialog.description=Chọn một tiện ích tích hợp phổ biến từ danh mục hoặc cấu hình thủ công.
+mcp.catalog.search.placeholder=Tìm kiếm máy chủ…
+mcp.catalog.search.empty=Không có máy chủ nào khớp với tìm kiếm của bạn.
+mcp.catalog.category.popular=Phổ biến
+mcp.catalog.card.credentials.required=Yêu cầu {0} thông tin xác thực
+mcp.catalog.card.no.credentials=Không yêu cầu thông tin xác thực
+mcp.catalog.card.configure=Cấu hình
+mcp.catalog.action.cancel=Hủy
+mcp.catalog.action.manual=Thiết lập thủ công
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ Không yêu cầu thông tin xác thực — máy chủ này hoạt động ngay lập tức.
+mcp.instance.template.config.title=Cấu hình
+mcp.instance.template.config.description=Điền các thông tin xác thực cần thiết cho tiện ích tích hợp này. Các giá trị được lưu trữ an toàn trên thiết bị của bạn.
+mcp.instance.template.param.optional= (tùy chọn)
+mcp.instance.template.advanced.show=Cài đặt nâng cao
+mcp.instance.template.advanced.hide=Ẩn cài đặt nâng cao
+
 # RAG Sources Tree
 rag.tree.expand=Mở rộng
 rag.tree.collapse=Thu gọn

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1074,6 +1074,26 @@ mcp.tools.dialog.export=导出工具
 mcp.tools.dialog.export.success=已将工具导出到 {0}
 mcp.tools.dialog.export.failed=导出工具失败: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=添加 MCP 服务器
+mcp.catalog.dialog.description=从目录中选择一个热门的集成，或者手动配置。
+mcp.catalog.search.placeholder=搜索服务器…
+mcp.catalog.search.empty=没有与您的搜索匹配的服务器。
+mcp.catalog.category.popular=热门
+mcp.catalog.card.credentials.required=需要 {0} 个凭据
+mcp.catalog.card.no.credentials=无需凭据
+mcp.catalog.card.configure=配置
+mcp.catalog.action.cancel=取消
+mcp.catalog.action.manual=手动设置
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ 无需凭据 — 此服务器开箱即用。
+mcp.instance.template.config.title=配置
+mcp.instance.template.config.description=填写此集成所需的凭据。这些值会安全地存储在您的设备上。
+mcp.instance.template.param.optional= (可选)
+mcp.instance.template.advanced.show=高级设置
+mcp.instance.template.advanced.hide=隐藏高级设置
+
 # RAG Sources Tree
 rag.tree.expand=展开
 rag.tree.collapse=折叠

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1075,6 +1075,26 @@ mcp.tools.dialog.export=匯出工具
 mcp.tools.dialog.export.success=已將工具匯出到 {0}
 mcp.tools.dialog.export.failed=匯出工具失敗: {0}
 
+# MCP Server Catalog Dialog
+mcp.catalog.dialog.title=新增 MCP 伺服器
+mcp.catalog.dialog.description=從目錄中選擇一個熱門的整合，或手動進行設定。
+mcp.catalog.search.placeholder=搜尋伺服器…
+mcp.catalog.search.empty=沒有符合您搜尋的伺服器。
+mcp.catalog.category.popular=熱門
+mcp.catalog.card.credentials.required=需要 {0} 個憑證
+mcp.catalog.card.no.credentials=無須憑證
+mcp.catalog.card.configure=設定
+mcp.catalog.action.cancel=取消
+mcp.catalog.action.manual=手動設定
+
+# MCP Instance Template Parameters
+mcp.instance.template.no.credentials=✅ 無須憑證 — 此伺服器開箱即用。
+mcp.instance.template.config.title=設定
+mcp.instance.template.config.description=填寫此整合所需的憑證。這些值會安全地儲存在您的裝置上。
+mcp.instance.template.param.optional= (選填)
+mcp.instance.template.advanced.show=進階設定
+mcp.instance.template.advanced.hide=隱藏進階設定
+
 # RAG Sources Tree
 rag.tree.expand=展開
 rag.tree.collapse=收合

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.askimo.core.mcp.McpInstance
 import io.askimo.core.mcp.McpInstanceService
+import io.askimo.core.mcp.McpServerDefinition
 import io.askimo.core.mcp.config.McpServersConfig
 import io.askimo.ui.common.components.dangerButton
 import io.askimo.ui.common.components.linkButton
@@ -59,6 +60,7 @@ import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.mcp.addMcpInstanceDialog
+import io.askimo.ui.mcp.mcpServerCatalogDialog
 import io.askimo.ui.mcp.mcpToolsDialog
 import kotlinx.coroutines.launch
 import org.koin.java.KoinJavaComponent.get
@@ -69,7 +71,9 @@ import java.net.URI
 fun mcpServerTemplatesSection() {
     val mcpService = remember { get<McpInstanceService>(McpInstanceService::class.java) }
     var mcpInstances by remember { mutableStateOf(mcpService.getInstances()) }
+    var showCatalogDialog by remember { mutableStateOf(false) }
     var showAddMcpDialog by remember { mutableStateOf(false) }
+    var selectedTemplate by remember { mutableStateOf<McpServerDefinition?>(null) }
     var editingMcpInstance by remember { mutableStateOf<McpInstance?>(null) }
     var deletingMcpInstance by remember { mutableStateOf<McpInstance?>(null) }
     val scope = rememberCoroutineScope()
@@ -130,7 +134,7 @@ fun mcpServerTemplatesSection() {
                     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.small)) {
                         themedTooltip(text = stringResource("mcp.instance.add.tooltip")) {
                             primaryButton(
-                                onClick = { showAddMcpDialog = true },
+                                onClick = { showCatalogDialog = true },
                                 modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Icon(Icons.Default.Add, contentDescription = null)
@@ -203,10 +207,31 @@ fun mcpServerTemplatesSection() {
         )
     }
 
-    // Add MCP Instance Dialog
+    // Step 1 — Catalog picker (shown when user clicks "Add")
+    if (showCatalogDialog) {
+        mcpServerCatalogDialog(
+            onSelectTemplate = { template ->
+                selectedTemplate = template
+                showCatalogDialog = false
+                showAddMcpDialog = true
+            },
+            onManualSetup = {
+                selectedTemplate = null
+                showCatalogDialog = false
+                showAddMcpDialog = true
+            },
+            onDismiss = { showCatalogDialog = false },
+        )
+    }
+
+    // Step 2 — Add MCP Instance Dialog (pre-filled from template, or blank for manual)
     if (showAddMcpDialog) {
         addMcpInstanceDialog(
-            onDismiss = { showAddMcpDialog = false },
+            templateDefinition = selectedTemplate,
+            onDismiss = {
+                showAddMcpDialog = false
+                selectedTemplate = null
+            },
             onSave = { serverId, name, parameters ->
                 scope.launch {
                     mcpService.createInstance(
@@ -217,6 +242,7 @@ fun mcpServerTemplatesSection() {
                     mcpInstances = mcpService.getInstances()
                 }
                 showAddMcpDialog = false
+                selectedTemplate = null
             },
         )
     }

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpServerTemplateRegistry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpServerTemplateRegistry.kt
@@ -1,0 +1,269 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.mcp
+
+/**
+ * Built-in catalog of popular MCP server definitions.
+ *
+ * Each entry is a fully-specified [McpServerDefinition] whose `stdioConfig`/`httpConfig`
+ * may contain `{{key}}` placeholders that correspond to entries in [McpServerDefinition.parameters].
+ * The UI resolves those placeholders with user-supplied values before saving.
+ *
+ * ## Adding a new template
+ * 1. Create a new [McpServerDefinition] value below.
+ * 2. Add `"popular"` to [tags] if it should appear in the Popular filter.
+ * 3. Add a category tag matching one of [CATEGORIES] (e.g. `"dev-tools"`, `"databases"`).
+ * 4. Declare every user-configurable placeholder as a [Parameter].
+ */
+object McpServerTemplateRegistry {
+
+    val CATEGORIES = listOf("All", "Popular", "Dev Tools", "Productivity", "Databases", "Search", "Utilities")
+
+    val templates: List<McpServerDefinition> = listOf(
+
+        // ── Dev Tools ─────────────────────────────────────────────────────────
+
+        McpServerDefinition(
+            id = "template-github",
+            name = "GitHub",
+            description = "Access repositories, issues, pull requests, and file contents via the official GitHub remote MCP server. No local tools required.",
+            transportType = TransportType.HTTP,
+            httpConfig = HttpConfig(
+                urlTemplate = "https://api.githubcopilot.com/mcp/",
+                headersTemplate = mapOf("Authorization" to "Bearer {{githubToken}}"),
+            ),
+            parameters = listOf(
+                Parameter(
+                    key = "githubToken",
+                    label = "GitHub Personal Access Token",
+                    type = ParameterType.SECRET,
+                    description = "Create at github.com/settings/tokens. Requires repo scope.",
+                    placeholder = "ghp_...",
+                    location = ParameterLocation.HTTP_HEADER,
+                ),
+            ),
+            tags = listOf("popular", "dev-tools"),
+            author = "GitHub",
+        ),
+
+        McpServerDefinition(
+            id = "template-github-enterprise",
+            name = "GitHub Enterprise",
+            description = "Access GitHub Enterprise Cloud (ghe.com) repositories and resources via the remote MCP server.",
+            transportType = TransportType.HTTP,
+            httpConfig = HttpConfig(
+                urlTemplate = "https://copilot-api.{{gheHost}}/mcp",
+                headersTemplate = mapOf("Authorization" to "Bearer {{githubToken}}"),
+            ),
+            parameters = listOf(
+                Parameter(
+                    key = "gheHost",
+                    label = "GitHub Enterprise Host",
+                    type = ParameterType.STRING,
+                    description = "Your GHE host, e.g. octocorp.ghe.com",
+                    placeholder = "octocorp.ghe.com",
+                    location = ParameterLocation.HTTP_URL,
+                ),
+                Parameter(
+                    key = "githubToken",
+                    label = "GitHub Personal Access Token",
+                    type = ParameterType.SECRET,
+                    description = "PAT with appropriate scopes for your GitHub Enterprise organization.",
+                    placeholder = "ghp_...",
+                    location = ParameterLocation.HTTP_HEADER,
+                ),
+            ),
+            tags = listOf("dev-tools"),
+            author = "GitHub",
+        ),
+
+        McpServerDefinition(
+            id = "template-puppeteer",
+            name = "Puppeteer",
+            description = "Browser automation — navigate web pages, take screenshots, fill forms, and run scripts.",
+            transportType = TransportType.STDIO,
+            stdioConfig = StdioConfig(
+                commandTemplate = listOf("npx", "-y", "@modelcontextprotocol/server-puppeteer"),
+            ),
+            parameters = emptyList(),
+            tags = listOf("popular", "dev-tools"),
+            author = "Anthropic",
+        ),
+
+        // ── Productivity ──────────────────────────────────────────────────────
+
+        McpServerDefinition(
+            id = "template-notion",
+            name = "Notion",
+            description = "Read and write Notion pages, databases, and blocks via the Notion API.",
+            transportType = TransportType.STDIO,
+            stdioConfig = StdioConfig(
+                commandTemplate = listOf("npx", "-y", "@notionhq/notion-mcp-server"),
+                envTemplate = mapOf(
+                    "OPENAPI_MCP_HEADERS" to """{"Authorization": "Bearer {{notionToken}}", "Notion-Version": "2022-06-28"}""",
+                ),
+            ),
+            parameters = listOf(
+                Parameter(
+                    key = "notionToken",
+                    label = "Notion Integration Token",
+                    type = ParameterType.SECRET,
+                    description = "Create an integration at notion.so/my-integrations and copy the token.",
+                    placeholder = "ntn_...",
+                    location = ParameterLocation.ENVIRONMENT,
+                ),
+            ),
+            tags = listOf("popular", "productivity"),
+            author = "Notion",
+        ),
+
+        McpServerDefinition(
+            id = "template-slack",
+            name = "Slack",
+            description = "Read messages, post to channels, list users, and manage Slack workspaces.",
+            transportType = TransportType.STDIO,
+            stdioConfig = StdioConfig(
+                commandTemplate = listOf("npx", "-y", "@modelcontextprotocol/server-slack"),
+                envTemplate = mapOf(
+                    "SLACK_BOT_TOKEN" to "{{slackBotToken}}",
+                    "SLACK_TEAM_ID" to "{{slackTeamId}}",
+                ),
+            ),
+            parameters = listOf(
+                Parameter(
+                    key = "slackBotToken",
+                    label = "Slack Bot Token",
+                    type = ParameterType.SECRET,
+                    description = "OAuth token for your Slack app bot user (starts with xoxb-).",
+                    placeholder = "xoxb-...",
+                    location = ParameterLocation.ENVIRONMENT,
+                ),
+                Parameter(
+                    key = "slackTeamId",
+                    label = "Slack Team ID",
+                    type = ParameterType.STRING,
+                    description = "Your Slack workspace Team ID. Found in the workspace URL or admin panel.",
+                    placeholder = "T01234567",
+                    location = ParameterLocation.ENVIRONMENT,
+                ),
+            ),
+            tags = listOf("popular", "productivity"),
+            author = "Anthropic",
+        ),
+
+        // ── Search ────────────────────────────────────────────────────────────
+
+        McpServerDefinition(
+            id = "template-brave-search",
+            name = "Brave Search",
+            description = "Search the web and retrieve results using the Brave Search API.",
+            transportType = TransportType.STDIO,
+            stdioConfig = StdioConfig(
+                commandTemplate = listOf("npx", "-y", "@modelcontextprotocol/server-brave-search"),
+                envTemplate = mapOf("BRAVE_API_KEY" to "{{braveApiKey}}"),
+            ),
+            parameters = listOf(
+                Parameter(
+                    key = "braveApiKey",
+                    label = "Brave Search API Key",
+                    type = ParameterType.SECRET,
+                    description = "Get a free API key at brave.com/search/api.",
+                    placeholder = "BSAxxxxxxxx...",
+                    location = ParameterLocation.ENVIRONMENT,
+                ),
+            ),
+            tags = listOf("popular", "search"),
+            author = "Anthropic",
+        ),
+
+        // ── Utilities ─────────────────────────────────────────────────────────
+
+        McpServerDefinition(
+            id = "template-filesystem",
+            name = "Filesystem",
+            description = "Read and write files within a specific directory on your local machine.",
+            transportType = TransportType.STDIO,
+            stdioConfig = StdioConfig(
+                commandTemplate = listOf("npx", "-y", "@modelcontextprotocol/server-filesystem", "{{rootPath}}"),
+            ),
+            parameters = listOf(
+                Parameter(
+                    key = "rootPath",
+                    label = "Allowed Root Directory",
+                    type = ParameterType.PATH,
+                    description = "The AI will only be able to access files inside this directory.",
+                    placeholder = "/Users/you/projects",
+                    location = ParameterLocation.COMMAND,
+                ),
+            ),
+            tags = listOf("popular", "utilities"),
+            author = "Anthropic",
+        ),
+
+        McpServerDefinition(
+            id = "template-fetch",
+            name = "Fetch",
+            description = "Fetch any URL and convert the response to Markdown for easy reading.",
+            transportType = TransportType.STDIO,
+            stdioConfig = StdioConfig(
+                commandTemplate = listOf("uvx", "mcp-server-fetch"),
+            ),
+            parameters = emptyList(),
+            tags = listOf("popular", "utilities"),
+            author = "Anthropic",
+        ),
+
+        McpServerDefinition(
+            id = "template-memory",
+            name = "Memory",
+            description = "Persistent knowledge graph memory — lets the AI remember facts across sessions.",
+            transportType = TransportType.STDIO,
+            stdioConfig = StdioConfig(
+                commandTemplate = listOf("npx", "-y", "@modelcontextprotocol/server-memory"),
+            ),
+            parameters = emptyList(),
+            tags = listOf("popular", "utilities"),
+            author = "Anthropic",
+        ),
+    )
+
+    /** Returns templates matching the given category label (case-insensitive). "All" returns everything. */
+    fun getByCategory(category: String): List<McpServerDefinition> = when (category.lowercase()) {
+        "all" -> templates
+        "popular" -> templates.filter { "popular" in it.tags }
+        else -> templates.filter { category.lowercase().replace(" ", "-") in it.tags }
+    }
+
+    /**
+     * Resolves all `{{key}}` placeholders in a template's command and env templates
+     * with the supplied [paramValues], producing a ready-to-use [McpServerDefinition].
+     */
+    fun resolve(template: McpServerDefinition, instanceId: String, instanceName: String, paramValues: Map<String, String>): McpServerDefinition {
+        fun String.resolve() = paramValues.entries.fold(this) { acc, (k, v) -> acc.replace("{{$k}}", v) }
+
+        val resolvedStdio = template.stdioConfig?.let { cfg ->
+            StdioConfig(
+                commandTemplate = cfg.commandTemplate.map { it.resolve() }.filter { it.isNotBlank() },
+                envTemplate = cfg.envTemplate.mapValues { (_, v) -> v.resolve() },
+                workingDirectory = cfg.workingDirectory?.resolve(),
+            )
+        }
+        val resolvedHttp = template.httpConfig?.let { cfg ->
+            HttpConfig(
+                urlTemplate = cfg.urlTemplate.resolve(),
+                headersTemplate = cfg.headersTemplate.mapValues { (_, v) -> v.resolve() },
+                timeoutMs = cfg.timeoutMs,
+            )
+        }
+        return template.copy(
+            id = instanceId,
+            name = instanceName,
+            stdioConfig = resolvedStdio,
+            httpConfig = resolvedHttp,
+            parameters = emptyList(), // resolved — no longer needed
+            tags = template.tags + "global",
+        )
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -21,7 +21,6 @@ import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.logging.display
-import io.askimo.core.logging.displayError
 import io.askimo.core.logging.logger
 import io.askimo.core.providers.AiServiceBuilder
 import io.askimo.core.providers.ChatClient
@@ -29,9 +28,10 @@ import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.LocalEmbeddingTokenLimits
 import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
+import io.askimo.core.providers.ModelProvider.DOCKER
+import io.askimo.core.providers.ProviderModelUtils.fetchModels
 import io.askimo.core.providers.ensureLocalEmbeddingModelAvailable
 import io.askimo.core.telemetry.TelemetryChatModelListener
-import io.askimo.core.util.ProcessBuilderExt
 import io.askimo.core.util.ProxyUtil
 import java.net.http.HttpClient
 import java.time.Duration
@@ -39,29 +39,14 @@ import java.time.Duration
 class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
     private val log = logger<DockerAiModelFactory>()
 
-    override fun getProvider(): ModelProvider = ModelProvider.DOCKER
+    override fun getProvider(): ModelProvider = DOCKER
 
-    override fun availableModels(settings: DockerAiSettings): List<ModelDTO> = try {
-        val process =
-            ProcessBuilderExt("docker", "model", "ls", "--openai")
-                .redirectErrorStream(true)
-                .start()
-
-        val output = process.inputStream.bufferedReader().readText()
-        process.waitFor()
-
-        val modelIds = mutableListOf<String>()
-        val idPattern = """"id"\s*:\s*"([^"]+)"""".toRegex()
-        idPattern.findAll(output).forEach { matchResult ->
-            val modelId = matchResult.groupValues[1]
-            if (modelId.isNotBlank()) modelIds.add(modelId)
-        }
-
-        modelIds.distinct().map { ModelDTO.of(ModelProvider.DOCKER, it) }
-    } catch (e: Exception) {
-        log.displayError("⚠️ Failed to fetch models from Docker AI: ${e.message}", e)
-        emptyList()
-    }
+    override fun availableModels(settings: DockerAiSettings): List<ModelDTO> = fetchModels(
+        apiKey = "docker-ai",
+        url = "${settings.baseUrl}/models",
+        providerName = DOCKER,
+        httpVersion = HttpClient.Version.HTTP_1_1,
+    ).map { ModelDTO.of(DOCKER, it) }
 
     override fun defaultSettings(): DockerAiSettings = DockerAiSettings()
 
@@ -82,7 +67,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
     ): ChatClient = AiServiceBuilder.buildChatClient(
         sessionId = sessionId,
         settings = settings,
-        provider = ModelProvider.DOCKER,
+        provider = DOCKER,
         chatModel = createStreamingModel(settings),
         secondaryChatModel = createSecondaryModel(settings),
         chatMemory = chatMemory,
@@ -94,9 +79,9 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
     override fun createImageModel(
         settings: DockerAiSettings,
     ): ImageModel = OpenAiImageModel.builder()
-        .apiKey("dockerai")
+        .apiKey("docker-ai")
         .baseUrl(settings.baseUrl)
-        .modelName(AppConfig.models[ModelProvider.DOCKER].imageModel)
+        .modelName(AppConfig.models[DOCKER].imageModel)
         .logger(log)
         .logRequests(log.isDebugEnabled)
         .logResponses(log.isTraceEnabled)
@@ -115,7 +100,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
             .logger(log)
             .logRequests(log.isDebugEnabled)
             .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.DOCKER.name.lowercase())))
+            .listeners(listOf(TelemetryChatModelListener(telemetry, DOCKER.name.lowercase())))
             .build()
     }
 
@@ -126,7 +111,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
             .httpClientBuilder(jdkHttpClientBuilder)
             .baseUrl(settings.baseUrl)
             .apiKey("docker-ai")
-            .modelName(AppConfig.models[ModelProvider.DOCKER].utilityModel.ifBlank { AppContext.getInstance().params.model })
+            .modelName(AppConfig.models[DOCKER].utilityModel.ifBlank { AppContext.getInstance().params.model })
             .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
             .build()
     }
@@ -142,7 +127,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
             .apiKey("docker-ai")
             .modelName(settings.defaultModel)
             .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.DOCKER.name.lowercase())))
+            .listeners(listOf(TelemetryChatModelListener(telemetry, DOCKER.name.lowercase())))
             .build()
     }
 
@@ -156,7 +141,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
 
     override fun createEmbeddingModel(settings: DockerAiSettings): EmbeddingModel {
         val baseUrl = settings.baseUrl.removeSuffix("/")
-        val modelName = AppConfig.models[ModelProvider.DOCKER].embeddingModel
+        val modelName = AppConfig.models[DOCKER].embeddingModel
 
         log.display(
             """
@@ -167,7 +152,7 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
             """.trimIndent(),
         )
 
-        ensureLocalEmbeddingModelAvailable(ModelProvider.DOCKER, baseUrl, modelName)
+        ensureLocalEmbeddingModelAvailable(DOCKER, baseUrl, modelName)
 
         return OpenAiEmbeddingModelBuilder()
             .apiKey("not-needed")
@@ -176,5 +161,5 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
             .build()
     }
 
-    override fun getEmbeddingTokenLimit(settings: DockerAiSettings): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[ModelProvider.DOCKER].embeddingModel)
+    override fun getEmbeddingTokenLimit(settings: DockerAiSettings): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[DOCKER].embeddingModel)
 }


### PR DESCRIPTION
- Introduce a new MCP Server Catalog Dialog for selecting or manually adding servers.
- Add internationalized resource strings for the dialog and instance template parameters.
- Create McpServerTemplateRegistry to register server templates.
- Refactor DockerAiModelFactory to use DOCKER constant instead of ModelProvider.DOCKER.
- Update UI imports and composition for consistency.
- Extend skills settings to support new dialog integration.